### PR TITLE
Postprocess: avoid isnan()

### DIFF
--- a/benchmarks/diffusion_of_hill/analytical_topography.cc
+++ b/benchmarks/diffusion_of_hill/analytical_topography.cc
@@ -231,7 +231,7 @@ namespace aspect
       // if this is the first time we get here, set the last output time
       // to the current time - output_interval. this makes sure we
       // always produce data during the first time step
-      if (std::isnan(last_output_time))
+      if (last_output_time < this->get_parameters().start_time - output_interval)
         {
           last_output_time = this->get_time() - output_interval;
         }

--- a/benchmarks/diffusion_of_hill/analytical_topography.h
+++ b/benchmarks/diffusion_of_hill/analytical_topography.h
@@ -25,6 +25,8 @@
 #include <aspect/postprocess/interface.h>
 #include <aspect/simulator_access.h>
 
+#include <limits>
+
 
 namespace aspect
 {
@@ -82,7 +84,7 @@ namespace aspect
          * A time (in seconds) at which the last text output was supposed
          * to be produced. Used to check for the next necessary output time.
          */
-        double last_output_time;
+        double last_output_time = std::numeric_limits<double>::lowest();
 
         /**
          * The amplitude of the sinusoidal initial topography.

--- a/doc/modules/changes/20260724_tjhei
+++ b/doc/modules/changes/20260724_tjhei
@@ -1,0 +1,3 @@
+Fixed: We no longer rely on std::isnan() for deciding when to run postprocessors. This logic would break with compilers and -O3 optimization levels.
+<br>
+(Timo Heister, 2026/07/24)

--- a/include/aspect/postprocess/particles.h
+++ b/include/aspect/postprocess/particles.h
@@ -192,14 +192,16 @@ namespace aspect
         std::vector<double> last_output_time;
 
         /**
-         * Set the time output was supposed to be written. In the simplest
-         * case, this is the previous last output time plus the interval, but
-         * in general we'd like to ensure that it is the largest supposed
-         * output time, which is smaller than the current time, to avoid
-         * falling behind with last_output_time and having to catch up once
-         * the time step becomes larger. This is done after every output.
+         * Set the time output was supposed to be written for the given
+         * particle manager. In the simplest case, this is the previous last
+         * output time plus the interval, but in general we'd like to ensure
+         * that it is the largest supposed output time, which is smaller than
+         * the current time, to avoid falling behind with last_output_time and
+         * having to catch up once the time step becomes larger. This is done
+         * after every output.
          */
-        void set_last_output_time (const double current_time);
+        void set_last_output_time (const unsigned int particle_manager,
+                                   const double current_time);
 
         /**
          * Consecutively counted number indicating the how-manyth time we will

--- a/include/aspect/postprocess/sea_level.h
+++ b/include/aspect/postprocess/sea_level.h
@@ -46,6 +46,11 @@ namespace aspect
     {
       public:
         /**
+         * Constructor.
+         */
+        SeaLevel();
+
+        /**
          * Sets up structured data lookup for topography and ice height input data.
          */
         void initialize() override;

--- a/include/aspect/postprocess/topography.h
+++ b/include/aspect/postprocess/topography.h
@@ -41,6 +41,11 @@ namespace aspect
     {
       public:
         /**
+         * Constructor.
+         */
+        Topography();
+
+        /**
          * Output topography [m] to file
          */
         std::pair<std::string,std::string> execute (TableHandler &statistics) override;

--- a/source/postprocess/crystal_preferred_orientation.cc
+++ b/source/postprocess/crystal_preferred_orientation.cc
@@ -39,7 +39,7 @@ namespace aspect
       output_interval (0),
       // initialize this to a nonsensical value; set it to the actual time
       // the first time around we get to check it
-      last_output_time (std::numeric_limits<double>::quiet_NaN()),
+      last_output_time (std::numeric_limits<double>::lowest()),
       output_file_number (numbers::invalid_unsigned_int),
       group_files(0),
       write_in_background_thread(false)
@@ -201,7 +201,7 @@ namespace aspect
       // if this is the first time we get here, set the last output time
       // to the current time - output_interval. this makes sure we
       // always produce data during the first time step
-      if (std::isnan(last_output_time))
+      if (last_output_time < this->get_parameters().start_time - output_interval)
         last_output_time = this->get_time() - output_interval;
 
       // If it's not time to generate an output file or we do not write output

--- a/source/postprocess/depth_average.cc
+++ b/source/postprocess/depth_average.cc
@@ -55,7 +55,7 @@ namespace aspect
       output_interval (0),
       // initialize this to a nonsensical value; set it to the actual time
       // the first time around we get to check it
-      last_output_time (std::numeric_limits<double>::quiet_NaN()),
+      last_output_time (std::numeric_limits<double>::lowest()),
       n_depth_zones (numbers::invalid_unsigned_int)
     {}
 
@@ -68,7 +68,7 @@ namespace aspect
       // if this is the first time we get here, set the next output time
       // to the current time. this makes sure we always produce data during
       // the first time step
-      if (std::isnan(last_output_time))
+      if (last_output_time < this->get_parameters().start_time - output_interval)
         last_output_time = this->get_time() - output_interval;
 
       // see if output is requested at this time

--- a/source/postprocess/gravity_point_values.cc
+++ b/source/postprocess/gravity_point_values.cc
@@ -48,7 +48,7 @@ namespace aspect
       output_interval (0),
       // initialize this to a nonsensical value; set it to the actual time
       // the first time around we get to check it
-      last_output_time (std::numeric_limits<double>::quiet_NaN()),
+      last_output_time (std::numeric_limits<double>::lowest()),
       maximum_timesteps_between_outputs (std::numeric_limits<int>::max()),
       last_output_timestep (numbers::invalid_unsigned_int),
       output_file_number (numbers::invalid_unsigned_int)
@@ -190,7 +190,7 @@ namespace aspect
       const int dim = 3;
 
       // Check time to see if we output gravity
-      if (std::isnan(last_output_time))
+      if (last_output_time < this->get_parameters().start_time - output_interval)
         {
           last_output_time = this->get_time() - output_interval;
           last_output_timestep = this->get_timestep_number();

--- a/source/postprocess/particles.cc
+++ b/source/postprocess/particles.cc
@@ -321,7 +321,7 @@ namespace aspect
           // if this is the first time we get here, set the last output time
           // to the current time - output_interval. this makes sure we
           // always produce data during the first time step
-          if (std::isnan(last_output_time[particle_manager]))
+          if (last_output_time[particle_manager] < this->get_parameters().start_time - output_interval[particle_manager])
             last_output_time[particle_manager] = this->get_time() - output_interval[particle_manager];
 
           const Particle::Manager<dim> &manager = this->get_particle_manager(particle_manager);
@@ -817,7 +817,7 @@ namespace aspect
               exclude_output_properties[particle_manager].emplace_back("internal: integrator properties");
 
               // Add a non-sensical value for each particle manager.
-              last_output_time.emplace_back(std::numeric_limits<double>::quiet_NaN());
+              last_output_time.emplace_back(std::numeric_limits<double>::lowest());
               output_file_number.emplace_back(numbers::invalid_unsigned_int);
             }
             prm.leave_subsection ();

--- a/source/postprocess/particles.cc
+++ b/source/postprocess/particles.cc
@@ -351,7 +351,7 @@ namespace aspect
             {
               // Up the next time we need output. This is relevant to correctly
               // write output after a restart if the format is changed.
-              set_last_output_time (this->get_time());
+              set_last_output_time (particle_manager, this->get_time());
 
               write_output[particle_manager] = false;
             }
@@ -550,7 +550,7 @@ namespace aspect
 
 
           // up the next time we need output
-          set_last_output_time (this->get_time());
+          set_last_output_time (particle_manager, this->get_time());
 
           const std::string particle_output = this->get_output_directory() + particles_output_base_name + "/" + particle_file_prefix;
 
@@ -573,23 +573,21 @@ namespace aspect
 
     template <int dim>
     void
-    Particles<dim>::set_last_output_time (const double current_time)
+    Particles<dim>::set_last_output_time (const unsigned int particle_manager,
+                                          const double current_time)
     {
       // if output_interval is positive, then update the last supposed output
-      // time for each particle manager
-      for (unsigned int particle_manager = 0; particle_manager < this->n_particle_managers(); ++particle_manager)
+      // time for this particle manager
+      if (output_interval[particle_manager] > 0)
         {
-          if (output_interval[particle_manager] > 0)
-            {
-              // We need to find the last time output was supposed to be written.
-              // this is the last_output_time plus the largest positive multiple
-              // of output_intervals that passed since then. We need to handle the
-              // edge case where last_output_time+output_interval==current_time,
-              // we did an output and std::floor sadly rounds to zero. This is done
-              // by forcing std::floor to round 1.0-eps to 1.0.
-              const double magic = 1.0+2.0*std::numeric_limits<double>::epsilon();
-              last_output_time[particle_manager] = last_output_time[particle_manager] + std::floor((current_time-last_output_time[particle_manager])/output_interval[particle_manager]*magic) * output_interval[particle_manager]/magic;
-            }
+          // We need to find the last time output was supposed to be written.
+          // this is the last_output_time plus the largest positive multiple
+          // of output_intervals that passed since then. We need to handle the
+          // edge case where last_output_time+output_interval==current_time,
+          // we did an output and std::floor sadly rounds to zero. This is done
+          // by forcing std::floor to round 1.0-eps to 1.0.
+          const double magic = 1.0+2.0*std::numeric_limits<double>::epsilon();
+          last_output_time[particle_manager] = last_output_time[particle_manager] + std::floor((current_time-last_output_time[particle_manager])/output_interval[particle_manager]*magic) * output_interval[particle_manager]/magic;
         }
     }
 

--- a/source/postprocess/point_values.cc
+++ b/source/postprocess/point_values.cc
@@ -39,11 +39,13 @@ namespace aspect
       output_interval (0),
       // initialize this to a nonsensical value; set it to the actual time
       // the first time around we get to check it
-      last_output_time (std::numeric_limits<double>::quiet_NaN()),
+      last_output_time (std::numeric_limits<double>::lowest()),
       evaluation_points_cartesian (std::vector<Point<dim>>() ),
       point_values (std::vector<std::pair<double, std::vector<Vector<double>>>>() ),
       use_natural_coordinates (false)
     {}
+
+
 
     template <int dim>
     std::pair<std::string,std::string>
@@ -52,7 +54,7 @@ namespace aspect
       // if this is the first time we get here, set the next output time
       // to the current time. this makes sure we always produce data during
       // the first time step
-      if (std::isnan(last_output_time))
+      if (last_output_time < this->get_parameters().start_time - output_interval)
         last_output_time = this->get_time() - output_interval;
 
       // see if output is requested at this time

--- a/source/postprocess/sea_level.cc
+++ b/source/postprocess/sea_level.cc
@@ -46,11 +46,21 @@ namespace aspect
   namespace Postprocess
   {
     template <int dim>
+    SeaLevel<dim>::SeaLevel()
+      : last_output_time(std::numeric_limits<double>::lowest())
+    {
+    }
+
+
+
+    template <int dim>
     void
     SeaLevel<dim>::initialize()
     {
       Assert(false, ExcNotImplemented(""));
     }
+
+
 
     template <>
     void
@@ -356,7 +366,7 @@ namespace aspect
       // If this is the first time we get here, set the last output time
       // to the current time - output_interval. This makes sure we
       // always produce data during the first time step.
-      if (std::isnan(last_output_time))
+      if (last_output_time < this->get_parameters().start_time - output_interval)
         {
           last_output_time = this->get_time() - output_interval;
         }

--- a/source/postprocess/topography.cc
+++ b/source/postprocess/topography.cc
@@ -39,6 +39,15 @@ namespace aspect
 {
   namespace Postprocess
   {
+
+    template <int dim>
+    Topography<dim>::Topography()
+      : last_output_time(std::numeric_limits<double>::lowest())
+    {
+    }
+
+
+
     template <int dim>
     std::pair<std::string,std::string>
     Topography<dim>::execute (TableHandler &statistics)
@@ -125,7 +134,7 @@ namespace aspect
       // if this is the first time we get here, set the last output time
       // to the current time - output_interval. this makes sure we
       // always produce data during the first time step
-      if (std::isnan(last_output_time))
+      if (last_output_time < this->get_parameters().start_time - output_interval)
         last_output_time = this->get_time() - output_interval;
 
       // Just return stats if text output is not required at all or not needed at this time


### PR DESCRIPTION
As reported, compilers with -O3 optimizations can assume that NaNs do not happen, so we can not rely on std::isnan in a normal code path. Fix all places in postprocess routines.

First draft written by an LLM.

part of #7026, related to #6972