### PR TITLE
Fix periodic free surfaces in spherical shell geometries

### DIFF
--- a/doc/modules/changes/20260729_Minerallo
+++ b/doc/modules/changes/20260729_Minerallo
@@ -1,0 +1,6 @@
+Fixed: Mesh deformation now uses geometry-specific periodicity constraints,
+including the rotation of vector components in curved geometries. This fixes
+free surfaces in phi-periodic spherical shell geometries, which previously
+failed while constructing constraints.
+<br>
+(Pons Michaël, 2026/07/29)

--- a/source/mesh_deformation/free_surface.cc
+++ b/source/mesh_deformation/free_surface.cc
@@ -103,11 +103,11 @@ namespace aspect
         mesh_locally_relevant);
       DoFTools::make_hanging_node_constraints(mesh_deformation_dof_handler, mass_matrix_constraints);
 
-      using periodic_boundary_pairs = std::set<std::pair<std::pair<types::boundary_id, types::boundary_id>, unsigned int>>;
-      periodic_boundary_pairs pbp = this->get_geometry_model().get_periodic_boundary_pairs();
-      for (const auto &p : pbp)
-        DoFTools::make_periodicity_constraints(mesh_deformation_dof_handler,
-                                               p.first.first, p.first.second, p.second, mass_matrix_constraints);
+      // Let the geometry model join periodic boundaries. Curved geometries
+      // such as a quarter annulus also rotate vector components when values
+      // pass from one side to the other.
+      this->get_geometry_model().make_periodicity_constraints(mesh_deformation_dof_handler,
+                                                              mass_matrix_constraints);
 
       mass_matrix_constraints.close();
 

--- a/source/mesh_deformation/interface.cc
+++ b/source/mesh_deformation/interface.cc
@@ -656,15 +656,10 @@ namespace aspect
       // information that was used for mesh_vertex constraints.
       mesh_velocity_constraints.merge(mesh_vertex_constraints);
 
-      // Add the vanilla periodic boundary constraints
-      using periodic_boundary_pairs = std::set<std::pair<std::pair<types::boundary_id, types::boundary_id>, unsigned int>>;
-      const periodic_boundary_pairs pbp = this->get_geometry_model().get_periodic_boundary_pairs();
-      for (const auto &p : pbp)
-        DoFTools::make_periodicity_constraints(mesh_deformation_dof_handler,
-                                               p.first.first,
-                                               p.first.second,
-                                               p.second,
-                                               mesh_velocity_constraints);
+      // Let the geometry model join periodic boundaries, including any
+      // rotation needed by curved geometries.
+      this->get_geometry_model().make_periodicity_constraints(mesh_deformation_dof_handler,
+                                                              mesh_velocity_constraints);
 
       // Zero out the displacement for the zero-velocity boundaries
       // if the boundary is not in the set of tangential mesh boundaries and not in the set of mesh deformation boundary indicators
@@ -784,21 +779,10 @@ namespace aspect
       // information that was used for mesh_vertex constraints.
       mesh_velocity_constraints.merge(mesh_vertex_constraints);
 
-      // Add the vanilla periodic boundary constraints
-      std::set<types::boundary_id> periodic_boundaries;
-      using periodic_boundary_pairs = std::set<std::pair<std::pair<types::boundary_id, types::boundary_id>, unsigned int>>;
-      const periodic_boundary_pairs pbp = this->get_geometry_model().get_periodic_boundary_pairs();
-      for (const auto &p : pbp)
-        {
-          periodic_boundaries.insert(p.first.first);
-          periodic_boundaries.insert(p.first.second);
-
-          DoFTools::make_periodicity_constraints(mesh_deformation_dof_handler,
-                                                 p.first.first,
-                                                 p.first.second,
-                                                 p.second,
-                                                 mesh_velocity_constraints);
-        }
+      // Let the geometry model join periodic boundaries, including any
+      // rotation needed by curved geometries.
+      this->get_geometry_model().make_periodicity_constraints(mesh_deformation_dof_handler,
+                                                              mesh_velocity_constraints);
 
       // Zero out the displacement for the fixed boundaries
       for (const types::boundary_id &boundary_id : zero_mesh_deformation_boundary_indicators)

--- a/tests/periodic_quarter_shell_free_surface.prm
+++ b/tests/periodic_quarter_shell_free_surface.prm
@@ -1,0 +1,94 @@
+# This test verifies that a free surface works on a quarter spherical shell
+# whose radial side boundaries are periodic. Mesh displacement is a vector, so
+# values crossing the periodic boundary must be rotated by 90 degrees. The
+# test advances the free surface for one time step.
+
+set Dimension                     = 2
+set Use years instead of seconds  = true
+set Pressure normalization        = no
+set Nonlinear solver scheme       = single Advection, single Stokes
+
+subsection Geometry model
+  set Model name = spherical shell
+
+  subsection Spherical shell
+    set Inner radius  = 3481e3
+    set Outer radius  = 6336e3
+    set Opening angle = 90
+    set Phi periodic  = true
+  end
+end
+
+subsection Initial temperature model
+  set Model name = harmonic perturbation
+
+  subsection Harmonic perturbation
+    set Magnitude             = 3
+    set Reference temperature = 1613
+  end
+end
+
+subsection Boundary temperature model
+  set Fixed temperature boundary indicators = inner, outer
+  set List of model names = spherical constant
+
+  subsection Spherical constant
+    set Inner temperature = 3000
+    set Outer temperature = 273
+  end
+end
+
+subsection Boundary velocity model
+  set Tangential velocity boundary indicators = inner
+end
+
+subsection Mesh deformation
+  set Mesh deformation boundary indicators = outer: free surface
+
+  subsection Free surface
+    set Free surface stabilization theta = 1
+  end
+end
+
+subsection Gravity model
+  set Model name = radial constant
+
+  subsection Radial constant
+    set Magnitude = 10
+  end
+end
+
+subsection Material model
+  set Model name = simple
+
+  subsection Simple model
+    set Viscosity = 1e21
+  end
+end
+
+subsection Mesh refinement
+  set Initial global refinement          = 2
+  set Initial adaptive refinement        = 0
+  set Time steps between mesh refinement = 0
+end
+
+subsection Solver parameters
+  subsection Stokes solver parameters
+    # The geometric multigrid mesh-displacement solver does not support
+    # periodic boundaries.
+    set Stokes solver type = block AMG
+  end
+end
+
+subsection Termination criteria
+  set End step             = 1
+  set Termination criteria = end step
+end
+
+subsection Postprocess
+  set List of postprocessors = topography, velocity statistics
+
+  subsection Topography
+    set Output to file = false
+  end
+end

--- a/tests/periodic_quarter_shell_free_surface/screen-output
+++ b/tests/periodic_quarter_shell_free_surface/screen-output
@@ -1,0 +1,30 @@
+
+Number of active cells: 48 (on 3 levels)
+Number of degrees of freedom: 740 (450+65+225)
+
+Number of mesh deformation degrees of freedom: 450
+   Solving mesh displacement system... 0 iterations.
+*** Timestep 0:  t=0 years, dt=0 years
+   Solving mesh displacement system... 0 iterations.
+   Solving temperature system... 0 iterations.
+   Rebuilding Stokes preconditioner...
+   Solving Stokes system (AMG)... 22+0 iterations.
+
+   Postprocessing:
+     Topography min/max: 0 m, 9.313e-10 m
+     RMS, max velocity:  1.03e+07 m/year, 1.27e+07 m/year
+
+*** Timestep 1:  t=0.0270135 years, dt=0.0270135 years
+   Solving mesh displacement system... 1 iterations.
+   Solving temperature system... 17 iterations.
+   Rebuilding Stokes preconditioner...
+   Solving Stokes system (AMG)... 13+0 iterations.
+
+   Postprocessing:
+     Topography min/max: -0.001102 m, 0.6762 m
+     RMS, max velocity:  1.05e+08 m/year, 1.3e+08 m/year
+
+Termination requested by criterion: end step
+
+
+


### PR DESCRIPTION
Hi everyone,
While running some quick tests, I realised that mesh deformation in a spherical shell with periodic boundary conditions was not working correctly and crashing.
The mesh-deformation now asks the geometry model to create the periodic constraints, which applies the rotation for the spherical shell.
Cheers,
Michael

### For all pull requests:

* [x] I have followed the [instructions for indenting my code](../blob/main/CONTRIBUTING.md#making-aspect-better).
* I followed the [AI Policy](../blob/main/CONTRIBUTING.md#policy-on-usage-of-ai):
  - [x] Significant parts of this PR were written by AI (please add a sentence below).
  - [ ] AI has not been used in significant ways.

*If yes, please describe your usage of AI models in the creation of this pull request*

### For new features/models or changes of existing features:

* [x] I have tested my new feature locally to ensure it is correct.
* [x] I have [created a testcase](https://aspect-documentation.readthedocs.io/en/latest/user/extending/testing/writing-tests.html) for the new feature/benchmark in the [tests/](../blob/main/tests/) directory.
* [x] I have added a changelog entry in the [doc/modules/changes](../blob/main/doc/modules/changes) directory that will inform other users of my change.
