### PR TITLE
remove trailing character in benchmarks markdown files

### DIFF
--- a/benchmarks/rayleigh_taylor_instability/doc/rayleigh_taylor_instability.md
+++ b/benchmarks/rayleigh_taylor_instability/doc/rayleigh_taylor_instability.md
@@ -6,7 +6,7 @@ feature:community-benchmark
 feature:analytical-solution
 ```
 
-(sec:benchmarks:rayleigh_taylor_instability)=`
+(sec:benchmarks:rayleigh_taylor_instability)=
 # The Rayleigh-Taylor instability
 
 *This section was contributed by Cedric Thieulot.*

--- a/benchmarks/rayleigh_taylor_instability_free_surface/doc/rayleigh_taylor_instability_free_surface.md
+++ b/benchmarks/rayleigh_taylor_instability_free_surface/doc/rayleigh_taylor_instability_free_surface.md
@@ -7,7 +7,7 @@ feature:analytical-solution
 feature:mesh-deformation
 ```
 
-(sec:benchmarks:rayleigh_taylor_instability_free_surface)=`
+(sec:benchmarks:rayleigh_taylor_instability_free_surface)=
 # The Rayleigh-Taylor instability with a free surface
 
 *This section was contributed by Anne Glerum, Ian Rose and Timo Heister.*

--- a/benchmarks/rigid_shear/doc/rigid_shear.md
+++ b/benchmarks/rigid_shear/doc/rigid_shear.md
@@ -6,7 +6,7 @@ feature:analytical-solution
 feature:particles
 ```
 
-(sec:benchmarks:rigid_shear)=`
+(sec:benchmarks:rigid_shear)=
 # The rigid shear benchmark
 
 *This section was contributed by R. Gassmoeller.*

--- a/benchmarks/shear_bands/README.md
+++ b/benchmarks/shear_bands/README.md
@@ -10,7 +10,7 @@ feature:melt
 feature:modular-equations
 ```
 
-(sec:benchmarks:shear_bands)=`
+(sec:benchmarks:shear_bands)=
 # Magmatic shear bands
 This directory contains magmatic shear bands examples for Newtonian rheology (as defined
 in Spiegelman, 2003, Linear analysis of melt band formation by simple shear) and for

--- a/benchmarks/sinking_block/doc/sinking_block.md
+++ b/benchmarks/sinking_block/doc/sinking_block.md
@@ -5,7 +5,7 @@ feature:cartesian
 feature:community-benchmark
 ```
 
-(sec:benchmarks:sinking_block)=`
+(sec:benchmarks:sinking_block)=
 # The sinking block benchmark
 
 This benchmark is based on the benchmark presented in {cite:t}`gerya:2010` and

--- a/benchmarks/slab_detachment/doc/slab_detachment.md
+++ b/benchmarks/slab_detachment/doc/slab_detachment.md
@@ -7,7 +7,7 @@ feature:nonlinear-solver
 feature:compositional-fields
 ```
 
-(sec:benchmarks:slab_detachment)=`
+(sec:benchmarks:slab_detachment)=
 # The slab detachment benchmark
 
 *This section was contributed by Cedric Thieulot and Anne Glerum.*


### PR DESCRIPTION
some benchmarks pages did not render properly because (I believe) of the presence of a back quote trailing character.