### PR TITLE
Add function advection method for compositional fields

### DIFF
--- a/doc/sphinx/parameters/Compositional_20fields.md
+++ b/doc/sphinx/parameters/Compositional_20fields.md
@@ -9,7 +9,7 @@
 :name: parameters:Compositional_20fields/Compositional_20field_20methods
 **Default value:**
 
-**Pattern:** [List of <[Selection field|particles|volume of fluid|static|melt field|darcy field|prescribed field|prescribed field with diffusion ]> of length 0...4294967295 (inclusive)]
+**Pattern:** [List of <[Selection field|particles|volume of fluid|static|melt field|darcy field|function defined field|prescribed field|prescribed field with diffusion ]> of length 0...4294967295 (inclusive)]
 
 **Documentation:** A comma separated list denoting the solution method of each compositional field. Each entry of the list must be one of the currently implemented field methods.
 
@@ -80,4 +80,46 @@ Each entry of the list must be one of several recognized types: * &ldquo;chemica
 * &ldquo;unspecified&rdquo;: The unspecified type is intended to tell ASPECT that the user has not explicitly indicated the type of this field. ASPECT will then try to detect the type automatically based on the name, but will default to &ldquo;chemical composition&rdquo; if the name does not correspond to a known type.
 
 Note that while ASPECT&rsquo;s functionality can make use of the field types, not all of the code will make use of it. It is the user&rsquo;s responsibility to check that the chosen material model and other plugins interpret the compositional fields as intended.
+::::
+
+(parameters:Compositional_20fields/Function_20defined_20fields)=
+## **Subsection:** Compositional fields / Function defined fields
+::::{dropdown} __Parameter:__ {ref}`Coordinate system<parameters:Compositional_20fields/Function_20defined_20fields/Coordinate_20system>`
+:name: parameters:Compositional_20fields/Function_20defined_20fields/Coordinate_20system
+**Default value:** depth
+
+**Pattern:** [Selection depth|cartesian|spherical ]
+
+**Documentation:** A selection that determines the assumed coordinate system for the function variables. Allowed values are &lsquo;depth&rsquo;, &lsquo;cartesian&rsquo; and &lsquo;spherical&rsquo;. &lsquo;depth&rsquo; will create a function, in which only the first variable is non-zero, which is interpreted to be the depth of the point. &lsquo;spherical&rsquo; coordinates are interpreted as r,phi or r,phi,theta in 2d/3d respectively with theta being the polar angle.
+::::
+
+::::{dropdown} __Parameter:__ {ref}`Function constants<parameters:Compositional_20fields/Function_20defined_20fields/Function_20constants>`
+:name: parameters:Compositional_20fields/Function_20defined_20fields/Function_20constants
+**Default value:**
+
+**Pattern:** [Anything]
+
+**Documentation:** Sometimes it is convenient to use symbolic constants in the expression that describes the function, rather than having to use its numeric value everywhere the constant appears. These values can be defined using this parameter, in the form &lsquo;var1=value1, var2=value2, ...&rsquo;.
+
+A typical example would be to set this runtime parameter to &lsquo;pi=3.1415926536&rsquo; and then use &lsquo;pi&rsquo; in the expression of the actual formula. (That said, for convenience this class actually defines both &lsquo;pi&rsquo; and &lsquo;Pi&rsquo; by default, but you get the idea.)
+::::
+
+::::{dropdown} __Parameter:__ {ref}`Function expression<parameters:Compositional_20fields/Function_20defined_20fields/Function_20expression>`
+:name: parameters:Compositional_20fields/Function_20defined_20fields/Function_20expression
+**Default value:** 0; 0
+
+**Pattern:** [Anything]
+
+**Documentation:** The formula that denotes the function you want to evaluate for particular values of the independent variables. This expression may contain any of the usual operations such as addition or multiplication, as well as all of the common functions such as &lsquo;sin&rsquo; or &lsquo;cos&rsquo;. In addition, it may contain expressions like &lsquo;if(x>0, 1, -1)&rsquo; where the expression evaluates to the second argument if the first argument is true, and to the third argument otherwise. For a full overview of possible expressions accepted see the documentation of the muparser library at http://muparser.beltoforion.de/.
+
+If the function you are describing represents a vector-valued function with multiple components, then separate the expressions for individual components by a semicolon.
+::::
+
+::::{dropdown} __Parameter:__ {ref}`Variable names<parameters:Compositional_20fields/Function_20defined_20fields/Variable_20names>`
+:name: parameters:Compositional_20fields/Function_20defined_20fields/Variable_20names
+**Default value:** x,y,t
+
+**Pattern:** [Anything]
+
+**Documentation:** The names of the variables as they will be used in the function, separated by commas. By default, the names of variables at which the function will be evaluated are &lsquo;x&rsquo; (in 1d), &lsquo;x,y&rsquo; (in 2d) or &lsquo;x,y,z&rsquo; (in 3d) for spatial coordinates and &lsquo;t&rsquo; for time. You can then use these variable names in your function expression and they will be replaced by the values of these variables at which the function is currently evaluated. However, you can also choose a different set of names for the independent variables at which to evaluate your function expression. For example, if you work in spherical coordinates, you may wish to set this input parameter to &lsquo;r,phi,theta,t&rsquo; and then use these variable names in your function expression.
 ::::

--- a/include/aspect/parameters.h
+++ b/include/aspect/parameters.h
@@ -23,7 +23,9 @@
 #define _aspect_parameters_h
 
 #include <deal.II/base/parameter_handler.h>
+#include <deal.II/base/parsed_function.h>
 
+#include <aspect/coordinate_systems.h>
 #include <aspect/global.h>
 #include <aspect/material_model/interface.h>
 
@@ -217,6 +219,7 @@ namespace aspect
         static_field,
         fem_melt_field,
         fem_darcy_field,
+        fem_function_field,
         prescribed_field,
         prescribed_field_with_diffusion
       };
@@ -538,6 +541,9 @@ namespace aspect
     Parameters (ParameterHandler &prm,
                 const MPI_Comm mpi_communicator);
 
+
+    // void update();
+
     /**
      * Declare the run-time parameters this class takes, and call the
      * respective <code>declare_parameters</code> functions of the namespaces
@@ -832,6 +838,20 @@ namespace aspect
      * field. Consequently the vector has n_compositional_fields entries.
      */
     std::vector<typename AdvectionFieldMethod::Kind> compositional_field_methods;
+
+    /**
+     * Parsed advection velocity function used by compositional fields with
+     * method 'function defined field'. This function determined the velocity
+     * of a compositional field at a given point in space and in time.
+     */
+    Functions::ParsedFunction<dim> compositional_field_advection_function;
+
+    /**
+     * The coordinate representation to evaluate the
+     * compositional_field_advection_function. Possible choices are depth,
+     * cartesian and spherical.
+     */
+    Utilities::Coordinates::CoordinateSystem compositional_field_advection_function_coordinate_system;
 
     /**
      * Map from compositional index to a pair "particle property", "component",

--- a/include/aspect/simulator/assemblers/advection.h
+++ b/include/aspect/simulator/assemblers/advection.h
@@ -23,6 +23,7 @@
 
 
 #include <aspect/simulator/assemblers/interface.h>
+#include <deal.II/base/parsed_function.h>
 #include <aspect/simulator_access.h>
 
 namespace aspect
@@ -46,6 +47,10 @@ namespace aspect
         compute_residual(internal::Assembly::Scratch::ScratchBase<dim>  &scratch_base) const override;
     };
 
+    /**
+     * This class creates an advection assembler that advects a compositional field
+     * with an approximate form of the Darcy velocity.
+     */
     template <int dim>
     class DarcySystem : public Assemblers::Interface<dim>, public Assemblers::AdvectionStabilizationInterface<dim>,
       public SimulatorAccess<dim>
@@ -60,6 +65,23 @@ namespace aspect
 
         void
         create_additional_material_model_outputs(MaterialModel::MaterialModelOutputs<dim> &outputs) const override;
+    };
+
+    /**
+     * This class creates an advection assembler that uses a user-defined function to advect a
+     * compositional field.
+     */
+    template <int dim>
+    class FunctionSystem : public Assemblers::Interface<dim>, public Assemblers::AdvectionStabilizationInterface<dim>,
+      public SimulatorAccess<dim>
+    {
+      public:
+        void
+        execute(internal::Assembly::Scratch::ScratchBase<dim>  &scratch_base,
+                internal::Assembly::CopyData::CopyDataBase<dim> &data_base) const override;
+
+        std::vector<double>
+        compute_residual(internal::Assembly::Scratch::ScratchBase<dim>  &scratch_base) const override;
     };
 
     /**

--- a/include/aspect/simulator/assemblers/interface.h
+++ b/include/aspect/simulator/assemblers/interface.h
@@ -54,7 +54,7 @@ namespace aspect
          * individual scratch objects for the different equations.
          */
         template <int dim>
-        struct ScratchBase
+        struct ScratchBase // DERIVE THIS FROM Plugins::InterfaceBase
         {
           ScratchBase()
             :
@@ -684,7 +684,7 @@ namespace aspect
      *   in this class.
      */
     template <int dim>
-    class Manager
+    class Manager : public Plugins::ManagerBase<Interface<dim>>
     {
       public:
 

--- a/source/simulator/assemblers/advection.cc
+++ b/source/simulator/assemblers/advection.cc
@@ -797,6 +797,165 @@ namespace aspect
     }
 
 
+    template <int dim>
+    void
+    FunctionSystem<dim>::execute (internal::Assembly::Scratch::ScratchBase<dim>   &scratch_base,
+                                  internal::Assembly::CopyData::CopyDataBase<dim> &data_base) const
+    {
+      // This function is similar to the AdvectionSystem::execute function, but it uses a user-defined
+      // function to compute the advection velocity field instead of using the velocity field from the
+      // solution vector. The rest of the assembly process is similar to that of the AdvectionSystem.
+      internal::Assembly::Scratch::AdvectionSystem<dim> &scratch = dynamic_cast<internal::Assembly::Scratch::AdvectionSystem<dim>& > (scratch_base);
+      internal::Assembly::CopyData::AdvectionSystem<dim> &data = dynamic_cast<internal::Assembly::CopyData::AdvectionSystem<dim>& > (data_base);
+      const Introspection<dim> &introspection = this->introspection();
+      const FiniteElement<dim> &fe = this->get_fe();
+
+      const Functions::ParsedFunction<dim> &compositional_field_advection_function = this->get_parameters().compositional_field_advection_function;
+
+      const AdvectionField advection_field = *scratch.advection_field;
+
+      Assert(advection_field.advection_method(introspection)
+             == Parameters<dim>::AdvectionFieldMethod::fem_function_field,
+             ExcMessage("The 'FunctionSystem' assembler can only be executed for fields "
+                        "that use the advection method 'function field'."));
+
+      const unsigned int n_q_points = scratch.finite_element_values.n_quadrature_points;
+      const unsigned int advection_dofs_per_cell = data.local_dof_indices.size();
+
+      // Is this check necessary for a function advection method??
+      const bool use_supg = (this->get_parameters().advection_stabilization_method
+                             == Parameters<dim>::AdvectionStabilizationMethod::supg);
+      AssertThrow(use_supg == false,
+                  ExcMessage("The Function field advection method does not support the use of SUPG"));
+
+      const bool   use_bdf2_scheme = (this->get_timestep_number() > 1);
+      const double time_step = this->get_timestep();
+      const double old_time_step = this->get_old_timestep();
+
+      const double bdf2_factor = (use_bdf2_scheme)? ((2*time_step + old_time_step) /
+                                                     (time_step + old_time_step)) : 1.0;
+      const unsigned int solution_component = advection_field.component_index(introspection);
+      const FEValuesExtractors::Scalar solution_field = advection_field.scalar_extractor(introspection);
+
+      for (unsigned int q=0; q<n_q_points; ++q)
+        {
+          // Precompute the values of shape functions and their gradients.
+          // We only need to look up values of shape functions if they
+          // belong to 'our' component. They are zero otherwise anyway.
+          // Note that we later only look at the values that we do set here.
+          for (unsigned int i=0, i_advection=0; i_advection<advection_dofs_per_cell;/*increment at end of loop*/)
+            {
+              if (fe.system_to_component_index(i).first == solution_component)
+                {
+                  scratch.grad_phi_field[i_advection] = scratch.finite_element_values[solution_field].gradient (i,q);
+                  scratch.phi_field[i_advection]      = scratch.finite_element_values[solution_field].value (i,q);
+                  ++i_advection;
+                }
+              ++i;
+            }
+
+          const double reaction_term = scratch.material_model_outputs.reaction_terms[q][advection_field.compositional_variable];
+
+          const double field_term_for_rhs
+            = (use_bdf2_scheme ?
+               (scratch.old_field_values[q] *
+                (1 + time_step/old_time_step)
+                -
+                scratch.old_old_field_values[q] *
+                (time_step * time_step) /
+                (old_time_step * (time_step + old_time_step)))
+               :
+               scratch.old_field_values[q]);
+
+          Tensor<1,dim> current_u;
+          const Point<dim> position = scratch.material_model_inputs.position[q];
+
+          for (unsigned int d=0; d<dim; ++d)
+            {
+              current_u[d] = compositional_field_advection_function.value(position,d);
+
+              if (this->convert_output_to_years())
+                current_u[d] /= year_in_seconds;
+            }
+
+          // Does this function method need to do this as well? Or do we want to make sure
+          // that the velocity is always the function velocity regardless of mesh deformation.
+          if (this->get_parameters().mesh_deformation_enabled)
+            current_u -= scratch.mesh_velocity_values[q];
+          const double JxW = scratch.finite_element_values.JxW(q);
+
+          //     // Perform the assembly. We only need to loop over advection
+          //     // shape functions because these are the only contributions computed here.
+          for (unsigned int i=0; i<advection_dofs_per_cell; ++i)
+            {
+              data.local_rhs(i)
+              += (field_term_for_rhs * scratch.phi_field[i]
+                  + scratch.phi_field[i]
+                  * reaction_term)
+                 * JxW;
+
+              for (unsigned int j=0; j<advection_dofs_per_cell; ++j)
+                {
+                  data.local_matrix(i,j)
+                  += (
+                       (time_step * scratch.artificial_viscosity
+                        * (scratch.grad_phi_field[i] * scratch.grad_phi_field[j]))
+                       + ((time_step * (scratch.phi_field[i] * (current_u * scratch.grad_phi_field[j])))
+                          + (bdf2_factor * scratch.phi_field[i] * scratch.phi_field[j]))
+                     )
+                     * JxW;
+                }
+            }
+        }
+    }
+
+
+
+    template <int dim>
+    std::vector<double>
+    FunctionSystem<dim>::compute_residual(internal::Assembly::Scratch::ScratchBase<dim> &scratch_base) const
+    {
+      // This function is similar to the AdvectionSystem::execute function, but it uses a user-defined
+      // function to compute the advection velocity field instead of using the velocity field from the
+      // solution vector. The rest of the assembly process is similar to that of the AdvectionSystem.
+      internal::Assembly::Scratch::AdvectionSystem<dim> &scratch = dynamic_cast<internal::Assembly::Scratch::AdvectionSystem<dim>&> (scratch_base);
+
+      const AdvectionField advection_field = *scratch.advection_field;
+      const unsigned int n_q_points = scratch.finite_element_values.n_quadrature_points;
+      std::vector<double> residuals(n_q_points);
+      const Functions::ParsedFunction<dim> &compositional_field_advection_function = this->get_parameters().compositional_field_advection_function;
+      // compositional_field_advection_function.set_time(this->get_time());
+
+      for (unsigned int q=0; q < n_q_points; ++q)
+        {
+          Tensor<1,dim> current_u;
+          const Point<dim> position = scratch.material_model_inputs.position[q];
+
+          for (unsigned int d=0; d<dim; ++d)
+            {
+              current_u[d] = compositional_field_advection_function.value(position,d);
+
+              if (this->convert_output_to_years())
+                current_u[d] /= year_in_seconds;
+            }
+
+          const double dField_dt = (this->get_old_timestep() == 0.0) ? 0.0 :
+                                   (
+                                     ((scratch.old_field_values)[q] - (scratch.old_old_field_values)[q])
+                                     / this->get_old_timestep());
+          const double u_grad_field = current_u * (scratch.old_field_grads[q] +
+                                                   scratch.old_old_field_grads[q]) / 2;
+
+          const double dreaction_term_dt = (this->get_old_timestep() == 0) ? 0.0 :
+                                           scratch.material_model_outputs.reaction_terms[q][advection_field.compositional_variable]
+                                           / this->get_old_timestep();
+
+          residuals[q] = std::abs(dField_dt + u_grad_field - dreaction_term_dt);
+        }
+      return residuals;
+    }
+
+
 
     template <int dim>
     void
@@ -819,11 +978,13 @@ namespace aspect
 
       const double time_step = this->get_timestep();
 
-      Assert(advection_field.is_discontinuous(introspection)
-             && advection_field.advection_method(introspection)
-             == Parameters<dim>::AdvectionFieldMethod::fem_field,
+      Assert((advection_field.is_discontinuous(introspection)
+              && (advection_field.advection_method(introspection)
+                  == Parameters<dim>::AdvectionFieldMethod::fem_function_field)
+              || (advection_field.is_discontinuous(introspection)
+                  == Parameters<dim>::AdvectionFieldMethod::fem_field)),
              ExcMessage("The 'AdvectionSystemBoundaryFace' assembler can only be executed for fields "
-                        "that use the advection method 'field' and a discontinuous discretization."));
+                        "that use the advection method 'field' or 'function field' and a discontinuous discretization."));
 
       // Number of DoFs associated with the element for the
       // system currently being assembled.
@@ -1750,6 +1911,7 @@ namespace aspect
   template class AdvectionSystem<dim>; \
   template class DiffusionSystem<dim>; \
   template class DarcySystem<dim>; \
+  template class FunctionSystem<dim>; \
   template class AdvectionSystemBoundaryFace<dim>; \
   template class AdvectionSystemInteriorFace<dim>; \
   template class AdvectionSystemBoundaryHeatFlux<dim>; \

--- a/source/simulator/assembly.cc
+++ b/source/simulator/assembly.cc
@@ -153,6 +153,11 @@ namespace aspect
           assemblers->advection_system[i].push_back(
             std::make_unique<aspect::Assemblers::AdvectionSystem<dim>>());
 
+        // Add the function assembler if the advection field uses the function field method.
+        if ((i>0 && parameters.compositional_field_methods[i-1] == Parameters<dim>::AdvectionFieldMethod::fem_function_field))
+          assemblers->advection_system[i].push_back(
+            std::make_unique<aspect::Assemblers::FunctionSystem<dim>>());
+
         // Only add the diffusion assembler if advection field i uses the prescribed_field_with_diffusion method.
         if ((i==0 && parameters.temperature_method == Parameters<dim>::AdvectionFieldMethod::prescribed_field_with_diffusion)
             ||
@@ -169,7 +174,9 @@ namespace aspect
              && parameters.temperature_method == Parameters<dim>::AdvectionFieldMethod::fem_field)
             ||
             (i>0 && parameters.use_discontinuous_composition_discretization[i-1]
-             && parameters.compositional_field_methods[i-1] == Parameters<dim>::AdvectionFieldMethod::fem_field))
+             &&
+             (parameters.compositional_field_methods[i-1] == Parameters<dim>::AdvectionFieldMethod::fem_field
+              || parameters.compositional_field_methods[i-1] == Parameters<dim>::AdvectionFieldMethod::fem_function_field)))
           {
             assemblers->advection_system_on_boundary_face[i].push_back(
               std::make_unique<aspect::Assemblers::AdvectionSystemBoundaryFace<dim>>());
@@ -204,7 +211,10 @@ namespace aspect
           }
 
         if (i > 0 && parameters.use_discontinuous_composition_discretization[i-1]
-            && parameters.compositional_field_methods[i-1] == Parameters<dim>::AdvectionFieldMethod::fem_field)
+            &&
+            ((parameters.compositional_field_methods[i-1] == Parameters<dim>::AdvectionFieldMethod::fem_field)
+             ||
+             (parameters.compositional_field_methods[i-1] == Parameters<dim>::AdvectionFieldMethod::fem_function_field)))
           {
             assemblers->advection_system_assembler_on_face_properties[i].need_face_material_model_data = true;
             assemblers->advection_system_assembler_on_face_properties[i].need_face_finite_element_evaluation = true;
@@ -219,8 +229,11 @@ namespace aspect
 
         for (unsigned int c=0; c<parameters.n_compositional_fields; ++c)
           {
-            if (parameters.use_discontinuous_composition_discretization[c]
-                && parameters.compositional_field_methods[c] == Parameters<dim>::AdvectionFieldMethod::fem_field)
+            if ((parameters.use_discontinuous_composition_discretization[c]
+                 && parameters.compositional_field_methods[c] == Parameters<dim>::AdvectionFieldMethod::fem_field)
+                ||
+                (parameters.use_discontinuous_composition_discretization[c]
+                 && parameters.compositional_field_methods[c] == Parameters<dim>::AdvectionFieldMethod::fem_function_field))
               {
                 dc_composition = true;
                 break;

--- a/source/simulator/core.cc
+++ b/source/simulator/core.cc
@@ -690,8 +690,10 @@ namespace aspect
     if (parameters.mesh_deformation_enabled)
       mesh_deformation->update();
 
-    if (prescribed_stokes_solution.get())
-      prescribed_stokes_solution->update();
+    if (parameters.convert_to_years)
+      parameters.compositional_field_advection_function.set_time(time / year_in_seconds);
+    else
+      parameters.compositional_field_advection_function.set_time(time);
 
     for (auto &particle_manager : particle_managers)
       particle_manager.update();
@@ -947,6 +949,7 @@ namespace aspect
           case Parameters<dim>::AdvectionFieldMethod::fem_melt_field:
           case Parameters<dim>::AdvectionFieldMethod::fem_darcy_field:
           case Parameters<dim>::AdvectionFieldMethod::prescribed_field_with_diffusion:
+          case Parameters<dim>::AdvectionFieldMethod::fem_function_field:
             return true;
           case Parameters<dim>::AdvectionFieldMethod::particles:
           case Parameters<dim>::AdvectionFieldMethod::volume_of_fluid:

--- a/source/simulator/entropy_viscosity.cc
+++ b/source/simulator/entropy_viscosity.cc
@@ -164,6 +164,7 @@ namespace aspect
     std::vector<Tensor<1,dim>> old_fluid_velocity_values(scratch.finite_element_values.n_quadrature_points);
     std::vector<Tensor<1,dim>> old_old_fluid_velocity_values(scratch.finite_element_values.n_quadrature_points);
     const bool use_darcy_velocity = (advection_field.advection_method(introspection) == Parameters<dim>::AdvectionFieldMethod::fem_darcy_field);
+    const bool use_function_velocity = (advection_field.advection_method(introspection) == Parameters<dim>::AdvectionFieldMethod::fem_function_field);
 
     std::shared_ptr<const MaterialModel::MeltOutputs<dim>> melt_outputs;
     if (use_darcy_velocity)
@@ -185,6 +186,22 @@ namespace aspect
         const Tensor<1,dim> velocity = (scratch.old_velocity_values[q] +
                                         scratch.old_old_velocity_values[q]) / 2;
         double velocity_norm = velocity.norm();
+
+        if (use_function_velocity)
+          {
+            Tensor<1,dim> function_velocity;
+            const Point<dim> position = scratch.finite_element_values.quadrature_point(q);
+            const Functions::ParsedFunction<dim> &compositional_field_advection_function = parameters.compositional_field_advection_function;
+            for (unsigned int d=0; d<dim; ++d)
+              {
+                function_velocity[d] = compositional_field_advection_function.value(position,d);
+
+                if (parameters.convert_to_years)
+                  function_velocity[d] /= year_in_seconds;
+              }
+
+            velocity_norm = std::max(function_velocity.norm(), velocity_norm);
+          }
 
         if (use_darcy_velocity)
           {

--- a/source/simulator/melt.cc
+++ b/source/simulator/melt.cc
@@ -1739,6 +1739,8 @@ namespace aspect
             ||
             (i>0 && this->get_parameters().compositional_field_methods[i-1] == Parameters<dim>::AdvectionFieldMethod::fem_field)
             ||
+            (i>0 && this->get_parameters().compositional_field_methods[i-1] == Parameters<dim>::AdvectionFieldMethod::fem_function_field)
+            ||
             (i>0 && this->get_parameters().compositional_field_methods[i-1] == Parameters<dim>::AdvectionFieldMethod::fem_melt_field))
           assemblers.advection_system[i].push_back(
             std::make_unique<Assemblers::MeltAdvectionSystem<dim>> ());

--- a/source/simulator/parameters.cc
+++ b/source/simulator/parameters.cc
@@ -40,10 +40,20 @@ namespace aspect
   template <int dim>
   Parameters<dim>::Parameters (ParameterHandler &prm,
                                const MPI_Comm mpi_communicator)
+    :
+    compositional_field_advection_function (dim)
   {
     parse_parameters (prm, mpi_communicator);
   }
 
+  // template <int dim>
+  // void
+  // Parameters<dim>::update()
+  // {
+  //   // we get time passed as seconds (always) but may want
+  //   // to reinterpret it in years
+  //   compositional_field_advection_function.update();
+  // }
 
   template <int dim>
   void
@@ -1415,7 +1425,7 @@ namespace aspect
                          "the user's responsibility to check that the chosen material model "
                          "and other plugins interpret the compositional fields as intended.");
       prm.declare_entry ("Compositional field methods", "",
-                         Patterns::List (Patterns::Selection("field|particles|volume of fluid|static|melt field|darcy field|prescribed field|prescribed field with diffusion")),
+                         Patterns::List (Patterns::Selection("field|particles|volume of fluid|static|melt field|darcy field|function defined field|prescribed field|prescribed field with diffusion")),
                          "A comma separated list denoting the solution method of each "
                          "compositional field. Each entry of the list must be "
                          "one of the currently implemented field methods."
@@ -1515,6 +1525,21 @@ namespace aspect
                          "at every point and the global maximum is determined. "
                          "Second, the compositional fields to be normalized are "
                          "divided by this maximum.");
+      prm.enter_subsection ("Function defined fields");
+      {
+        prm.declare_entry ("Coordinate system", "depth",
+                           Patterns::Selection ("depth|cartesian|spherical"),
+                           "A selection that determines the assumed coordinate "
+                           "system for the function variables. Allowed values "
+                           "are `depth', `cartesian' and `spherical'. `depth' "
+                           "will create a function, in which only the first "
+                           "variable is non-zero, which is interpreted to "
+                           "be the depth of the point. `spherical' coordinates "
+                           "are interpreted as r,phi or r,phi,theta in 2d/3d "
+                           "respectively with theta being the polar angle.");
+        Functions::ParsedFunction<dim>::declare_parameters (prm, dim);
+      }
+      prm.leave_subsection ();
     }
     prm.leave_subsection ();
 
@@ -1962,6 +1987,26 @@ namespace aspect
     prm.enter_subsection ("Compositional fields");
     {
       n_compositional_fields = prm.get_integer ("Number of fields");
+
+      prm.enter_subsection ("Function defined fields");
+      {
+        compositional_field_advection_function_coordinate_system = Utilities::Coordinates::string_to_coordinate_system(prm.get("Coordinate system"));
+      }
+      try
+        {
+          compositional_field_advection_function.parse_parameters (prm);
+        }
+      catch (...)
+        {
+          std::cerr << "ERROR: FunctionParser failed to parse\n"
+                    << "\t'Compositional fields/Function defined fields'\n"
+                    << "with expression\n"
+                    << "\t'" << prm.get("Function expression") << "'"
+                    << "More information about the cause of the parse error \n"
+                    << "is shown below.\n";
+          throw;
+        }
+      prm.leave_subsection();
     }
     prm.leave_subsection();
 
@@ -2264,6 +2309,8 @@ namespace aspect
             compositional_field_methods[i] = AdvectionFieldMethod::fem_melt_field;
           else if (x_compositional_field_methods[i] == "darcy field")
             compositional_field_methods[i] = AdvectionFieldMethod::fem_darcy_field;
+          else if (x_compositional_field_methods[i] == "function defined field")
+            compositional_field_methods[i] = AdvectionFieldMethod::fem_function_field;
           else if (x_compositional_field_methods[i] == "prescribed field")
             compositional_field_methods[i] = AdvectionFieldMethod::prescribed_field;
           else if (x_compositional_field_methods[i] == "prescribed field with diffusion")

--- a/source/simulator/solver_schemes.cc
+++ b/source/simulator/solver_schemes.cc
@@ -272,6 +272,7 @@ namespace aspect
             case Parameters<dim>::AdvectionFieldMethod::fem_melt_field:
             case Parameters<dim>::AdvectionFieldMethod::prescribed_field_with_diffusion:
             case Parameters<dim>::AdvectionFieldMethod::fem_darcy_field:
+            case Parameters<dim>::AdvectionFieldMethod::fem_function_field:
             {
               // if this is a prescribed field with diffusion, we first have to copy the material model
               // outputs into the prescribed field before we assemble and solve the equation

--- a/source/time_stepping/convection_time_step.cc
+++ b/source/time_stepping/convection_time_step.cc
@@ -35,6 +35,7 @@ namespace aspect
                                                this->get_parameters().stokes_velocity_degree);
 
       bool consider_darcy_timestep = false;
+      bool consider_function_timestep = false;
       unsigned int porosity_idx = numbers::invalid_unsigned_int;
       if (this->introspection().composition_type_exists(CompositionalFieldDescription::porosity))
         {
@@ -43,9 +44,14 @@ namespace aspect
             consider_darcy_timestep = true;
         }
 
+      for (unsigned int c=0; c<this->n_compositional_fields(); ++c)
+        if (this->get_parameters().compositional_field_methods[c] == Parameters<dim>::AdvectionFieldMethod::fem_function_field)
+          consider_function_timestep = true;
+
+      const bool update_more_flags = consider_function_timestep || consider_darcy_timestep;
       const UpdateFlags update_flags
         = UpdateFlags(
-            consider_darcy_timestep
+            update_more_flags
             ?
             update_values |
             update_gradients |
@@ -100,6 +106,22 @@ namespace aspect
                                                           gravity * (solid_density - fluid_density);
                     max_local_velocity = std::max(max_local_velocity, fluid_velocity.norm());
                   }
+
+                if (consider_function_timestep)
+                  {
+                    Tensor<1,dim> function_velocity;
+                    const Point<dim> position = fe_values.quadrature_point(q);
+                    const Functions::ParsedFunction<dim> &compositional_field_advection_function = this->get_parameters().compositional_field_advection_function;
+                    for (unsigned int d=0; d<dim; ++d)
+                      {
+                        function_velocity[d] = compositional_field_advection_function.value(position,d);
+
+                        if (this->get_parameters().convert_to_years)
+                          function_velocity[d] /= year_in_seconds;
+                      }
+                    max_local_velocity = std::max(max_local_velocity, function_velocity.norm());
+                  }
+
                 max_local_velocity = std::max (max_local_velocity,
                                                velocity_values[q].norm());
               }


### PR DESCRIPTION
Create a new advection method which advects a compositional field with a user defined function. At the moment, only a single function can be applied to all compositional fields that are flagged with the new advection method. The idea is for this to be extended to the particle velocity features that @Arijitchkc is working on.

<img width="1986" height="1210" alt="anim" src="https://github.com/user-attachments/assets/22356bc1-0e3d-48f1-a3a8-9912beb5f47a" />
