### PR TITLE
Check if the adiabatic conditions are initialized

### DIFF
--- a/source/initial_composition/adiabatic_density.cc
+++ b/source/initial_composition/adiabatic_density.cc
@@ -32,7 +32,8 @@ namespace aspect
     AdiabaticDensity<dim>::
     initial_composition (const Point<dim> &position, const unsigned int n_comp) const
     {
-      if (n_comp == this->introspection().find_composition_type(CompositionalFieldDescription::density))
+      if (n_comp == this->introspection().find_composition_type(CompositionalFieldDescription::density) &&
+          this->get_adiabatic_conditions().is_initialized())
         return this->get_adiabatic_conditions().density(position);
 
       return 0.0;


### PR DESCRIPTION
The tests were failing on @anweiii PR#7132 because the branch uses initial composition based on the adiabatic density model, which threw a nan value before the adiabatic_conditions were initialized. This PR adds the if condition to fix it.