### PR TITLE
Add scratch memory function

### DIFF
--- a/include/aspect/utilities.h
+++ b/include/aspect/utilities.h
@@ -25,6 +25,8 @@
 #include <aspect/global.h>
 
 #include <array>
+#include <deal.II/base/exceptions.h>
+#include <deal.II/base/thread_local_storage.h>
 #include <random>
 #include <deal.II/base/point.h>
 #include <deal.II/base/conditional_ostream.h>
@@ -72,6 +74,68 @@ namespace aspect
     */
     using namespace dealii::Utilities;
 
+
+    /**
+     * A class that allows for creating reusable chunks of memory.
+     * When this class's get_object_from_pool() function is called, it returns a reference to a currently unused object,
+     * or creates a new one if non are available. When done with an object it can be returned to the pool for later use.
+     * This is particularly useful when needing the same size memory in a function which is called in a loop. Since the
+     * objects are not reset, using this scratch space can prevent reallocating memory over and over. This class works
+     * in recursive functions.
+     * The class is recommended to be used with the ScopedScratchObject, which will automatically return the
+     * object to the pool when the ScopedScratchObject goes out of scope.
+     */
+    template <typename T>
+    class ScratchSpace
+    {
+      public:
+        /**
+         * This class takes an object from a ScratchSpace pool and will return it to the pool when the ScopedScratchObject
+         * goes out of scope.
+         */
+        class ScopedScratchObject
+        {
+          public:
+            /**
+             * Constructor
+             */
+            ScopedScratchObject (ScratchSpace<T> &/*space_*/);
+
+            /**
+             * Destructor: return the object to the pool
+             */
+            ~ScopedScratchObject();
+
+            /**
+             * Get a reference to the object.
+             */
+            operator T &();
+
+          private:
+            ScratchSpace &space;
+            T &t;
+        };
+
+        /**
+         * returns an object from the pool. If there are no unused objects, it creates a new object and returns it.
+         */
+        T &get_object_from_pool();
+
+        /**
+         * Destructor
+         */
+        ~ScratchSpace();
+
+        /**
+         * returns an object to the pool to be reused later.
+         */
+        void return_object_to_pool (T &t);
+
+      private:
+        dealii::Threads::ThreadLocalStorage<std::list<std::pair<T,bool>>>  object_list;
+    };
+
+    //template<typename T> thread_local std::list<std::pair<T,bool>> ScratchSpace<T>::object_list = {};
 
     /**
      * Given an array @p values, consider three cases:
@@ -1196,6 +1260,57 @@ namespace aspect
 #ifndef DOXYGEN
   namespace Utilities
   {
+    template<typename T>
+    T &ScratchSpace<T>::get_object_from_pool()
+    {
+      for (auto &pair : object_list.get())
+        if (pair.second == false)
+          {
+            pair.second = true;
+            return pair.first;
+          }
+
+      object_list.get().emplace_back (T(), true);
+      return object_list.get().back().first;
+    }
+
+    template<typename T>
+    void ScratchSpace<T>::return_object_to_pool (T &t)
+    {
+      for (auto &pair : object_list.get())
+        if (&pair.first == &t)
+          {
+            pair.second = false;
+            return;
+          }
+      AssertThrow(false, ExcMessage("You are tying to return an object to the pool which has apparently not been allocated by this pool."));
+    }
+
+    template<typename T>
+    ScratchSpace<T>::~ScratchSpace ()
+    {
+
+      for (auto &pair : object_list.get())
+        pair.first.clear();
+    }
+
+    template<typename T>
+    ScratchSpace<T>::ScopedScratchObject::ScopedScratchObject(ScratchSpace<T> &space_)
+      : space (space_),
+        t (space.get_object_from_pool())
+    {}
+
+    template<typename T>
+    ScratchSpace<T>::ScopedScratchObject::~ScopedScratchObject()
+    {
+      space.return_object_to_pool(t);
+    }
+
+    template<typename T>
+    ScratchSpace<T>::ScopedScratchObject::operator T &()
+    {
+      return t;
+    }
 
     template <typename T>
     inline

--- a/unit_tests/utilities.cc
+++ b/unit_tests/utilities.cc
@@ -18,8 +18,39 @@
   <http://www.gnu.org/licenses/>.
 */
 
+#include "catch.hpp"
 #include "common.h"
 #include <aspect/utilities.h>
+
+TEST_CASE("Utilities::ScratchSpace")
+{
+  aspect::Utilities::ScratchSpace<std::vector<double>> space1;
+  typename aspect::Utilities::ScratchSpace<std::vector<double>>::ScopedScratchObject scoped_object1(space1);
+  std::vector<double> &object1 = scoped_object1;
+  object1.resize(3);
+  object1[0] = 10;
+  object1[1] = 20;
+  object1[2] = 30;
+  {
+    typename aspect::Utilities::ScratchSpace<std::vector<double>>::ScopedScratchObject scoped_object2(space1);
+    std::vector<double> &object2 = scoped_object2;
+    object2.resize(4);
+    object2[0] = 11;
+    object2[1] = 21;
+    object2[2] = 31;
+    object2[3] = 41;
+  }
+  {
+    typename aspect::Utilities::ScratchSpace<std::vector<double>>::ScopedScratchObject scoped_object2(space1);
+    std::vector<double> &object2 = scoped_object2;
+    REQUIRE(object2.size() == 4);
+    CHECK(object2[0] == 11);
+    CHECK(object2[1] == 21);
+    CHECK(object2[2] == 31);
+    CHECK(object2[3] == 41);
+  }
+
+}
 
 TEST_CASE("Utilities::weighted_p_norm_average")
 {


### PR DESCRIPTION
This add a scratch space for creating reusable chunks of memory. This class can be useful to prevent a lot of reallocations inside functions which are called a lot an require the same size vector.

This is tangentially related to #7115. It is not yet used in practice, but that would come in follow up pull requests.

This class was originally designed by @bangerth for use in the world builder (see https://github.com/GeodynamicWorldBuilder/WorldBuilder/pull/943)