### PR TITLE
Avoid the need to explicitly specify a template argument.

### DIFF
--- a/include/aspect/utilities.h
+++ b/include/aspect/utilities.h
@@ -1066,7 +1066,7 @@ namespace aspect
                      const Quadrature<dim>                                     &quadrature,
                      const std::function<void(
                        const typename DoFHandler<dim>::active_cell_iterator &,
-                       const std::vector<Point<dim>> &,
+                       const typename std_cxx20::type_identity<std::vector<Point<dim>>>::type &,
                        std::vector<double> &)>                                 &function,
                      VectorType                                                &vec_result);
 

--- a/source/simulator/initial_conditions.cc
+++ b/source/simulator/initial_conditions.cc
@@ -546,13 +546,13 @@ namespace aspect
         system_tmp.reinit (system_rhs);
 
         const Quadrature<dim> &quadrature = introspection.quadratures.velocities;
-        Utilities::project_cellwise<dim,LinearAlgebra::BlockVector>(*mapping,
-                                                                    dof_handler,
-                                                                    introspection.component_indices.pressure,
-                                                                    quadrature,
-                                                                    [&](const typename DoFHandler<dim>::active_cell_iterator & /*cell*/,
-                                                                        const std::vector<Point<dim>> &q_points,
-                                                                        std::vector<double> &values) -> void
+        Utilities::project_cellwise(*mapping,
+                                    dof_handler,
+                                    introspection.component_indices.pressure,
+                                    quadrature,
+                                    [&](const typename DoFHandler<dim>::active_cell_iterator & /*cell*/,
+                                        const std::vector<Point<dim>> &q_points,
+                                        std::vector<double> &values) -> void
         {
           for (unsigned int i=0; i<values.size(); ++i)
             values[i] = adiabatic_conditions->pressure(q_points[i]);

--- a/source/simulator/solver/matrix_free_operators.cc
+++ b/source/simulator/solver/matrix_free_operators.cc
@@ -201,13 +201,13 @@ namespace aspect
         // a vector defined by the projection DoFHandler. As an input, we must define a lambda which returns
         // a viscosity value for each quadrature point of the given cell. The projection is then stored in
         // the active level viscosity vector provided.
-        Utilities::project_cellwise<dim, dealii::LinearAlgebra::distributed::Vector<double>>(mapping,
-            dof_handler_projection,
-            0,
-            quadrature_formula,
-            [&](const typename DoFHandler<dim>::active_cell_iterator & cell,
-                const std::vector<Point<dim>> & /*q_points*/,
-                std::vector<double> &values) -> void
+        Utilities::project_cellwise(mapping,
+                                    dof_handler_projection,
+                                    0,
+                                    quadrature_formula,
+                                    [&](const typename DoFHandler<dim>::active_cell_iterator & cell,
+                                        const std::vector<Point<dim>> & /*q_points*/,
+                                        std::vector<double> &values) -> void
         {
           const typename DoFHandler<dim>::active_cell_iterator FEQ_cell(&dof_handler.get_triangulation(),
           cell->level(),

--- a/source/utilities.cc
+++ b/source/utilities.cc
@@ -2705,7 +2705,7 @@ namespace aspect
                      const Quadrature<dim>                                     &quadrature,
                      const std::function<void(
                        const typename DoFHandler<dim>::active_cell_iterator &,
-                       const std::vector<Point<dim>> &,
+                       const typename std_cxx20::type_identity<std::vector<Point<dim>>>::type &,
                        std::vector<double> &)>                                 &function,
                      VectorType                                                &vec_result)
     {
@@ -3459,7 +3459,7 @@ namespace aspect
                    const Quadrature<dim> &quadrature, \
                    const std::function<void( \
                                              const DoFHandler<dim>::active_cell_iterator &, \
-                                             const std::vector<Point<dim>> &, \
+                                             const std_cxx20::type_identity<std::vector<Point<dim>>>::type &, \
                                              std::vector<double> &)> &function, \
                    dealii::LinearAlgebra::distributed::Vector<double> &vec_result); \
   \


### PR DESCRIPTION
Follow-up to #7135: We can omit the template arguments to `project_cellwise()` if we make sure that the template arguments can be deduced from the arguments. That means not allowing the compiler to deduce the template argument from the `std::function` function argument because we typically provide a lambda function for that.

@tjhei FYI.

*Describe what you did in this PR and why you did it.*

### Before your first pull request:

* [x] I have read the guidelines in our [CONTRIBUTING.md](../blob/main/CONTRIBUTING.md) document.

### For all pull requests:

* [x] I have followed the [instructions for indenting my code](../blob/main/CONTRIBUTING.md#making-aspect-better).
* I followed the [AI Policy](../blob/main/CONTRIBUTING.md#policy-on-usage-of-ai):
  - [ ] Significant parts of this PR were written by AI (please add a sentence below).
  - [x] AI has not been used in significant ways.

*If yes, please describe your usage of AI models in the creation of this pull request*

### For new features/models or changes of existing features:

* [x] I have tested my new feature locally to ensure it is correct.
* [ ] I have [created a testcase](https://aspect-documentation.readthedocs.io/en/latest/user/extending/testing/writing-tests.html) for the new feature/benchmark in the [tests/](../blob/main/tests/) directory.
* [ ] I have added a changelog entry in the [doc/modules/changes](../blob/main/doc/modules/changes) directory that will inform other users of my change.
