### PR TITLE
remove pi definitions from ParsedFunctions

### DIFF
--- a/benchmarks/advection/drop_supg.prm
+++ b/benchmarks/advection/drop_supg.prm
@@ -38,7 +38,6 @@ subsection Initial temperature model
 
   subsection Function
     set Variable names      = x,y
-    set Function constants  =
     set Function expression = if ((abs(x)<0.2)&(abs(y-0.5)<0.2),1,0)
   end
 end
@@ -48,7 +47,6 @@ subsection Initial composition model
 
   subsection Function
     set Variable names      = x,y
-    set Function constants  =
     set Function expression = if ((abs(x)<0.2)&(abs(y-0.5)<0.2),1,0)
   end
 end

--- a/benchmarks/advection/rotate_shape_supg.prm
+++ b/benchmarks/advection/rotate_shape_supg.prm
@@ -34,7 +34,6 @@ subsection Initial temperature model
 
   subsection Function
     set Variable names      = x,y
-    set Function constants  =
     set Function expression =  if((sqrt((x-0)^2+(y-0.5)^2)<0.3)&(abs(x)>=0.05|y>=0.7),1,if(sqrt((x-0)^2+(y+0.5)^2)<0.3,1-sqrt((x-0)^2+(y+0.5)^2)/0.3,if(sqrt((x+0.5)^2+(y+0)^2)<0.3,1.0/4.0*(1+cos(pi*min(sqrt((x+0.5)^2+(y+0)^2)/0.3,1))),0)))
   end
 end
@@ -44,7 +43,6 @@ subsection Initial composition model
 
   subsection Function
     set Variable names      = x,y
-    set Function constants  =
     set Function expression =  if((sqrt((x-0)^2+(y-0.5)^2)<0.3)&(abs(x)>=0.05|y>=0.7),1,if(sqrt((x-0)^2+(y+0.5)^2)<0.3,1-sqrt((x-0)^2+(y+0.5)^2)/0.3,if(sqrt((x+0.5)^2+(y+0)^2)<0.3,1.0/4.0*(1+cos(pi*min(sqrt((x+0.5)^2+(y+0)^2)/0.3,1))),0)))
   end
 end

--- a/benchmarks/blankenbach/base_case1a.prm
+++ b/benchmarks/blankenbach/base_case1a.prm
@@ -9,7 +9,6 @@ subsection Adiabatic conditions model
   set Model name = function
 
   subsection Function
-    set Function constants  =
     set Function expression = 0; 0; 1
     set Variable names      = depth
   end
@@ -48,7 +47,7 @@ subsection Initial temperature model
   set Model name = ascii data
 
   subsection Function
-    set Function constants  = z1=0.102367, z2=0.897633, pi=3.14159265359
+    set Function constants  = z1=0.102367, z2=0.897633
     set Function expression = if(z<z1,0.5+0.5*(z1-z)/z1,if(z>z2,0.5*(1-z)/(1-z2),0.5)) + 0.1 * cos(x*pi) * sin(z*pi)
     set Variable names      = x,z
   end

--- a/benchmarks/blankenbach/base_case2a.prm
+++ b/benchmarks/blankenbach/base_case2a.prm
@@ -9,7 +9,6 @@ subsection Adiabatic conditions model
   set Model name = function
 
   subsection Function
-    set Function constants  =
     set Function expression = 0; 0; 1
     set Variable names      = depth
   end
@@ -48,7 +47,7 @@ subsection Initial temperature model
   set Model name = ascii data
 
   subsection Function
-    set Function constants  = z1=0.102367, z2=0.897633, pi=3.14159265359
+    set Function constants  = z1=0.102367, z2=0.897633
     set Function expression = if(z<z1,0.5+0.5*(z1-z)/z1,if(z>z2,0.5*(1-z)/(1-z2),0.5)) + 0.1 * cos(x*pi) * sin(z*pi)
     set Variable names      = x,z
   end

--- a/benchmarks/blankenbach/base_case2b.prm
+++ b/benchmarks/blankenbach/base_case2b.prm
@@ -9,7 +9,6 @@ subsection Adiabatic conditions model
   set Model name = function
 
   subsection Function
-    set Function constants  =
     set Function expression = 0; 0; 1
     set Variable names      = depth
   end
@@ -51,7 +50,7 @@ subsection Initial temperature model
 
   subsection Function
     set Variable names      = x,z
-    set Function constants  = p=0.01, L=1, pi=3.1415926536, k=1, ratio=2.5
+    set Function constants  = p=0.01, L=1, k=1, ratio=2.5
     set Function expression = 1* ((1.0-z/L) + p*cos(k*pi*x/L/ratio)*sin(pi*z/L))
   end
 

--- a/benchmarks/free_surface_tractions/viscoelastic/free_surface_VE_cylinder_2D_loading.prm
+++ b/benchmarks/free_surface_tractions/viscoelastic/free_surface_VE_cylinder_2D_loading.prm
@@ -109,7 +109,6 @@ subsection Initial composition model
 
   subsection Function
     set Variable names      = x,y
-    set Function constants  =
     set Function expression = 0; 0; 0; 0; 0; 0;
   end
 end

--- a/benchmarks/free_surface_tractions/viscoelastic/free_surface_VE_cylinder_3D_loading.prm
+++ b/benchmarks/free_surface_tractions/viscoelastic/free_surface_VE_cylinder_3D_loading.prm
@@ -111,7 +111,6 @@ subsection Initial composition model
 
   subsection Function
     set Variable names      = x,y,z
-    set Function constants  =
     set Function expression = 0; 0; 0; 0; 0; 0; 0; 0; 0; 0; 0; 0;
   end
 end

--- a/benchmarks/infill_density/infill_ascii.prm
+++ b/benchmarks/infill_density/infill_ascii.prm
@@ -149,7 +149,6 @@ subsection Initial composition model
 
   subsection Function
     set Variable names      = x,y
-    set Function constants  =
     set Function expression = 0; 0; 0; 0; 0; 0; if(y>=1125e3, 1, 0)
   end
 end

--- a/benchmarks/king2dcompressible/ala.prm
+++ b/benchmarks/king2dcompressible/ala.prm
@@ -102,7 +102,7 @@ subsection Initial temperature model
 
   subsection Function
     set Variable names      = x,z
-    set Function constants  = p=0.01, L=1, pi=3.1415926536, k=1
+    set Function constants  = p=0.01, L=1, k=1
     set Function expression =  1* ((1.0-z/L) + p*cos(k*pi*x/L/1.0)*sin(pi*z/L)) +0.091
   end
 end

--- a/benchmarks/newton_solver_benchmark_set/tosi_et_al_2015/input.prm
+++ b/benchmarks/newton_solver_benchmark_set/tosi_et_al_2015/input.prm
@@ -61,7 +61,7 @@ subsection Initial temperature model
 
   subsection Function
     set Variable names      = x,z
-    set Function constants  = A=0.01, pi=3.1415926536
+    set Function constants  = A=0.01
     set Function expression = (1.0-z) + A*cos(pi*x)*sin(pi*z)
   end
 end

--- a/benchmarks/onset-of-convection/convection-box-base.prm
+++ b/benchmarks/onset-of-convection/convection-box-base.prm
@@ -37,7 +37,7 @@ subsection Initial temperature model
 
   subsection Function
     set Variable names      = x,z
-    set Function constants  = p=PMAG, L=WIDTH,H=HEIGHT, pi=3.1415926536, k=2
+    set Function constants  = p=PMAG, L=WIDTH,H=HEIGHT, k=2
     set Function expression = DELTA_T*(1.0-z/H) - p*cos(k*pi*x/L)*sin(pi*z/H)
   end
 end

--- a/benchmarks/operator_splitting/advection_reaction/advection_reaction.base.prm
+++ b/benchmarks/operator_splitting/advection_reaction/advection_reaction.base.prm
@@ -62,7 +62,6 @@ subsection Boundary velocity model
 
   subsection Function
     set Variable names      = x,z,t
-    set Function constants  =
     set Function expression = 0.01;0.0
   end
 end
@@ -83,7 +82,6 @@ subsection Initial temperature model
 
   subsection Function
     set Variable names      = x,z
-    set Function constants  = pi=3.1415926
     set Function expression = sin(2*pi*x)
   end
 end
@@ -93,7 +91,6 @@ subsection Initial composition model
 
   subsection Function
     set Variable names      = x,z
-    set Function constants  = pi=3.1415926
     set Function expression = sin(2*pi*x)
   end
 end

--- a/benchmarks/particle_distribution/addition_algorithm_benchmarks.prm
+++ b/benchmarks/particle_distribution/addition_algorithm_benchmarks.prm
@@ -26,7 +26,6 @@ subsection Initial temperature model
 
   subsection Function
     set Variable names      = x,y
-    set Function constants  =
     set Function expression = 1
   end
 end

--- a/benchmarks/particle_distribution/removal_algorithm_benchmarks.prm
+++ b/benchmarks/particle_distribution/removal_algorithm_benchmarks.prm
@@ -26,7 +26,6 @@ subsection Initial temperature model
 
   subsection Function
     set Variable names      = x,y
-    set Function constants  =
     set Function expression = 1
   end
 end

--- a/benchmarks/solcx/compositional_fields/solcx_compositional_fields.prm
+++ b/benchmarks/solcx/compositional_fields/solcx_compositional_fields.prm
@@ -56,7 +56,7 @@ subsection Initial composition model
 
   subsection Function
     set Variable names      = x, z
-    set Function constants  = pi=3.1415926536, eta_b=1e6, background_density=0.0
+    set Function constants  =  eta_b=1e6, background_density=0.0
     set Function expression = background_density - sin(pi*z) * cos(pi*x); if(x<=0.5, 1, eta_b)
   end
 end

--- a/benchmarks/solcx/compositional_fields/solcx_particles.prm
+++ b/benchmarks/solcx/compositional_fields/solcx_particles.prm
@@ -84,7 +84,7 @@ subsection Initial composition model
 
   subsection Function
     set Variable names      = x,y
-    set Function constants  = pi=3.1415926, eta_b=1e6, background_density=0.0
+    set Function constants  =  eta_b=1e6, background_density=0.0
     set Function expression = background_density - sin(pi*y) * cos(pi*x); if(x<0.5, 1, eta_b)
   end
 end
@@ -121,7 +121,7 @@ subsection Particles
   subsection Function
     set Number of components = 2
     set Variable names      = x, y
-    set Function constants  = pi=3.1415926, eta_b=1e6, background_density=0.0
+    set Function constants  =  eta_b=1e6, background_density=0.0
     set Function expression =  background_density - sin(pi*y) * cos(pi*x); if(x<0.5, 1, eta_b)
   end
 

--- a/benchmarks/solkz/compositional_fields/solkz_compositional_fields.prm
+++ b/benchmarks/solkz/compositional_fields/solkz_compositional_fields.prm
@@ -74,7 +74,6 @@ subsection Initial composition model
 
   subsection Function
     set Variable names      = x,z
-    set Function constants  = pi = 3.1415926536
     set Function expression = -1 * sin(2*z) * cos(3*pi*x); exp(log(1e6)*z)
   end
 end

--- a/benchmarks/solkz/compositional_fields/solkz_particles.prm
+++ b/benchmarks/solkz/compositional_fields/solkz_particles.prm
@@ -71,7 +71,7 @@ subsection Initial composition model
 
   subsection Function
     set Variable names      = x,z
-    set Function constants  = pi=3.1415926, eta_b=1e6
+    set Function constants  =  eta_b=1e6
     set Function expression = -1 * sin(2*z) * cos(3*pi*x); exp(log(eta_b)*z)
   end
 end
@@ -108,7 +108,7 @@ subsection Particles
   subsection Function
     set Number of components = 2
     set Variable names      = x, z
-    set Function constants  = pi=3.1415926, eta_b=1e6
+    set Function constants  =  eta_b=1e6
     set Function expression =  -1 * sin(2*z) * cos(3*pi*x); exp(log(eta_b)*z)
   end
 

--- a/benchmarks/time_dependent_annulus/time_dependent_annulus.prm
+++ b/benchmarks/time_dependent_annulus/time_dependent_annulus.prm
@@ -34,7 +34,6 @@ subsection Boundary velocity model
   set Prescribed velocity boundary indicators = 0: function, 1: function
 
   subsection Function
-    set Function constants  = pi=3.1415926
     set Variable names      = x,y
     set Function expression = y*sqrt(x^2 + y^2)^6;-x*sqrt(x^2 + y^2)^6
   end
@@ -108,7 +107,6 @@ subsection Adiabatic conditions model
   set Model name = function
 
   subsection Function
-    set Function constants  =
     set Function expression = 0; 0; 0
     set Variable names      = depth
   end

--- a/benchmarks/tosi_et_al_2015_gcubed/Tosi_base.prm
+++ b/benchmarks/tosi_et_al_2015_gcubed/Tosi_base.prm
@@ -53,7 +53,7 @@ subsection Initial temperature model
 
   subsection Function
     set Variable names      = x,z
-    set Function constants  = A=0.01, pi=3.1415926536
+    set Function constants  = A=0.01
     set Function expression = (1.0-z) + A*cos(pi*x)*sin(pi*z)
   end
 end

--- a/benchmarks/viscoelastic_beam_modified/20km_opentopbot.prm
+++ b/benchmarks/viscoelastic_beam_modified/20km_opentopbot.prm
@@ -66,7 +66,6 @@ subsection Initial composition model
 
   subsection Function
     set Variable names      = x,y
-    set Function constants  =
     set Function expression = 0; 0; 0; 0; 0; 0; if ( 180e3>=x && y>=100e3 && y<=120e3, 1, 0)
   end
 end

--- a/benchmarks/viscoelastic_bending_beam/viscoelastic_bending_beam.prm
+++ b/benchmarks/viscoelastic_bending_beam/viscoelastic_bending_beam.prm
@@ -118,7 +118,6 @@ subsection Initial composition model
 
   subsection Function
     set Variable names      = x,y
-    set Function constants  =
     set Function expression = 0; 0; 0; 0; 0; 0; if (x<=4.5e3 && y>=2.5e3 && y<=3.0e3, 1, 0)
   end
 end

--- a/benchmarks/viscoelastic_plastic_shear_bands/gerya_2019/gerya_2019_vep.prm
+++ b/benchmarks/viscoelastic_plastic_shear_bands/gerya_2019/gerya_2019_vep.prm
@@ -48,7 +48,6 @@ subsection Initial composition model
 
   subsection Function
     set Variable names      = x,y
-    set Function constants  =
     set Function expression = 0; 0; 0; 0; 0; 0; \
                               if ( ( x<43.75e3 && y>25.e3 && y<75.e3) || (x>56.25e3 && y>25.e3 && y<75.e3) || (y>56.25e3 && y<75.e3 && x>=43.75e3 && x<=56.25e3) || (y<43.75e3 && y>25.e3 && x>=43.75e3 && x<=56.25e3), 1, 0); \
                               if (y<=25.e3 || y>=75.e3, 1, 0); \

--- a/benchmarks/viscoelastic_plastic_shear_bands/gerya_2019/gerya_2019_vp.prm
+++ b/benchmarks/viscoelastic_plastic_shear_bands/gerya_2019/gerya_2019_vp.prm
@@ -111,7 +111,6 @@ subsection Initial composition model
 
   subsection Function
     set Variable names      = x,y
-    set Function constants  =
     set Function expression = if ( ( x<43.75e3 && y>25.e3 && y<75.e3) || (x>56.25e3 && y>25.e3 && y<75.e3) || (y>56.25e3 && y<75.e3 && x>=43.75e3 && x<=56.25e3) || (y<43.75e3 && y>25.e3 && x>=43.75e3 && x<=56.25e3), 1, 0); \
                               if (y<=25.e3 || y>=75.e3, 1, 0); \
                               if (y<=56.25e3 && y>=43.75e3 && x>=43.75e3 && x<=56.25e3, 1, 0);

--- a/benchmarks/viscoelastic_plastic_shear_bands/kaus_2010/kaus_2010_extension.prm
+++ b/benchmarks/viscoelastic_plastic_shear_bands/kaus_2010/kaus_2010_extension.prm
@@ -140,7 +140,6 @@ subsection Initial composition model
 
   subsection Function
     set Variable names      = x,y
-    set Function constants  =
     set Function expression = 0; 0; 0; 0; 0; 0; 0; \
                               if (y<=0.4e3 && x>=19.6e3 && x<=20.4e3, 1, 0);
   end

--- a/benchmarks/viscoelastic_plate_flexure/viscoelastic_plate_flexure.prm
+++ b/benchmarks/viscoelastic_plate_flexure/viscoelastic_plate_flexure.prm
@@ -114,7 +114,6 @@ subsection Initial composition model
 
   subsection Function
     set Variable names      = x,y
-    set Function constants  =
     set Function expression = 0; 0; 0; 0; 0; 0; \
                               if (y>12.5e3, 1, 0); \
                               if (x>=45e3 && y>=7.5e3 && y<=12.5e3, 1, 0);

--- a/benchmarks/viscoelastic_relaxation/viscoelastic_relaxation.prm
+++ b/benchmarks/viscoelastic_relaxation/viscoelastic_relaxation.prm
@@ -76,7 +76,6 @@ subsection Initial composition model
   set Model name = function
   subsection Function
     set Variable names      = x,y
-    set Function constants  =
     set Function expression = 20e6; -20e6; 0; 20e6; -20e6; 0
   end
 end

--- a/benchmarks/viscoelastic_relaxation/viscoelastic_relaxation_particles.prm
+++ b/benchmarks/viscoelastic_relaxation/viscoelastic_relaxation_particles.prm
@@ -77,7 +77,6 @@ subsection Initial composition model
   set Model name = function
   subsection Function
     set Variable names      = x,y
-    set Function constants  =
     set Function expression = 20e6; -20e6; 0; 20e6; -20e6; 0
   end
 end

--- a/benchmarks/viscoelastic_stress_build_up/viscoelastic_stress_build_up.prm
+++ b/benchmarks/viscoelastic_stress_build_up/viscoelastic_stress_build_up.prm
@@ -125,7 +125,6 @@ subsection Initial composition model
 
   subsection Function
     set Variable names      = x,y
-    set Function constants  =
     set Function expression = 0; 0; 0; 0; 0; 0;
   end
 end

--- a/benchmarks/zhong_et_al_93/zhong_case1.prm
+++ b/benchmarks/zhong_et_al_93/zhong_case1.prm
@@ -21,7 +21,7 @@ subsection Initial temperature model
 
   subsection Function
     set Variable names      = x1,x2
-    set Function constants  = lambda=1, pi=3.1415926536, L=1, depth=62, sigma = 0.5, N=64
+    set Function constants  = lambda=1, L=1, depth=62, sigma = 0.5, N=64
     set Function expression = 1/(sigma/N*L * sqrt( 2 * pi) ) * exp( -0.5*(x2-depth/N)*(x2-depth/N)/sigma/sigma/L/L*N*N ) * cos(2*pi/lambda*x1/L)
   end
 end

--- a/cookbooks/anisotropic_viscosity/AV_Rayleigh_Taylor.prm
+++ b/cookbooks/anisotropic_viscosity/AV_Rayleigh_Taylor.prm
@@ -62,7 +62,6 @@ subsection Initial composition model
 
   subsection Function
     set Variable names      = x,z
-    set Function constants  = pi=3.1415926
     set Function expression = 0.5*(1+tanh((z-0.85-0.02*cos(2*pi*x/2))/0.02)); \
                             (0.5*(1+tanh((z-0.85-0.02*cos(2*pi*x/2))/0.02))) > 0.8 ? sin(45*pi/180) : 0.0; \
                             (0.5*(1+tanh((z-0.85-0.02*cos(2*pi*x/2))/0.02))) > 0.8 ? cos(45*pi/180) : 0.0;

--- a/cookbooks/bunge_et_al_mantle_convection/bunge_et_al.prm
+++ b/cookbooks/bunge_et_al_mantle_convection/bunge_et_al.prm
@@ -65,7 +65,7 @@ subsection Initial temperature model
   subsection Function
     set Coordinate system = spherical
     set Variable names      = r,phi
-    set Function constants  = A=100, B=75, C=50, D=25, pi=3.1415926536, Ri=3480e3, Ro=6370e3, Ti=3450, To=1060
+    set Function constants  = A=100, B=75, C=50, D=25, Ri=3480e3, Ro=6370e3, Ti=3450, To=1060
     set Function expression = (r-Ri)/(Ro-Ri)*(To-Ti)+Ti + A*sin(7*phi) + B*sin(13*phi) + C*cos(0.123*phi+pi/3) + D*cos(0.456*phi+pi/6)
   end
 end

--- a/cookbooks/christensen_yuen_phase_function/christensen_yuen_phase_function.prm
+++ b/cookbooks/christensen_yuen_phase_function/christensen_yuen_phase_function.prm
@@ -63,7 +63,7 @@ subsection Initial temperature model
   set Model name = function
 
   subsection Function
-    set Function constants = delta=0.1, A=10, h=1350000, pi=3.1416
+    set Function constants = delta=0.1, A=10, h=1350000
     set Variable names = x,z
     set Function expression = 500 + 500*(erfc(z/(h*delta)) - erfc((1-z/h)/delta)) + A*cos(pi*x/h)*sin(pi*z/h) + A*cos(2*pi*x/h)*sin(pi*z/h) + A*cos(pi*x/h)*sin(2*pi*z/h) + A*cos(2*pi*x/h)*sin(2*pi*z/h)
   end

--- a/cookbooks/composition-reaction/composition-reaction.prm
+++ b/cookbooks/composition-reaction/composition-reaction.prm
@@ -51,7 +51,6 @@ subsection Boundary velocity model
 
   subsection Function
     set Variable names      = x,z,t
-    set Function constants  = pi=3.1415926
     set Function expression = if(x>1+sin(0.5*pi*t), 1, -1); 0
   end
 end

--- a/cookbooks/composition_active/composition_active.prm
+++ b/cookbooks/composition_active/composition_active.prm
@@ -37,7 +37,6 @@ subsection Boundary velocity model
 
   subsection Function
     set Variable names      = x,z,t
-    set Function constants  = pi=3.1415926
     set Function expression = if(x>1+sin(0.5*pi*t), 1, -1); 0
   end
 end

--- a/cookbooks/composition_active_particles/composition_active_particles.prm
+++ b/cookbooks/composition_active_particles/composition_active_particles.prm
@@ -38,7 +38,6 @@ subsection Boundary velocity model
 
   subsection Function
     set Variable names      = x,z,t
-    set Function constants  = pi=3.1415926
     set Function expression = if(x>1+sin(0.5*pi*t), 1, -1); 0
   end
 end

--- a/cookbooks/composition_passive/composition_passive.prm
+++ b/cookbooks/composition_passive/composition_passive.prm
@@ -37,7 +37,6 @@ subsection Boundary velocity model
 
   subsection Function
     set Variable names      = x,z,t
-    set Function constants  = pi=3.1415926
     set Function expression = if(x>1+sin(0.5*pi*t), 1, -1); 0
   end
 end

--- a/cookbooks/composition_passive_particles/composition_passive_particles.prm
+++ b/cookbooks/composition_passive_particles/composition_passive_particles.prm
@@ -39,7 +39,6 @@ subsection Boundary velocity model
 
   subsection Function
     set Variable names      = x,z,t
-    set Function constants  = pi=3.1415926
     set Function expression = if(x>1+sin(0.5*pi*t), 1, -1); 0
   end
 end

--- a/cookbooks/composition_passive_particles/composition_passive_particles_properties.prm
+++ b/cookbooks/composition_passive_particles/composition_passive_particles_properties.prm
@@ -39,7 +39,6 @@ subsection Boundary velocity model
 
   subsection Function
     set Variable names      = x,z,t
-    set Function constants  = pi=3.1415926
     set Function expression = if(x>1+sin(0.5*pi*t), 1, -1); 0
   end
 end

--- a/cookbooks/convection-box-particles/convection-box-particles.prm
+++ b/cookbooks/convection-box-particles/convection-box-particles.prm
@@ -61,7 +61,7 @@ subsection Initial temperature model
 
   subsection Function
     set Variable names      = x,y
-    set Function constants  = p=-0.01, L=4.2e6, D=3e6, pi=3.1415926536, k=1, T_top=273, T_bottom=3600
+    set Function constants  = p=-0.01, L=4.2e6, D=3e6, k=1, T_top=273, T_bottom=3600
     set Function expression = T_top + (T_bottom-T_top)*(1-(y/D) - p*cos(k*pi*x/L)*sin(pi*y/D))
   end
 end

--- a/cookbooks/convection-box/convection-box.prm
+++ b/cookbooks/convection-box/convection-box.prm
@@ -58,7 +58,7 @@ subsection Initial temperature model
 
   subsection Function
     set Variable names      = x,z
-    set Function constants  = p=0.01, L=1, pi=3.1415926536, k=1
+    set Function constants  = p=0.01, L=1, k=1
     set Function expression = (1.0-z) - p*cos(k*pi*x/L)*sin(pi*z)
   end
 end

--- a/cookbooks/convection-box/tutorial-onset-of-convection/model_input/convection-box.prm
+++ b/cookbooks/convection-box/tutorial-onset-of-convection/model_input/convection-box.prm
@@ -58,7 +58,7 @@ subsection Initial temperature model
 
   subsection Function
     set Variable names      = x,z
-    set Function constants  = p=0.01, L=1, pi=3.1415926536, k=1
+    set Function constants  = p=0.01, L=1, k=1
     set Function expression = (1.0-z) - p*cos(k*pi*x/L)*sin(pi*z)
   end
 end

--- a/cookbooks/convection-box/tutorial-onset-of-convection/model_input/convection-box2.prm
+++ b/cookbooks/convection-box/tutorial-onset-of-convection/model_input/convection-box2.prm
@@ -58,7 +58,7 @@ subsection Initial temperature model
 
   subsection Function
     set Variable names      = x,z
-    set Function constants  = p=0.01, L=1, pi=3.1415926536, k=1
+    set Function constants  = p=0.01, L=1, k=1
     set Function expression = (1.0-z) - p*cos(k*pi*x/L)*sin(pi*z)
   end
 end

--- a/cookbooks/convection-box/tutorial-onset-of-convection/model_input/tutorial.prm
+++ b/cookbooks/convection-box/tutorial-onset-of-convection/model_input/tutorial.prm
@@ -70,7 +70,7 @@ subsection Initial temperature model
 
   subsection Function
     set Variable names      = x,y
-    set Function constants  = p=-0.01, L=4.2e6, D=3e6, pi=3.1415926536, k=1, T_top=273, T_bottom=3600
+    set Function constants  = p=-0.01, L=4.2e6, D=3e6, k=1, T_top=273, T_bottom=3600
     set Function expression = T_top + (T_bottom-T_top)*(1-(y/D) - p*cos(k*pi*x/L)*sin(pi*y/D))
   end
 end

--- a/cookbooks/convection_box_3d/convection_box_3d.prm
+++ b/cookbooks/convection_box_3d/convection_box_3d.prm
@@ -51,7 +51,7 @@ subsection Initial temperature model
 
   subsection Function
     set Variable names      = x,y,z
-    set Function constants  = p=0.01, L=1, pi=3.1415926536, k=1
+    set Function constants  = p=0.01, L=1, k=1
     set Function expression = (1.0-z) - p*cos(k*pi*x/L)*sin(pi*z)*y^3
   end
 end

--- a/cookbooks/convection_box_3d/doc/initial.part.prm
+++ b/cookbooks/convection_box_3d/doc/initial.part.prm
@@ -3,7 +3,7 @@ subsection Initial temperature model
 
   subsection Function
     set Variable names      = x,y,z
-    set Function constants  = p=0.01, L=1, pi=3.1415926536, k=1
+    set Function constants  = p=0.01, L=1, k=1
     set Function expression = (1.0-z) - p*cos(k*pi*x/L)*sin(pi*z)*y^3
   end
 end

--- a/cookbooks/kinematically_driven_subduction_2d/kinematically_driven_subduction_2d_case1.prm
+++ b/cookbooks/kinematically_driven_subduction_2d/kinematically_driven_subduction_2d_case1.prm
@@ -139,7 +139,6 @@ subsection Initial temperature model
   set List of model names = function
 
   subsection Function
-    set Function constants  =
     set Function expression = 0
     set Variable names      = x,y,t
   end

--- a/cookbooks/onset_of_convection/onset_of_convection.prm
+++ b/cookbooks/onset_of_convection/onset_of_convection.prm
@@ -36,7 +36,7 @@ subsection Initial temperature model
 
   subsection Function
     set Variable names      = x,z
-    set Function constants  = p=1, L=9.424777e6, H=3.0e6, pi=3.1415926536, k=2
+    set Function constants  = p=1, L=9.424777e6, H=3.0e6, k=2
     set Function expression = 2500 * (1.0-z/H) - p*cos(k*pi*x/L)*sin(pi*z/H)
   end
 end

--- a/cookbooks/platelike-boundary/doc/boundary.part.prm
+++ b/cookbooks/platelike-boundary/doc/boundary.part.prm
@@ -4,7 +4,6 @@ subsection Boundary velocity model
 
   subsection Function
     set Variable names      = x,z,t
-    set Function constants  = pi=3.1415926
     set Function expression = if(x>1+sin(0.5*pi*t), 1, -1); 0
   end
 end

--- a/cookbooks/platelike-boundary/doc/platelike.prm
+++ b/cookbooks/platelike-boundary/doc/platelike.prm
@@ -42,7 +42,6 @@ subsection Boundary velocity model
 
   subsection Function
     set Variable names      = x,z,t
-    set Function constants  = pi=3.1415926
     set Function expression = if(x>1+sin(0.5*pi*t), 1, -1); 0
   end
 end

--- a/cookbooks/platelike-boundary/platelike-boundary.prm
+++ b/cookbooks/platelike-boundary/platelike-boundary.prm
@@ -47,7 +47,6 @@ subsection Boundary velocity model
 
   subsection Function
     set Variable names      = x,z,t
-    set Function constants  = pi=3.1415926
     set Function expression = if(x>1+sin(0.5*pi*t), 1, -1); 0
   end
 end

--- a/cookbooks/plume_2D_chunk/plume2D.prm
+++ b/cookbooks/plume_2D_chunk/plume2D.prm
@@ -65,7 +65,6 @@ subsection Boundary temperature model
   subsection Function
     set Coordinate system = spherical
     set Variable names = r, phi
-    set Function constants = pi=3.1415926536
     set Function expression = if (r>4e6,273,if(phi>7*pi/16,3273,2773))
   end
 end

--- a/cookbooks/van-keken-vof/doc/main.part.prm
+++ b/cookbooks/van-keken-vof/doc/main.part.prm
@@ -13,7 +13,6 @@ subsection Initial composition model
 
   subsection Function
     set Variable names      = x,z
-    set Function constants  = pi=3.1415926
     set Function expression = 0.2+0.02*cos(pi*x/0.9142)-z
   end
 end

--- a/cookbooks/van-keken-vof/doc/variation.part.prm
+++ b/cookbooks/van-keken-vof/doc/variation.part.prm
@@ -4,7 +4,7 @@ subsection Initial composition model
 
   subsection Function
     set Variable names      = x,z
-    set Function constants  = pi=3.1415926, a=0.02
+    set Function constants  =  a=0.02
     set Function expression = 0.2+a*cos(pi*x/0.9142)-z
   end
 end

--- a/cookbooks/van-keken-vof/van-keken-vof.prm
+++ b/cookbooks/van-keken-vof/van-keken-vof.prm
@@ -71,7 +71,6 @@ subsection Initial composition model
 
   subsection Function
     set Variable names      = x,z
-    set Function constants  = pi=3.1415926
     set Function expression  =  0.2+0.02*cos(pi*x/0.9142)-z
   end
 end

--- a/cookbooks/van-keken/doc/main.part.prm
+++ b/cookbooks/van-keken/doc/main.part.prm
@@ -13,7 +13,6 @@ subsection Initial composition model
 
   subsection Function
     set Variable names      = x,z
-    set Function constants  = pi=3.14159
     set Function expression = if( (z>0.2+0.02*cos(pi*x/0.9142)) , 0 , 1 )
   end
 end

--- a/cookbooks/van-keken/doc/smooth.part.prm
+++ b/cookbooks/van-keken/doc/smooth.part.prm
@@ -3,7 +3,6 @@ subsection Initial composition model
 
   subsection Function
     set Variable names      = x,z
-    set Function constants  = pi=3.14159
     set Function expression = 0.5*(1+tanh((0.2+0.02*cos(pi*x/0.9142)-z)/0.02))
   end
 end

--- a/cookbooks/van-keken/van-keken-discontinuous.prm
+++ b/cookbooks/van-keken/van-keken-discontinuous.prm
@@ -65,7 +65,6 @@ subsection Initial composition model
 
   subsection Function
     set Variable names      = x,z
-    set Function constants  = pi=3.1415926
     set Function expression = if( (z>0.2+0.02*cos(pi*x/0.9142)) , 0 , 1 )
   end
 end

--- a/cookbooks/van-keken/van-keken-smooth.prm
+++ b/cookbooks/van-keken/van-keken-smooth.prm
@@ -66,7 +66,6 @@ subsection Initial composition model
 
   subsection Function
     set Variable names      = x,z
-    set Function constants  = pi=3.1415926
     set Function expression = 0.5*(1+tanh((0.2+0.02*cos(pi*x/0.9142)-z)/0.02))
   end
 end

--- a/tests/adiabatic_conditions_function.prm
+++ b/tests/adiabatic_conditions_function.prm
@@ -18,7 +18,6 @@ subsection Adiabatic conditions model
   set Model name = function
 
   subsection Function
-    set Function constants  =
     set Function expression = sin(depth); depth; 5.0+depth*depth
     set Variable names      = depth
   end

--- a/tests/advect_field_with_melt_velocity.prm
+++ b/tests/advect_field_with_melt_velocity.prm
@@ -55,7 +55,7 @@ subsection Boundary velocity model
   #  set Prescribed velocity boundary indicators = 2:function
   subsection Function
     set Variable names      = x,y
-    set Function constants  = pi=3.1415926,x0=100000,y0=50000,c=10000
+    set Function constants  = x0=100000,y0=50000,c=10000
     set Function expression = 0;0.01
   end
 end
@@ -92,7 +92,7 @@ subsection Initial temperature model
 
   subsection Function
     set Variable names      = x,y
-    set Function constants  = pi=3.1415926,x0=100000,y0=50000,c=10000
+    set Function constants  = x0=100000,y0=50000,c=10000
     set Function expression = 293
   end
 end
@@ -102,7 +102,7 @@ subsection Initial composition model
 
   subsection Function
     set Variable names      = x,y
-    set Function constants  = pi=3.1415926,x0=50000,y0=0.5,c=10000
+    set Function constants  = x0=50000,y0=0.5,c=10000
     set Function expression = 0.0872158; if(y>y0,1,0); if(y>y0,1,0)
   end
 end

--- a/tests/advection_reaction.prm
+++ b/tests/advection_reaction.prm
@@ -70,7 +70,6 @@ subsection Boundary velocity model
 
   subsection Function
     set Variable names      = x,z,t
-    set Function constants  =
     set Function expression = 0.01;0.0
   end
 end
@@ -95,7 +94,6 @@ subsection Initial temperature model
 
   subsection Function
     set Variable names      = x,z
-    set Function constants  = pi=3.1415926
     set Function expression = sin(2*pi*x)
   end
 end
@@ -105,7 +103,6 @@ subsection Initial composition model
 
   subsection Function
     set Variable names      = x,z
-    set Function constants  = pi=3.1415926
     set Function expression = sin(2*pi*x)
   end
 end

--- a/tests/always_refine.prm
+++ b/tests/always_refine.prm
@@ -32,7 +32,6 @@ subsection Boundary velocity model
 
   subsection Function
     set Variable names      = x,z,t
-    set Function constants  = pi=3.1415926
     set Function expression = if(x>1+sin(0.5*pi*t), 1, -1); 0
   end
 end

--- a/tests/average_density_boundary_fluid_pressure.prm
+++ b/tests/average_density_boundary_fluid_pressure.prm
@@ -55,7 +55,6 @@ subsection Boundary velocity model
   set Tangential velocity boundary indicators = left
 
   subsection Function
-    set Function constants  =
     set Function expression = 0; 0
   end
 end

--- a/tests/blankenbach.prm
+++ b/tests/blankenbach.prm
@@ -46,7 +46,7 @@ subsection Initial temperature model
   set Model name = function
 
   subsection Function
-    set Function constants  = z1=0.102367, z2=0.897633, pi=3.14159265359
+    set Function constants  = z1=0.102367, z2=0.897633
     set Function expression = if(z<z1,0.5+0.5*(z1-z)/z1,if(z>z2,0.5*(1-z)/(1-z2),0.5)) + 0.1 * cos(x*pi) * sin(z*pi)
     set Variable names      = x,z
   end

--- a/tests/blankenbach_approximation.prm
+++ b/tests/blankenbach_approximation.prm
@@ -8,7 +8,6 @@ subsection Adiabatic conditions model
   set Model name = function
 
   subsection Function
-    set Function constants  =
     set Function expression = 0; 0; 1
     set Variable names      = depth
   end
@@ -47,7 +46,7 @@ subsection Initial temperature model
   set Model name = function
 
   subsection Function
-    set Function constants  = z1=0.102367, z2=0.897633, pi=3.14159265359
+    set Function constants  = z1=0.102367, z2=0.897633
     set Function expression = if(z<z1,0.5+0.5*(z1-z)/z1,if(z>z2,0.5*(1-z)/(1-z2),0.5)) + 0.1 * cos(x*pi) * sin(z*pi)
     set Variable names      = x,z
   end

--- a/tests/blankenbach_case1a.prm
+++ b/tests/blankenbach_case1a.prm
@@ -9,7 +9,7 @@ subsection Initial temperature model
   set Model name = function
 
   subsection Function
-    set Function constants  = z1=0.102367, z2=0.897633, pi=3.14159265359
+    set Function constants  = z1=0.102367, z2=0.897633
     set Function expression = if(z<z1,0.5+0.5*(z1-z)/z1,if(z>z2,0.5*(1-z)/(1-z2),0.5)) + 0.1 * cos(x*pi) * sin(z*pi)
     set Variable names      = x,z
   end

--- a/tests/blankenbach_case1b.prm
+++ b/tests/blankenbach_case1b.prm
@@ -9,7 +9,7 @@ subsection Initial temperature model
   set Model name = function
 
   subsection Function
-    set Function constants  = z1=0.102367, z2=0.897633, pi=3.14159265359
+    set Function constants  = z1=0.102367, z2=0.897633
     set Function expression = if(z<z1,0.5+0.5*(z1-z)/z1,if(z>z2,0.5*(1-z)/(1-z2),0.5)) + 0.1 * cos(x*pi) * sin(z*pi)
     set Variable names      = x,z
   end

--- a/tests/blankenbach_case1c.prm
+++ b/tests/blankenbach_case1c.prm
@@ -9,7 +9,7 @@ subsection Initial temperature model
   set Model name = function
 
   subsection Function
-    set Function constants  = z1=0.102367, z2=0.897633, pi=3.14159265359
+    set Function constants  = z1=0.102367, z2=0.897633
     set Function expression = if(z<z1,0.5+0.5*(z1-z)/z1,if(z>z2,0.5*(1-z)/(1-z2),0.5)) + 0.1 * cos(x*pi) * sin(z*pi)
     set Variable names      = x,z
   end

--- a/tests/blankenbach_case2a.prm
+++ b/tests/blankenbach_case2a.prm
@@ -9,7 +9,7 @@ subsection Initial temperature model
   set Model name = function
 
   subsection Function
-    set Function constants  = z1=0.102367, z2=0.897633, pi=3.14159265359
+    set Function constants  = z1=0.102367, z2=0.897633
     set Function expression = if(z<z1,0.5+0.5*(z1-z)/z1,if(z>z2,0.5*(1-z)/(1-z2),0.5)) + 0.1 * cos(x*pi) * sin(z*pi)
     set Variable names      = x,z
   end

--- a/tests/blankenbach_case2b.prm
+++ b/tests/blankenbach_case2b.prm
@@ -10,7 +10,7 @@ subsection Initial temperature model
 
   subsection Function
     set Variable names      = x,z
-    set Function constants  = p=0.01, L=1, pi=3.1415926536, k=1, ratio=2.5
+    set Function constants  = p=0.01, L=1, k=1, ratio=2.5
     set Function expression = 1* ((1.0-z/L) + p*cos(k*pi*x/L/ratio)*sin(pi*z/L))
   end
 end

--- a/tests/boundary_composition_passive_cartesian.prm
+++ b/tests/boundary_composition_passive_cartesian.prm
@@ -36,7 +36,6 @@ subsection Boundary velocity model
 
   subsection Function
     set Variable names      = x,z,t
-    set Function constants  = pi=3.1415926
     set Function expression = if(x>1+sin(0.5*pi*t), 1, -1); 0
   end
 end

--- a/tests/boundary_composition_passive_depth.prm
+++ b/tests/boundary_composition_passive_depth.prm
@@ -36,7 +36,6 @@ subsection Boundary velocity model
 
   subsection Function
     set Variable names      = x,z,t
-    set Function constants  = pi=3.1415926
     set Function expression = if(x>1+sin(0.5*pi*t), 1, -1); 0
   end
 end

--- a/tests/boundary_traction_function_cartesian_free_surface.prm
+++ b/tests/boundary_traction_function_cartesian_free_surface.prm
@@ -100,7 +100,6 @@ subsection Initial composition model
 
   subsection Function
     set Variable names      = x,y
-    set Function constants  =
     set Function expression = 0; 0; 0; 0; 0; 0;
   end
 end

--- a/tests/boundary_traction_function_cartesian_free_surface_mesh_deformation_degree.prm
+++ b/tests/boundary_traction_function_cartesian_free_surface_mesh_deformation_degree.prm
@@ -104,7 +104,6 @@ subsection Initial composition model
 
   subsection Function
     set Variable names      = x,y
-    set Function constants  =
     set Function expression = 0; 0; 0; 0; 0; 0;
   end
 end

--- a/tests/boundary_traction_function_spherical_free_surface.prm
+++ b/tests/boundary_traction_function_spherical_free_surface.prm
@@ -101,7 +101,6 @@ subsection Initial composition model
 
   subsection Function
     set Variable names      = x,y
-    set Function constants  =
     set Function expression = 0; 0; 0; 0; 0; 0;
   end
 end

--- a/tests/box_simple_log_viscosity_depth_average.prm
+++ b/tests/box_simple_log_viscosity_depth_average.prm
@@ -31,7 +31,7 @@ subsection Initial temperature model
 
   subsection Function
     set Variable names      = x,z
-    set Function constants  = p=10.0, L=3.0e6, pi=3.1415926536, k=1
+    set Function constants  = p=10.0, L=3.0e6, k=1
     set Function expression = 2773.0 - z/L*(2500.0) + p*cos(k*pi*x/L)*sin(k*pi*z/L/2.0)
   end
 end

--- a/tests/burnman_seismic_test.prm
+++ b/tests/burnman_seismic_test.prm
@@ -102,7 +102,6 @@ subsection Initial temperature model
 
   subsection Function
     set Variable names      = x,z
-    set Function constants  = pi=3.1415926
     set Function expression = if(sqrt(x*x+(z-4500000)*(z-4500000))<1000000,800,0)
   end
 end

--- a/tests/checkpoint_09_particles_no_postprocessor.prm
+++ b/tests/checkpoint_09_particles_no_postprocessor.prm
@@ -43,7 +43,6 @@ subsection Boundary velocity model
 
   subsection Function
     set Variable names      = x,z,t
-    set Function constants  = pi=3.1415926
     set Function expression = if(x>1+sin(0.5*pi*t), 1, -1); 0
   end
 end

--- a/tests/composition_active.prm
+++ b/tests/composition_active.prm
@@ -33,7 +33,6 @@ subsection Boundary velocity model
 
   subsection Function
     set Variable names      = x,z,t
-    set Function constants  = pi=3.1415926
     set Function expression = if(x>1+sin(0.5*pi*t), 1, -1); 0
   end
 end

--- a/tests/composition_active_with_melt.prm
+++ b/tests/composition_active_with_melt.prm
@@ -41,7 +41,6 @@ subsection Boundary velocity model
 
   subsection Function
     set Variable names      = x,z,t
-    set Function constants  = pi=3.1415926
     set Function expression = if(x>1+sin(0.5*pi*t), 1, -1); 0
   end
 end

--- a/tests/composition_active_without_melt.prm
+++ b/tests/composition_active_without_melt.prm
@@ -40,7 +40,6 @@ subsection Boundary velocity model
 
   subsection Function
     set Variable names      = x,z,t
-    set Function constants  = pi=3.1415926
     set Function expression = if(x>1+sin(0.5*pi*t), 1, -1); 0
   end
 end

--- a/tests/composition_cg_dg_fem.prm
+++ b/tests/composition_cg_dg_fem.prm
@@ -33,7 +33,6 @@ subsection Boundary velocity model
 
   subsection Function
     set Variable names      = x,z,t
-    set Function constants  = pi=3.1415926
     set Function expression = if(x>1+sin(0.5*pi*t), 1, -1); 0
   end
 end

--- a/tests/composition_cg_dg_fem2.prm
+++ b/tests/composition_cg_dg_fem2.prm
@@ -33,7 +33,6 @@ subsection Boundary velocity model
 
   subsection Function
     set Variable names      = x,z,t
-    set Function constants  = pi=3.1415926
     set Function expression = if(x>1+sin(0.5*pi*t), 1, -1); 0
   end
 end

--- a/tests/composition_passive_discontinuous_constant.prm
+++ b/tests/composition_passive_discontinuous_constant.prm
@@ -36,7 +36,6 @@ subsection Boundary velocity model
 
   subsection Function
     set Variable names      = x,z,t
-    set Function constants  = pi=3.1415926
     set Function expression = if(x>1+sin(0.5*pi*t), 1, -1); 0
   end
 end

--- a/tests/composition_passive_particles.prm
+++ b/tests/composition_passive_particles.prm
@@ -35,7 +35,6 @@ subsection Boundary velocity model
 
   subsection Function
     set Variable names      = x,z,t
-    set Function constants  = pi=3.1415926
     set Function expression = if(x>1+sin(0.5*pi*t), 1, -1); 0
   end
 end

--- a/tests/composition_passive_quarter_shell_cartesian.prm
+++ b/tests/composition_passive_quarter_shell_cartesian.prm
@@ -28,7 +28,6 @@ subsection Boundary velocity model
 
   subsection Function
     set Variable names      = x,z,t
-    set Function constants  = pi=3.1415926
     set Function expression = if(x>1+sin(0.5*pi*t), 1, -1); 0
   end
 end

--- a/tests/composition_passive_quarter_shell_depth.prm
+++ b/tests/composition_passive_quarter_shell_depth.prm
@@ -28,7 +28,6 @@ subsection Boundary velocity model
 
   subsection Function
     set Variable names      = x,z,t
-    set Function constants  = pi=3.1415926
     set Function expression = if(x>1+sin(0.5*pi*t), 1, -1); 0
   end
 end

--- a/tests/composition_passive_quarter_shell_spherical.prm
+++ b/tests/composition_passive_quarter_shell_spherical.prm
@@ -28,7 +28,6 @@ subsection Boundary velocity model
 
   subsection Function
     set Variable names      = x,z,t
-    set Function constants  = pi=3.1415926
     set Function expression = if(x>1+sin(0.5*pi*t), 1, -1); 0
   end
 end

--- a/tests/composition_passive_static.prm
+++ b/tests/composition_passive_static.prm
@@ -33,7 +33,6 @@ subsection Boundary velocity model
 
   subsection Function
     set Variable names      = x,z,t
-    set Function constants  = pi=3.1415926
     set Function expression = if(x>1+sin(0.5*pi*t), 1, -1); 0
   end
 end

--- a/tests/composition_reaction.prm
+++ b/tests/composition_reaction.prm
@@ -48,7 +48,6 @@ subsection Boundary velocity model
 
   subsection Function
     set Variable names      = x,z,t
-    set Function constants  = pi=3.1415926
     set Function expression = if(x>1+sin(0.5*pi*t), 1, -1); 0
   end
 end
@@ -79,7 +78,6 @@ subsection Initial composition model
 
   subsection Function
     set Variable names      = x,z
-    set Function constants  = pi=3.1415926
     set Function expression = if(z<0.5+0.4*sin((x-0.5)*pi),1,0);0
   end
 end

--- a/tests/composition_reaction_iterated_IMPES.prm
+++ b/tests/composition_reaction_iterated_IMPES.prm
@@ -56,7 +56,6 @@ subsection Boundary velocity model
 
   subsection Function
     set Variable names      = x,z,t
-    set Function constants  = pi=3.1415926
     set Function expression = if(x>1+sin(0.5*pi*t), 1, -1); 0
   end
 end
@@ -91,7 +90,6 @@ subsection Initial composition model
 
   subsection Function
     set Variable names      = x,z
-    set Function constants  = pi=3.1415926
     set Function expression = 0.0;0.0;0.0
   end
 end

--- a/tests/composition_stabilization.prm
+++ b/tests/composition_stabilization.prm
@@ -39,7 +39,6 @@ subsection Boundary velocity model
 
   subsection Function
     set Variable names      = x,z,t
-    set Function constants  = pi=3.1415926
     set Function expression = if(z>0.5,sin(pi*x),-sin(pi*x)); 0
   end
 end

--- a/tests/constant_composition_convergence.prm
+++ b/tests/constant_composition_convergence.prm
@@ -37,7 +37,6 @@ subsection Initial temperature model
 
   subsection Function
     set Variable names      = x,z
-    set Function constants  = pi=3.1415926
     set Function expression = 1600 + 100*sin(x*pi/200000.0)
   end
 end

--- a/tests/convection_box_phase_function.prm
+++ b/tests/convection_box_phase_function.prm
@@ -58,7 +58,7 @@ subsection Initial temperature model
   set Model name = function
 
   subsection Function
-    set Function constants = delta=0.1, A=10, h=1350000, pi=3.1416
+    set Function constants = delta=0.1, A=10, h=1350000
     set Variable names = x,z
     set Function expression = 500 + 500*(erfc(z/(h*delta)) - erfc((1-z/h)/delta)) + A*cos(pi*x/h)*sin(pi*z/h) + A*cos(2*pi*x/h)*sin(pi*z/h) + A*cos(pi*x/h)*sin(2*pi*z/h) + A*cos(2*pi*x/h)*sin(2*pi*z/h)
   end

--- a/tests/convective_heating.prm
+++ b/tests/convective_heating.prm
@@ -82,7 +82,7 @@ subsection Boundary convective heating model
   
   subsection Function
     set Variable names      = x,z
-    set Function constants  = p=0.01, L=1, pi=3.1415926536, k=1
+    set Function constants  = p=0.01, L=1, k=1
     set Function expression = 100
   end
 end
@@ -92,7 +92,6 @@ subsection Boundary heat flux model
   
   subsection Function
     set Variable names      = x,z
-    set Function constants  = 
     set Function expression = 0
   end
 end

--- a/tests/convective_heating_cosine.prm
+++ b/tests/convective_heating_cosine.prm
@@ -77,7 +77,7 @@ subsection Initial temperature model
 
   subsection Function
     set Variable names      = x,z
-    set Function constants  = DeltaT=80, L=0.1, lambda=2.028757838, pi=3.1415926536
+    set Function constants  = DeltaT=80, L=0.1, lambda=2.028757838
     set Function expression = 293 + DeltaT * sin(lambda*z/L)
   end
 end
@@ -101,7 +101,7 @@ subsection Boundary convective heating model
   
   subsection Function
     set Variable names      = x,z
-    set Function constants  = p=0.01, L=1, pi=3.1415926536, k=1
+    set Function constants  = p=0.01, L=1, k=1
     set Function expression = 100
   end
 end
@@ -111,7 +111,6 @@ subsection Boundary heat flux model
   
   subsection Function
     set Variable names      = x,z
-    set Function constants  = 
     set Function expression = 0
   end
 end

--- a/tests/darcy_convection_step.prm
+++ b/tests/darcy_convection_step.prm
@@ -103,7 +103,6 @@ subsection Initial composition model
 
   subsection Function
     set Variable names      = x,y
-    set Function constants  =
     set Function expression = 0.02; 0.0
   end
 end

--- a/tests/darcy_field_diffusion.prm
+++ b/tests/darcy_field_diffusion.prm
@@ -32,7 +32,7 @@ subsection Initial composition model
 
   subsection Function
     set Variable names      = x,y,t
-    set Function constants  = pi=3.1415926, x0=50000, y0=50000, c=5000
+    set Function constants  =  x0=50000, y0=50000, c=5000
     set Function expression = 0.01 * exp(-((x-x0)*(x-x0)+(y-y0)*(y-y0))/(2*c*c)); 0.0
   end
 end

--- a/tests/darcy_velocity.prm
+++ b/tests/darcy_velocity.prm
@@ -97,7 +97,7 @@ subsection Initial composition model
 
   subsection Function
     set Variable names      = x,y
-    set Function constants  = pi=3.1415926,x0=100000,y0=50000,c=12500, A_f=0.2, A_s = 1.0
+    set Function constants  = x0=100000,y0=50000,c=12500, A_f=0.2, A_s = 1.0
     set Function expression = A_f; if((x - x0)*(x - x0) + (y - y0)*(y - y0) <= c*c, A_s, 0)
   end
 end

--- a/tests/depth_average_01.prm
+++ b/tests/depth_average_01.prm
@@ -24,7 +24,7 @@ subsection Initial temperature model
 
   subsection Function
     set Variable names      = x,z
-    set Function constants  = p=0.01, L=1, pi=3.1415926536, k=1
+    set Function constants  = p=0.01, L=1, k=1
     set Function expression = (1.0-z) - p*cos(k*pi*x/L)*sin(pi*z)
   end
 end

--- a/tests/depth_average_02.prm
+++ b/tests/depth_average_02.prm
@@ -22,7 +22,7 @@ subsection Initial temperature model
 
   subsection Function
     set Variable names      = x,z
-    set Function constants  = p=0.01, L=1, pi=3.1415926536, k=1
+    set Function constants  = p=0.01, L=1, k=1
     set Function expression = (1.0-z) - p*cos(k*pi*x/L)*sin(pi*z)
   end
 end

--- a/tests/depth_average_03.prm
+++ b/tests/depth_average_03.prm
@@ -24,7 +24,7 @@ subsection Initial temperature model
 
   subsection Function
     set Variable names      = x,z
-    set Function constants  = p=0.01, L=1, pi=3.1415926536, k=1
+    set Function constants  = p=0.01, L=1, k=1
     set Function expression = (1.0-z) - p*cos(k*pi*x/L)*sin(pi*z)
   end
 end

--- a/tests/depth_average_04.prm
+++ b/tests/depth_average_04.prm
@@ -21,7 +21,7 @@ subsection Initial temperature model
 
   subsection Function
     set Variable names      = x,z
-    set Function constants  = p=0.01, L=1, pi=3.1415926536, k=1
+    set Function constants  = p=0.01, L=1, k=1
     set Function expression = (1.0-z) - p*cos(k*pi*x/L)*sin(pi*z)
   end
 end

--- a/tests/depth_average_05.prm
+++ b/tests/depth_average_05.prm
@@ -22,7 +22,7 @@ subsection Initial temperature model
 
   subsection Function
     set Variable names      = x,z
-    set Function constants  = p=0.01, L=1, pi=3.1415926536, k=1
+    set Function constants  = p=0.01, L=1, k=1
     set Function expression = (1.0-z) - p*cos(k*pi*x/L)*sin(pi*z)
   end
 end

--- a/tests/depth_average_txt_output.prm
+++ b/tests/depth_average_txt_output.prm
@@ -22,7 +22,7 @@ subsection Initial temperature model
 
   subsection Function
     set Variable names      = x,z
-    set Function constants  = p=0.01, L=1, pi=3.1415926536, k=1
+    set Function constants  = p=0.01, L=1, k=1
     set Function expression = (1.0-z) - p*cos(k*pi*x/L)*sin(pi*z)
   end
 end

--- a/tests/depth_average_underres.prm
+++ b/tests/depth_average_underres.prm
@@ -26,7 +26,7 @@ subsection Initial temperature model
 
   subsection Function
     set Variable names      = x,z
-    set Function constants  = p=0.01, L=1, pi=3.1415926536, k=1
+    set Function constants  = p=0.01, L=1, k=1
     set Function expression = (1.0-z) - p*cos(k*pi*x/L)*sin(pi*z)
   end
 end

--- a/tests/depth_dependent_box_file_simple.prm
+++ b/tests/depth_dependent_box_file_simple.prm
@@ -57,7 +57,7 @@ subsection Initial temperature model
 
   subsection Function
     set Variable names      = x,z
-    set Function constants  = p=10.0, L=3.0e6, pi=3.1415926536, k=1
+    set Function constants  = p=10.0, L=3.0e6, k=1
     set Function expression = 2773.0 - z/L*(2500.0) + p*cos(k*pi*x/L)*sin(k*pi*z/L/2.0)
   end
 end

--- a/tests/depth_dependent_box_function_simple.prm
+++ b/tests/depth_dependent_box_function_simple.prm
@@ -56,7 +56,7 @@ subsection Initial temperature model
 
   subsection Function
     set Variable names      = x,z
-    set Function constants  = p=10.0, L=3.0e6, pi=3.1415926536, k=1
+    set Function constants  = p=10.0, L=3.0e6, k=1
     set Function expression = 2773.0 - z/L*(2500.0) + p*cos(k*pi*x/L)*sin(k*pi*z/L/2.0)
   end
 end

--- a/tests/depth_dependent_box_function_time_dependent.prm
+++ b/tests/depth_dependent_box_function_time_dependent.prm
@@ -55,7 +55,7 @@ subsection Initial temperature model
 
   subsection Function
     set Variable names      = x,z
-    set Function constants  = p=10.0, L=3.0e6, pi=3.1415926536, k=1
+    set Function constants  = p=10.0, L=3.0e6, k=1
     set Function expression = 2773.0 - z/L*(2500.0) + p*cos(k*pi*x/L)*sin(k*pi*z/L/2.0)
   end
 end

--- a/tests/depth_dependent_box_none_simple.prm
+++ b/tests/depth_dependent_box_none_simple.prm
@@ -57,7 +57,7 @@ subsection Initial temperature model
 
   subsection Function
     set Variable names      = x,z
-    set Function constants  = p=10.0, L=3.0e6, pi=3.1415926536, k=1
+    set Function constants  = p=10.0, L=3.0e6, k=1
     set Function expression = 2773.0 - z/L*(2500.0) + p*cos(k*pi*x/L)*sin(k*pi*z/L/2.0)
   end
 end

--- a/tests/discontinuous_composition_1.prm
+++ b/tests/discontinuous_composition_1.prm
@@ -32,7 +32,6 @@ subsection Boundary velocity model
 
   subsection Function
     set Variable names      = x,z,t
-    set Function constants  = pi=3.1415926
     set Function expression = if(x>1+sin(0.5*pi*t), 1, -1); 0
   end
 end

--- a/tests/discontinuous_temperature.prm
+++ b/tests/discontinuous_temperature.prm
@@ -32,7 +32,6 @@ subsection Boundary velocity model
 
   subsection Function
     set Variable names      = x,z,t
-    set Function constants  = pi=3.1415926
     set Function expression = if(x>1+sin(0.5*pi*t), 1, -1); 0
   end
 end

--- a/tests/discontinuous_temperature_blankenbach.prm
+++ b/tests/discontinuous_temperature_blankenbach.prm
@@ -12,7 +12,6 @@ subsection Adiabatic conditions model
   set Model name = function
 
   subsection Function
-    set Function constants  =
     set Function expression = 0; 0; 1
     set Variable names      = depth
   end
@@ -51,7 +50,7 @@ subsection Initial temperature model
   set Model name = ascii data
 
   subsection Function
-    set Function constants  = z1=0.102367, z2=0.897633, pi=3.14159265359
+    set Function constants  = z1=0.102367, z2=0.897633
     set Function expression = if(z<z1,0.5+0.5*(z1-z)/z1,if(z>z2,0.5*(1-z)/(1-z2),0.5)) + 0.1 * cos(x*pi) * sin(z*pi)
     set Variable names      = x,z
   end

--- a/tests/fluid_outflow.prm
+++ b/tests/fluid_outflow.prm
@@ -26,7 +26,7 @@ subsection Initial composition model
 
   subsection Function
     set Variable names      = x,y,t
-    set Function constants  = pi=3.1415926, x0=2500, y0=2500, c=1000
+    set Function constants  =  x0=2500, y0=2500, c=1000
     set Function expression = 0.01 * exp(-((x-x0)*(x-x0)+(y-y0)*(y-y0))/(2*c*c)); 0.0; if(y>=7000, 1, 0)
   end
 end

--- a/tests/free_surface_timestep_repeat.prm
+++ b/tests/free_surface_timestep_repeat.prm
@@ -119,7 +119,6 @@ subsection Initial composition model
 
   subsection Function
     set Variable names      = x,y
-    set Function constants  =
     set Function expression = 0; 0; 0; 0; 0; 0;
   end
 end

--- a/tests/geoid.prm
+++ b/tests/geoid.prm
@@ -50,7 +50,6 @@ subsection Initial temperature model
 
   subsection Function
     set Coordinate system = spherical
-    set Function constants = pi=3.1415926536
     set Variable names = r,phi,theta,t
     set Function expression = (5/2)*sqrt(5/pi)*(3*(cos(theta))^2-1)
   end

--- a/tests/geoid_freesurface.prm
+++ b/tests/geoid_freesurface.prm
@@ -45,7 +45,6 @@ subsection Initial temperature model
 
   subsection Function
     set Coordinate system = spherical
-    set Function constants = pi=3.1415926536
     set Variable names = r,phi,theta,t
     set Function expression = (5/2)*sqrt(5/pi)*(3*(cos(theta))^2-1)
   end

--- a/tests/geoid_no_topo.prm
+++ b/tests/geoid_no_topo.prm
@@ -47,7 +47,6 @@ subsection Initial temperature model
 
   subsection Function
     set Coordinate system = spherical
-    set Function constants = pi=3.1415926536
     set Variable names = r,phi,theta,t
     set Function expression = (5/2)*sqrt(5/pi)*(3*(cos(theta))^2-1)
   end

--- a/tests/geoid_visualization.prm
+++ b/tests/geoid_visualization.prm
@@ -47,7 +47,6 @@ subsection Initial temperature model
 
   subsection Function
     set Coordinate system = spherical
-    set Function constants = pi=3.1415926536
     set Variable names = r,phi,theta,t
     set Function expression = (5/2)*sqrt(5/pi)*(3*(cos(theta))^2-1)
   end

--- a/tests/global_melt.prm
+++ b/tests/global_melt.prm
@@ -107,7 +107,7 @@ subsection Initial composition model
   set Model name = function
 
   subsection Function
-    set Function constants  = pi=3.1415926,a = 0.0, b = 2500000, c = 100000, d=1450000
+    set Function constants  = a = 0.0, b = 2500000, c = 100000, d=1450000
     set Function expression = a * exp(-((y-b)*(y-b)+(0.2*(x-d))*(0.2*(x-d)))/(2*c*c)); a * exp(-((y-b)*(y-b)+(0.2*(x-d))*(0.2*(x-d)))/(2*c*c))
     set Variable names      = x,y
   end

--- a/tests/global_melt_parallel.prm
+++ b/tests/global_melt_parallel.prm
@@ -109,7 +109,7 @@ subsection Initial composition model
   set Model name = function
 
   subsection Function
-    set Function constants  = pi=3.1415926,a = 0.0, b = 2500000, c = 100000, d=1450000
+    set Function constants  = a = 0.0, b = 2500000, c = 100000, d=1450000
     set Function expression = a * exp(-((y-b)*(y-b)+(0.2*(x-d))*(0.2*(x-d)))/(2*c*c)); a * exp(-((y-b)*(y-b)+(0.2*(x-d))*(0.2*(x-d)))/(2*c*c))
     set Variable names      = x,y
   end

--- a/tests/global_refine_bug.prm
+++ b/tests/global_refine_bug.prm
@@ -39,7 +39,6 @@ subsection Boundary velocity model
 
   subsection Function
     set Variable names      = x,z,t
-    set Function constants  = pi=3.1415926
     set Function expression = if(x>1+sin(0.5*pi*t), 1, -1); 0
   end
 end

--- a/tests/gmg_mesh_deform_topo.prm
+++ b/tests/gmg_mesh_deform_topo.prm
@@ -23,7 +23,7 @@ subsection Initial temperature model
 
   subsection Function
     set Variable names      = x,z
-    set Function constants  = p=0.01, L=1, pi=3.1415926536, k=1
+    set Function constants  = p=0.01, L=1, k=1
     set Function expression = (1.0-z) - p*cos(k*pi*x/L)*sin(pi*z)
   end
 end

--- a/tests/grain_size_crossed_transition.prm
+++ b/tests/grain_size_crossed_transition.prm
@@ -70,7 +70,6 @@ subsection Initial composition model
 
   subsection Function
     set Variable names      = x,z
-    set Function constants  =
     set Function expression = 2e-3
   end
 end

--- a/tests/grain_size_friction_heating.prm
+++ b/tests/grain_size_friction_heating.prm
@@ -69,7 +69,6 @@ subsection Initial composition model
 
   subsection Function
     set Variable names      = x,z
-    set Function constants  =
     set Function expression = if(z<50000,1e-3,1.0000001e-3)
   end
 end

--- a/tests/grain_size_growth.prm
+++ b/tests/grain_size_growth.prm
@@ -94,7 +94,6 @@ subsection Initial composition model
 
   subsection Function
     set Variable names      = x,z
-    set Function constants  =
     set Function expression = if(z<50000,8e-5,8.00001e-5)
   end
 end

--- a/tests/grain_size_growth_one_cell.prm
+++ b/tests/grain_size_growth_one_cell.prm
@@ -87,7 +87,6 @@ subsection Initial composition model
 
   subsection Function
     set Variable names      = x,z
-    set Function constants  =
     set Function expression = 8e-5
   end
 end

--- a/tests/grain_size_latent_heat.prm
+++ b/tests/grain_size_latent_heat.prm
@@ -33,7 +33,6 @@ subsection Initial composition model
 
   subsection Function
     set Variable names      = x,z
-    set Function constants  =
     set Function expression = 8e-5
   end
 end

--- a/tests/grain_size_particle_interpolation.prm
+++ b/tests/grain_size_particle_interpolation.prm
@@ -60,7 +60,6 @@ subsection Initial composition model
 
   subsection Function
     set Variable names      = x,z
-    set Function constants  =
     set Function expression = 1000; 1e-3
   end
 end

--- a/tests/grain_size_phase_function.prm
+++ b/tests/grain_size_phase_function.prm
@@ -56,7 +56,6 @@ subsection Initial composition model
 
   subsection Function
     set Variable names      = x,z
-    set Function constants  =
     set Function expression = 1e-3
   end
 end

--- a/tests/grain_size_strain.prm
+++ b/tests/grain_size_strain.prm
@@ -68,7 +68,6 @@ subsection Initial composition model
 
   subsection Function
     set Variable names      = x,z
-    set Function constants  =
     set Function expression = if(z<50000,1e-3,1.0000001e-3)
   end
 end

--- a/tests/heat_flux_densities.prm
+++ b/tests/heat_flux_densities.prm
@@ -8,7 +8,6 @@ subsection Adiabatic conditions model
   set Model name = function
 
   subsection Function
-    set Function constants  =
     set Function expression = 0; 0; 1
     set Variable names      = depth
   end
@@ -50,7 +49,7 @@ subsection Initial temperature model
 
   subsection Function
     set Variable names      = x,z
-    set Function constants  = p=0.01, L=1, pi=3.1415926536, k=1, ratio=2.5
+    set Function constants  = p=0.01, L=1, k=1, ratio=2.5
     set Function expression = 1* ((1.0-z/L) + p*cos(k*pi*x/L/ratio)*sin(pi*z/L))
   end
 end

--- a/tests/heat_flux_map.prm
+++ b/tests/heat_flux_map.prm
@@ -19,7 +19,7 @@ subsection Initial temperature model
 
   subsection Function
     set Variable names      = x,z
-    set Function constants  = p=0.01, L=1, pi=3.1415926536, k=1
+    set Function constants  = p=0.01, L=1, k=1
     set Function expression = (1.0-z) - p*cos(k*pi*x/L)*sin(pi*z)
   end
 end

--- a/tests/heat_flux_map_vis.prm
+++ b/tests/heat_flux_map_vis.prm
@@ -19,7 +19,7 @@ subsection Initial temperature model
 
   subsection Function
     set Variable names      = x,z
-    set Function constants  = p=0.01, L=1, pi=3.1415926536, k=1
+    set Function constants  = p=0.01, L=1, k=1
     set Function expression = (1.0-z) - p*cos(k*pi*x/L)*sin(pi*z)
   end
 end

--- a/tests/iterated_advection_and_defect_correction_Stokes.prm
+++ b/tests/iterated_advection_and_defect_correction_Stokes.prm
@@ -72,7 +72,7 @@ subsection Initial temperature model
   set Model name = function
 
   subsection Function
-    set Function constants  = pi=3.1415926,x0=150000,a = 0.2, b = 75000, c = 10000, d=0.0
+    set Function constants  = x0=150000,a = 0.2, b = 75000, c = 10000, d=0.0
     set Function expression = d + a * exp(-((x-b)*(x-b)+y*y)/(2*c*c))
     set Variable names      = x,y
   end
@@ -82,7 +82,7 @@ subsection Initial composition model
   set Model name = function
 
   subsection Function
-    set Function constants  = pi=3.1415926,x0=150000,a = 0.2, b = 75000, c = 10000, d=0.0
+    set Function constants  = x0=150000,a = 0.2, b = 75000, c = 10000, d=0.0
     set Function expression = d + a * exp(-((x-b)*(x-b)+y*y)/(2*c*c))
     set Variable names      = x,y
   end

--- a/tests/iterated_advection_and_stokes.prm
+++ b/tests/iterated_advection_and_stokes.prm
@@ -72,7 +72,7 @@ subsection Initial temperature model
   set Model name = function
 
   subsection Function
-    set Function constants  = pi=3.1415926,x0=150000,a = 0.2, b = 75000, c = 10000, d=0.0
+    set Function constants  = x0=150000,a = 0.2, b = 75000, c = 10000, d=0.0
     set Function expression = d + a * exp(-((x-b)*(x-b)+y*y)/(2*c*c))
     set Variable names      = x,y
   end
@@ -82,7 +82,7 @@ subsection Initial composition model
   set Model name = function
 
   subsection Function
-    set Function constants  = pi=3.1415926,x0=150000,a = 0.2, b = 75000, c = 10000, d=0.0
+    set Function constants  = x0=150000,a = 0.2, b = 75000, c = 10000, d=0.0
     set Function expression = d + a * exp(-((x-b)*(x-b)+y*y)/(2*c*c))
     set Variable names      = x,y
   end

--- a/tests/iterated_advection_and_stokes_DG.prm
+++ b/tests/iterated_advection_and_stokes_DG.prm
@@ -73,7 +73,7 @@ subsection Initial temperature model
   set Model name = function
 
   subsection Function
-    set Function constants  = pi=3.1415926,x0=150000,a = 0.2, b = 75000, c = 10000, d=0.0
+    set Function constants  = x0=150000,a = 0.2, b = 75000, c = 10000, d=0.0
     set Function expression = d + a * exp(-((x-b)*(x-b)+y*y)/(2*c*c))
     set Variable names      = x,y
   end
@@ -83,7 +83,7 @@ subsection Initial composition model
   set Model name = function
 
   subsection Function
-    set Function constants  = pi=3.1415926,x0=150000,a = 0.2, b = 75000, c = 10000, d=0.0
+    set Function constants  = x0=150000,a = 0.2, b = 75000, c = 10000, d=0.0
     set Function expression = d + a * exp(-((x-b)*(x-b)+y*y)/(2*c*c)); if(x<75e3,1,0)
     set Variable names      = x,y
   end

--- a/tests/iterated_advection_and_stokes_DG_limiter.prm
+++ b/tests/iterated_advection_and_stokes_DG_limiter.prm
@@ -80,7 +80,7 @@ subsection Initial temperature model
   set Model name = function
 
   subsection Function
-    set Function constants  = pi=3.1415926,x0=150000,a = 0.2, b = 75000, c = 10000, d=0.0
+    set Function constants  = x0=150000,a = 0.2, b = 75000, c = 10000, d=0.0
     set Function expression = d + a * exp(-((x-b)*(x-b)+y*y)/(2*c*c))
     set Variable names      = x,y
   end
@@ -90,7 +90,7 @@ subsection Initial composition model
   set Model name = function
 
   subsection Function
-    set Function constants  = pi=3.1415926,x0=150000,a = 0.2, b = 75000, c = 10000, d=0.0
+    set Function constants  = x0=150000,a = 0.2, b = 75000, c = 10000, d=0.0
     set Function expression = d + a * exp(-((x-b)*(x-b)+y*y)/(2*c*c)); if(x<75e3,1,0)
     set Variable names      = x,y
   end

--- a/tests/iterated_advection_and_stokes_direct_solver.prm
+++ b/tests/iterated_advection_and_stokes_direct_solver.prm
@@ -75,7 +75,7 @@ subsection Initial temperature model
   set Model name = function
 
   subsection Function
-    set Function constants  = pi=3.1415926,x0=150000,a = 0.2, b = 75000, c = 10000, d=0.0
+    set Function constants  = x0=150000,a = 0.2, b = 75000, c = 10000, d=0.0
     set Function expression = d + a * exp(-((x-b)*(x-b)+y*y)/(2*c*c))
     set Variable names      = x,y
   end
@@ -85,7 +85,7 @@ subsection Initial composition model
   set Model name = function
 
   subsection Function
-    set Function constants  = pi=3.1415926,x0=150000,a = 0.2, b = 75000, c = 10000, d=0.0
+    set Function constants  = x0=150000,a = 0.2, b = 75000, c = 10000, d=0.0
     set Function expression = d + a * exp(-((x-b)*(x-b)+y*y)/(2*c*c))
     set Variable names      = x,y
   end

--- a/tests/iterated_advection_and_stokes_residual.prm
+++ b/tests/iterated_advection_and_stokes_residual.prm
@@ -72,7 +72,7 @@ subsection Initial temperature model
   set Model name = function
 
   subsection Function
-    set Function constants  = pi=3.1415926,x0=150000,a = 0.2, b = 75000, c = 10000, d=0.0
+    set Function constants  = x0=150000,a = 0.2, b = 75000, c = 10000, d=0.0
     set Function expression = d + a * exp(-((x-b)*(x-b)+y*y)/(2*c*c))
     set Variable names      = x,y
   end
@@ -82,7 +82,7 @@ subsection Initial composition model
   set Model name = function
 
   subsection Function
-    set Function constants  = pi=3.1415926,x0=150000,a = 0.2, b = 75000, c = 10000, d=0.0
+    set Function constants  = x0=150000,a = 0.2, b = 75000, c = 10000, d=0.0
     set Function expression = 0.0
     set Variable names      = x,y
   end

--- a/tests/kaus_2010_with_plastic_dilation.prm
+++ b/tests/kaus_2010_with_plastic_dilation.prm
@@ -106,7 +106,6 @@ subsection Initial composition model
 
   subsection Function
     set Variable names      = x,y
-    set Function constants  =
     set Function expression = 0; 0; 0; 0; 0; 0; 0; \
                               if (y<=0.4e3 && x>=19.6e3 && x<=20.4e3, 1, 0);
   end

--- a/tests/kinematically_driven_subduction_2d_case1.prm
+++ b/tests/kinematically_driven_subduction_2d_case1.prm
@@ -121,7 +121,6 @@ subsection Initial temperature model
   set List of model names = function
 
   subsection Function
-    set Function constants  =
     set Function expression = 0
     set Variable names      = x,y,t
   end

--- a/tests/king_ala_nondim.prm
+++ b/tests/king_ala_nondim.prm
@@ -57,7 +57,7 @@ subsection Initial temperature model
 
   subsection Function
     set Variable names      = x,z
-    set Function constants  = p=0.01, L=1, pi=3.1415926536, k=1
+    set Function constants  = p=0.01, L=1, k=1
     set Function expression =  1* ((1.0-z/L) + p*cos(k*pi*x/L/1.0)*sin(pi*z/L)) +0.091
   end
 end

--- a/tests/matrix_nonzeros_4.prm
+++ b/tests/matrix_nonzeros_4.prm
@@ -44,7 +44,6 @@ subsection Boundary velocity model
 
   subsection Function
     set Variable names      = x,z,t
-    set Function constants  = pi=3.1415926
     set Function expression = if(x>1+sin(0.5*pi*t), 1, -1); 0
   end
 end
@@ -79,7 +78,6 @@ subsection Initial composition model
 
   subsection Function
     set Variable names      = x,z
-    set Function constants  = pi=3.1415926
     set Function expression = if(z<0.5+0.4*sin((x-0.5)*pi),1,0);0
   end
 end

--- a/tests/matrix_nonzeros_5.prm
+++ b/tests/matrix_nonzeros_5.prm
@@ -43,7 +43,6 @@ subsection Boundary velocity model
 
   subsection Function
     set Variable names      = x,z,t
-    set Function constants  = pi=3.1415926
     set Function expression = if(x>1+sin(0.5*pi*t), 1, -1); 0
   end
 end
@@ -75,7 +74,6 @@ subsection Initial composition model
 
   subsection Function
     set Variable names      = x,z
-    set Function constants  = pi=3.1415926
     set Function expression = if(z<0.5+0.4*sin((x-0.5)*pi),1,0);0;1
   end
 end

--- a/tests/matrix_nonzeros_6.prm
+++ b/tests/matrix_nonzeros_6.prm
@@ -44,7 +44,6 @@ subsection Boundary velocity model
 
   subsection Function
     set Variable names      = x,z,t
-    set Function constants  = pi=3.1415926
     set Function expression = if(x>1+sin(0.5*pi*t), 1, -1); 0
   end
 end
@@ -76,7 +75,6 @@ subsection Initial composition model
 
   subsection Function
     set Variable names      = x,z
-    set Function constants  = pi=3.1415926
     set Function expression = if(z<0.5+0.4*sin((x-0.5)*pi),1,0);0;1
   end
 end

--- a/tests/matrix_nonzeros_7.prm
+++ b/tests/matrix_nonzeros_7.prm
@@ -49,7 +49,6 @@ subsection Boundary velocity model
 
   subsection Function
     set Variable names      = x,z,t
-    set Function constants  = pi=3.1415926
     set Function expression = if(x>1+sin(0.5*pi*t), 1, -1); 0
   end
 end
@@ -81,7 +80,6 @@ subsection Initial composition model
 
   subsection Function
     set Variable names      = x,z
-    set Function constants  = pi=3.1415926
     set Function expression = if(z<0.5+0.4*sin((x-0.5)*pi),1,0);0;1
   end
 end

--- a/tests/max_timesteps_btwn_output.prm
+++ b/tests/max_timesteps_btwn_output.prm
@@ -55,7 +55,7 @@ subsection Initial temperature model
 
   subsection Function
     set Variable names      = x,z
-    set Function constants  = p=0.01, L=1, pi=3.1415926536, k=1
+    set Function constants  = p=0.01, L=1, k=1
     set Function expression = (1.0-z) - p*cos(k*pi*x/L)*sin(pi*z)
   end
 end

--- a/tests/maximum_horizontal_compressive_stress_case_elasticity.prm
+++ b/tests/maximum_horizontal_compressive_stress_case_elasticity.prm
@@ -107,7 +107,6 @@ subsection Initial composition model
 
   subsection Function
     set Variable names      = x, y, z
-    set Function constants  = 
     set Function expression = 0; 0; 0; 0; 0; 0; 0; 0; 0; 0; 0; 0;
   end
 end

--- a/tests/maximum_refinement_function.prm
+++ b/tests/maximum_refinement_function.prm
@@ -98,7 +98,6 @@ subsection Mesh refinement
   set Time steps between mesh refinement       = 1
 
   subsection Maximum refinement function
-    set Function constants  =
 
     # This is in fact the default value
     set Coordinate system = depth

--- a/tests/maximum_refinement_function_cartesian.prm
+++ b/tests/maximum_refinement_function_cartesian.prm
@@ -99,7 +99,6 @@ subsection Mesh refinement
 
   subsection Maximum refinement function
     set Coordinate system      = cartesian
-    set Function constants     =
     set Function expression    = 6 + 2*sin(x*2*pi/250000)*sin(y*2*pi/250000)
     set Variable names         = x,y
   end

--- a/tests/maximum_refinement_function_spherical.prm
+++ b/tests/maximum_refinement_function_spherical.prm
@@ -91,7 +91,6 @@ subsection Mesh refinement
 
   subsection Maximum refinement function
     set Coordinate system      = spherical
-    set Function constants     =
     set Function expression    = 5 + 2*sin((r+250000)*2*pi/250000)*sin(12*phi)
     set Variable names         = r,phi
   end

--- a/tests/melt_and_traction.prm
+++ b/tests/melt_and_traction.prm
@@ -52,7 +52,6 @@ subsection Boundary velocity model
   set Tangential velocity boundary indicators = left
 
   subsection Function
-    set Function constants  =
     set Function expression = 0; 0
   end
 end

--- a/tests/melt_boundary_heat_flux.prm
+++ b/tests/melt_boundary_heat_flux.prm
@@ -87,7 +87,7 @@ subsection Initial composition model
 
   subsection Function
     set Variable names      = x,y
-    set Function constants  = pi=3.1415926,x0=100000,y0=50000,c=10000
+    set Function constants  = x0=100000,y0=50000,c=10000
     set Function expression = 0.2 * exp(-((x-x0)*(x-x0)+(y-y0)*(y-y0))/(2*c*c)); 0.2 * exp(-((x-x0)*(x-x0)+(y-y0)*(y-y0))/(2*c*c))
   end
 end

--- a/tests/melt_force_vector.prm
+++ b/tests/melt_force_vector.prm
@@ -99,7 +99,6 @@ subsection Initial composition model
   set Model name = function
 
   subsection Function
-    set Function constants = pi=3.14159265359
 
     #    set Function expression = if(abs(x)==1 || abs(z)==1, 0.1000000000e-1 + 0.1000000000e0 * exp(-0.40e1 * ((x + 0.20e1 * z)^ 0.2e1)), 0)
     #    set Function expression = 0.1000000000e-1 + 0.1000000000e0 * exp(-0.40e1 * ((x + 0.20e1 * z)^ 0.2e1))

--- a/tests/melt_restart.prm
+++ b/tests/melt_restart.prm
@@ -113,7 +113,7 @@ subsection Initial composition model
   set Model name = function
 
   subsection Function
-    set Function constants  = pi=3.1415926,a = 0.0, b = 2500000, c = 100000, d=1450000
+    set Function constants  = a = 0.0, b = 2500000, c = 100000, d=1450000
     set Function expression = a * exp(-((y-b)*(y-b)+(0.2*(x-d))*(0.2*(x-d)))/(2*c*c)); a * exp(-((y-b)*(y-b)+(0.2*(x-d))*(0.2*(x-d)))/(2*c*c))
     set Variable names      = x,y
   end

--- a/tests/melt_transport_adaptive.prm
+++ b/tests/melt_transport_adaptive.prm
@@ -105,7 +105,6 @@ subsection Initial composition model
   set Model name = function
 
   subsection Function
-    set Function constants = pi=3.14159265359
 
     #    set Function expression = if(abs(x)==1 || abs(z)==1, 0.1000000000e-1 + 0.1000000000e0 * exp(-0.40e1 * ((x + 0.20e1 * z)^ 0.2e1)), 0)
     #    set Function expression = 0.1000000000e-1 + 0.1000000000e0 * exp(-0.40e1 * ((x + 0.20e1 * z)^ 0.2e1))

--- a/tests/melt_transport_convergence_simple.prm
+++ b/tests/melt_transport_convergence_simple.prm
@@ -69,7 +69,7 @@ subsection Gravity model
   set Model name = function
 
   subsection Function
-    set Function constants = c=1,pi=3.14159265359
+    set Function constants = c=1
     set Function expression = 0.0;\
                               0.1 * exp(z/10.0);
     set Variable names      = x,z
@@ -99,7 +99,6 @@ subsection Initial composition model
   set Model name = function
 
   subsection Function
-    set Function constants = pi=3.14159265359
     set Function expression = 0.15+1.0/20.0*(pi/2+atan(x+2*z))
     set Variable names      = x,z
   end

--- a/tests/melt_transport_convergence_test.prm
+++ b/tests/melt_transport_convergence_test.prm
@@ -70,7 +70,7 @@ subsection Gravity model
   set Model name = function
 
   subsection Function
-    set Function constants = c=1,pi=3.14159265359
+    set Function constants = c=1
     set Function expression = (.1166666666*(2*x+4.0*z)/(1+(x+2.0*z)^4)*exp(.1-.5e-1*atan((x+2.0*z)^2))+.500e-1*(4.0*x+8.00*z)/(1+(x+2.0*z)^4)*exp(.1-.5e-1*atan((x+2.0*z)^2))*(cos(z)+1)+1.00*exp(.1-.5e-1*atan((x+2.0*z)^2))*sin(z)+.5e-1*(2*x+4.0*z)/(1+(x+2.0*z)^4)*exp(.1-.5e-1*atan((x+2.0*z)^2))/(-.9-.5e-1*atan((x+2.0*z)^2))-.5e-1*exp(.1-.5e-1*atan((x+2.0*z)^2))/(-.9-.5e-1*atan((x+2.0*z)^2))^2*(2*x+4.0*z)/(1+(x+2.0*z)^4))/(.95+.25e-1*atan((x+2.0*z)^2));\
                               (.1666666667e-1*(4.0*x+8.00*z)/(1+(x+2.0*z)^4)*exp(.1-.5e-1*atan((x+2.0*z)^2))+.500e-1*(2*x+4.0*z)/(1+(x+2.0*z)^4)*exp(.1-.5e-1*atan((x+2.0*z)^2))*(cos(z)+1)+.5e-1*(4.0*x+8.00*z)/(1+(x+2.0*z)^4)*exp(.1-.5e-1*atan((x+2.0*z)^2))/(-.9-.5e-1*atan((x+2.0*z)^2))-.5e-1*exp(.1-.5e-1*atan((x+2.0*z)^2))/(-.9-.5e-1*atan((x+2.0*z)^2))^2*(4.0*x+8.00*z)/(1+(x+2.0*z)^4)+.5000000000e-1*exp(.5000000000e-1*z))/(.95+.25e-1*atan((x+2.0*z)^2))
     set Variable names      = x,z
@@ -100,7 +100,6 @@ subsection Initial composition model
   set Model name = function
 
   subsection Function
-    set Function constants = pi=3.14159265359
     set Function expression = 0.1-0.05*atan((x+2.0*z)*(x+2.0*z))
     set Variable names      = x,z
   end

--- a/tests/melting_rate.prm
+++ b/tests/melting_rate.prm
@@ -98,7 +98,7 @@ subsection Initial composition model
 
   subsection Function
     set Variable names      = x,y
-    set Function constants  = pi=3.1415926,x0=100000,y0=50000,c=10000
+    set Function constants  = x0=100000,y0=50000,c=10000
     set Function expression = 0.2 * exp(-((x-x0)*(x-x0)+(y-y0)*(y-y0))/(2*c*c)); 0.2 * exp(-((x-x0)*(x-x0)+(y-y0)*(y-y0))/(2*c*c))
   end
 end

--- a/tests/melting_rate_operator_splitting.prm
+++ b/tests/melting_rate_operator_splitting.prm
@@ -82,7 +82,7 @@ subsection Initial composition model
 
   subsection Function
     set Variable names      = x,y
-    set Function constants  = pi=3.1415926,x0=100000,y0=50000,c=10000
+    set Function constants  = x0=100000,y0=50000,c=10000
     set Function expression = 0.0; 0.0
   end
 end

--- a/tests/melting_rate_operator_splitting2.prm
+++ b/tests/melting_rate_operator_splitting2.prm
@@ -86,7 +86,7 @@ subsection Initial composition model
 
   subsection Function
     set Variable names      = x,y
-    set Function constants  = pi=3.1415926,x0=100000,y0=50000,c=10000
+    set Function constants  = x0=100000,y0=50000,c=10000
     set Function expression = 0.0; 0.0
   end
 end

--- a/tests/minimum_refinement_function.prm
+++ b/tests/minimum_refinement_function.prm
@@ -98,7 +98,6 @@ subsection Mesh refinement
   set Time steps between mesh refinement       = 1
 
   subsection Minimum refinement function
-    set Function constants  =
 
     # This is in fact the default value
     set Coordinate system   = depth

--- a/tests/minimum_refinement_function_cartesian.prm
+++ b/tests/minimum_refinement_function_cartesian.prm
@@ -99,7 +99,6 @@ subsection Mesh refinement
 
   subsection Minimum refinement function
     set Coordinate system      = cartesian
-    set Function constants     =
     set Function expression    = 4 + 2*sin(x*pi/250000)*sin(y*pi/250000)
     set Variable names         = x,y
   end

--- a/tests/minimum_refinement_function_spherical.prm
+++ b/tests/minimum_refinement_function_spherical.prm
@@ -91,7 +91,6 @@ subsection Mesh refinement
 
   subsection Minimum refinement function
     set Coordinate system      = spherical
-    set Function constants     =
     set Function expression    = 2 + 3*sin((r+250000)*pi/250000)*sin(6*phi)
     set Variable names         = r,phi
   end

--- a/tests/minimum_refinement_function_time_dependent.prm
+++ b/tests/minimum_refinement_function_time_dependent.prm
@@ -98,7 +98,6 @@ subsection Mesh refinement
   set Time steps between mesh refinement       = 1
 
   subsection Minimum refinement function
-    set Function constants  =
 
     # This is in fact the default value
     set Coordinate system   = depth

--- a/tests/n_expensive_stokes_solver_steps.prm
+++ b/tests/n_expensive_stokes_solver_steps.prm
@@ -58,7 +58,7 @@ subsection Initial temperature model
 
   subsection Function
     set Variable names      = x,z
-    set Function constants  = p=10.0, L=3.0e6, pi=3.1415926536, k=1
+    set Function constants  = p=10.0, L=3.0e6, k=1
     set Function expression = 2773.0 - z/L*(2500.0) + p*cos(k*pi*x/L)*sin(k*pi*z/L/2.0)
   end
 end

--- a/tests/newton_postprocess_nonlinear.prm
+++ b/tests/newton_postprocess_nonlinear.prm
@@ -111,7 +111,6 @@ subsection Initial composition model
 
   subsection Function
     set Variable names      = x,y
-    set Function constants  =
     set Function expression = 0; 0; 0; 0; 0; 0; \
                               if ( ( x<43.75e3 && y>25.e3 && y<75.e3) || (x>56.25e3 && y>25.e3 && y<75.e3) || (y>56.25e3 && y<75.e3 && x>=43.75e3 && x<=56.25e3) || (y<43.75e3 && y>25.e3 && x>=43.75e3 && x<=56.25e3), 1, 0); \
                               if (y<=25.e3 || y>=75.e3, 1, 0); \

--- a/tests/no_Advection_iterated_defect_correction_Stokes.prm
+++ b/tests/no_Advection_iterated_defect_correction_Stokes.prm
@@ -72,7 +72,7 @@ subsection Initial temperature model
   set Model name = function
 
   subsection Function
-    set Function constants  = pi=3.1415926,x0=150000,a = 0.2, b = 75000, c = 10000, d=0.0
+    set Function constants  = x0=150000,a = 0.2, b = 75000, c = 10000, d=0.0
     set Function expression = d + a * exp(-((x-b)*(x-b)+y*y)/(2*c*c))
     set Variable names      = x,y
   end
@@ -82,7 +82,7 @@ subsection Initial composition model
   set Model name = function
 
   subsection Function
-    set Function constants  = pi=3.1415926,x0=150000,a = 0.2, b = 75000, c = 10000, d=0.0
+    set Function constants  = x0=150000,a = 0.2, b = 75000, c = 10000, d=0.0
     set Function expression = d + a * exp(-((x-b)*(x-b)+y*y)/(2*c*c))
     set Variable names      = x,y
   end

--- a/tests/no_conduction_timestep.prm
+++ b/tests/no_conduction_timestep.prm
@@ -40,7 +40,6 @@ subsection Initial temperature model
 
   subsection Function
     set Variable names      = x,z
-    set Function constants  = pi=3.1415926
     set Function expression = 1600 + 100*sin(x*pi/200000.0)
   end
 end

--- a/tests/no_dirichlet_on_outflow.prm
+++ b/tests/no_dirichlet_on_outflow.prm
@@ -53,7 +53,7 @@ subsection Initial temperature model
 
   subsection Function
     set Variable names      = x,z
-    set Function constants  = p=0.01, L=1, pi=3.1415926536, k=1
+    set Function constants  = p=0.01, L=1, k=1
     set Function expression = (1.0-z) - p*cos(k*pi*x/L)*sin(pi*z)
   end
 end

--- a/tests/no_dirichlet_on_outflow_C.prm
+++ b/tests/no_dirichlet_on_outflow_C.prm
@@ -54,7 +54,7 @@ subsection Initial temperature model
 
   subsection Function
     set Variable names      = x,z
-    set Function constants  = p=0.01, L=1, pi=3.1415926536, k=1
+    set Function constants  = p=0.01, L=1, k=1
     set Function expression = (1.0-z) - p*cos(k*pi*x/L)*sin(pi*z)
   end
 end
@@ -68,7 +68,7 @@ subsection Initial composition model
 
   subsection Function
     set Variable names      = x,z
-    set Function constants  = p=0.01, L=1, pi=3.1415926536, k=1
+    set Function constants  = p=0.01, L=1, k=1
     set Function expression = (1.0-z) - p*cos(k*pi*x/L)*sin(pi*z)
   end
 end

--- a/tests/no_dirichlet_on_outflow_adaptive.prm
+++ b/tests/no_dirichlet_on_outflow_adaptive.prm
@@ -57,7 +57,7 @@ subsection Initial temperature model
 
   subsection Function
     set Variable names      = x,z
-    set Function constants  = p=0.01, L=1, pi=3.1415926536, k=1
+    set Function constants  = p=0.01, L=1, k=1
     set Function expression = (1.0-z) - p*cos(k*pi*x/L)*sin(pi*z)
   end
 end

--- a/tests/no_dirichlet_on_outflow_melt.prm
+++ b/tests/no_dirichlet_on_outflow_melt.prm
@@ -41,7 +41,7 @@ subsection Initial temperature model
 
   subsection Function
     set Variable names      = x,z
-    set Function constants  = p=0.01, L=100000, pi=3.1415926536, k=1
+    set Function constants  = p=0.01, L=100000, k=1
     set Function expression = 1600
   end
 end
@@ -60,7 +60,7 @@ subsection Initial composition model
 
   subsection Function
     set Variable names      = x,y
-    set Function constants  = pi=3.1415926,x0=50000,y0=50000,c=10000
+    set Function constants  = x0=50000,y0=50000,c=10000
     set Function expression = 0.2 * exp(-((x-x0)*(x-x0)+(y-y0)*(y-y0))/(2*c*c)); 0.2 * exp(-((x-x0)*(x-x0)+(y-y0)*(y-y0))/(2*c*c))
   end
 end

--- a/tests/no_dirichlet_on_outflow_only_new_constraints.prm
+++ b/tests/no_dirichlet_on_outflow_only_new_constraints.prm
@@ -53,7 +53,7 @@ subsection Initial temperature model
 
   subsection Function
     set Variable names      = x,z
-    set Function constants  = p=0.01, L=1, pi=3.1415926536, k=1
+    set Function constants  = p=0.01, L=1, k=1
     set Function expression = (1.0-z) - p*cos(k*pi*x/L)*sin(pi*z)
   end
 end

--- a/tests/nonlinear_convergence_for_small_composition.prm
+++ b/tests/nonlinear_convergence_for_small_composition.prm
@@ -104,7 +104,7 @@ subsection Initial composition model
   set Model name = function
 
   subsection Function
-    set Function constants  = pi=3.1415926,a = 0.0, b = 2500000, c = 100000, d=1450000
+    set Function constants  = a = 0.0, b = 2500000, c = 100000, d=1450000
     set Function expression = a * exp(-((y-b)*(y-b)+(0.2*(x-d))*(0.2*(x-d)))/(2*c*c)); a * exp(-((y-b)*(y-b)+(0.2*(x-d))*(0.2*(x-d)))/(2*c*c))
     set Variable names      = x,y
   end

--- a/tests/particles/particle_KDE_addition_3d.prm
+++ b/tests/particles/particle_KDE_addition_3d.prm
@@ -39,7 +39,6 @@ subsection Initial temperature model
 
   subsection Function
     set Variable names      = x,y,z
-    set Function constants  =
     set Function expression = 1
   end
 end

--- a/tests/particles/particle_KDE_deletion.prm
+++ b/tests/particles/particle_KDE_deletion.prm
@@ -40,7 +40,6 @@ subsection Initial temperature model
 
   subsection Function
     set Variable names      = x,y
-    set Function constants  =
     set Function expression = 1
   end
 end

--- a/tests/particles/particle_KDE_deletion_3d.prm
+++ b/tests/particles/particle_KDE_deletion_3d.prm
@@ -45,7 +45,6 @@ subsection Initial temperature model
 
   subsection Function
     set Variable names      = x,y,z
-    set Function constants  =
     set Function expression = 1
   end
 end

--- a/tests/particles/particle_distribution_score.prm
+++ b/tests/particles/particle_distribution_score.prm
@@ -37,7 +37,6 @@ subsection Initial temperature model
 
   subsection Function
     set Variable names      = x,y
-    set Function constants  =
     set Function expression = 1
   end
 end

--- a/tests/particles/particle_distribution_score_3d.prm
+++ b/tests/particles/particle_distribution_score_3d.prm
@@ -39,7 +39,6 @@ subsection Initial temperature model
 
   subsection Function
     set Variable names      = x,y,z
-    set Function constants  =
     set Function expression = 1
   end
 end

--- a/tests/particles/particle_distribution_statistics.prm
+++ b/tests/particles/particle_distribution_statistics.prm
@@ -39,7 +39,6 @@ subsection Initial temperature model
 
   subsection Function
     set Variable names      = x,y,z
-    set Function constants  =
     set Function expression = 1
   end
 end

--- a/tests/particles/particle_distribution_statistics_per_particle.prm
+++ b/tests/particles/particle_distribution_statistics_per_particle.prm
@@ -40,7 +40,6 @@ subsection Initial temperature model
 
   subsection Function
     set Variable names      = x,y,z
-    set Function constants  =
     set Function expression = 1
   end
 end

--- a/tests/particles/particle_distribution_statistics_singlecell.prm
+++ b/tests/particles/particle_distribution_statistics_singlecell.prm
@@ -35,7 +35,6 @@ subsection Initial temperature model
 
   subsection Function
     set Variable names      = x,y
-    set Function constants  =
     set Function expression = 1
   end
 end

--- a/tests/particles/particle_exclude_all_properties.prm
+++ b/tests/particles/particle_exclude_all_properties.prm
@@ -39,7 +39,6 @@ subsection Boundary velocity model
 
   subsection Function
     set Variable names      = x,z,t
-    set Function constants  = pi=3.1415926
     set Function expression = if(x>1+sin(0.5*pi*t), 1, -1); 0
   end
 end

--- a/tests/particles/particle_exclude_one_property.prm
+++ b/tests/particles/particle_exclude_one_property.prm
@@ -39,7 +39,6 @@ subsection Boundary velocity model
 
   subsection Function
     set Variable names      = x,z,t
-    set Function constants  = pi=3.1415926
     set Function expression = if(x>1+sin(0.5*pi*t), 1, -1); 0
   end
 end

--- a/tests/particles/particle_exclude_one_property_vtu.prm
+++ b/tests/particles/particle_exclude_one_property_vtu.prm
@@ -39,7 +39,6 @@ subsection Boundary velocity model
 
   subsection Function
     set Variable names      = x,z,t
-    set Function constants  = pi=3.1415926
     set Function expression = if(x>1+sin(0.5*pi*t), 1, -1); 0
   end
 end

--- a/tests/particles/particle_exclude_three_properties_vtu.prm
+++ b/tests/particles/particle_exclude_three_properties_vtu.prm
@@ -39,7 +39,6 @@ subsection Boundary velocity model
 
   subsection Function
     set Variable names      = x,z,t
-    set Function constants  = pi=3.1415926
     set Function expression = if(x>1+sin(0.5*pi*t), 1, -1); 0
   end
 end

--- a/tests/particles/particle_exclude_two_properties_vtu.prm
+++ b/tests/particles/particle_exclude_two_properties_vtu.prm
@@ -39,7 +39,6 @@ subsection Boundary velocity model
 
   subsection Function
     set Variable names      = x,z,t
-    set Function constants  = pi=3.1415926
     set Function expression = if(x>1+sin(0.5*pi*t), 1, -1); 0
   end
 end

--- a/tests/particles/particle_free_surface.prm
+++ b/tests/particles/particle_free_surface.prm
@@ -66,7 +66,6 @@ subsection Initial composition model
 
   subsection Function
     set Variable names      = x,z
-    set Function constants  = pi=3.1415926
     set Function expression = 0.5*(1+tanh((0.2+0.02*cos(pi*x/0.9142)-z)/0.02))
   end
 end

--- a/tests/particles/particle_generator_ascii.prm
+++ b/tests/particles/particle_generator_ascii.prm
@@ -67,7 +67,6 @@ subsection Initial composition model
 
   subsection Function
     set Variable names      = x,z
-    set Function constants  = pi=3.1415926
     set Function expression = 0.5*(1+tanh((0.2+0.02*cos(pi*x/0.9142)-z)/0.02))
   end
 end

--- a/tests/particles/particle_generator_box.prm
+++ b/tests/particles/particle_generator_box.prm
@@ -65,7 +65,6 @@ subsection Initial composition model
 
   subsection Function
     set Variable names      = x,z
-    set Function constants  = pi=3.1415926
     set Function expression = 0.5*(1+tanh((0.2+0.02*cos(pi*x/0.9142)-z)/0.02))
   end
 end

--- a/tests/particles/particle_generator_box_3d.prm
+++ b/tests/particles/particle_generator_box_3d.prm
@@ -67,7 +67,6 @@ subsection Initial composition model
 
   subsection Function
     set Variable names      = x,y,z
-    set Function constants  = pi=3.1415926
     set Function expression = 0.5*(1+tanh((0.2+0.02*cos(pi*x/0.9142)-z)/0.02))
   end
 end

--- a/tests/particles/particle_generator_probability_default_value.prm
+++ b/tests/particles/particle_generator_probability_default_value.prm
@@ -59,7 +59,6 @@ subsection Initial composition model
 
   subsection Function
     set Variable names      = x,z
-    set Function constants  = pi=3.1415926
     set Function expression = 0.5*(1+tanh((0.2+0.02*cos(pi*x/0.9142)-z)/0.02))
   end
 end

--- a/tests/particles/particle_generator_quadrature_points.prm
+++ b/tests/particles/particle_generator_quadrature_points.prm
@@ -67,7 +67,6 @@ subsection Initial composition model
 
   subsection Function
     set Variable names      = x,z
-    set Function constants  = pi=3.1415926
     set Function expression = 0.5*(1+tanh((0.2+0.02*cos(pi*x/0.9142)-z)/0.02))
   end
 end

--- a/tests/particles/particle_generator_radial.prm
+++ b/tests/particles/particle_generator_radial.prm
@@ -65,7 +65,6 @@ subsection Initial composition model
 
   subsection Function
     set Variable names      = x,z
-    set Function constants  = pi=3.1415926
     set Function expression = 0.5*(1+tanh((0.2+0.02*cos(pi*x/0.9142)-z)/0.02))
   end
 end

--- a/tests/particles/particle_generator_random_uniform.prm
+++ b/tests/particles/particle_generator_random_uniform.prm
@@ -64,7 +64,6 @@ subsection Initial composition model
 
   subsection Function
     set Variable names      = x,z
-    set Function constants  = pi=3.1415926
     set Function expression = 0.5*(1+tanh((0.2+0.02*cos(pi*x/0.9142)-z)/0.02))
   end
 end

--- a/tests/particles/particle_generator_random_uniform_3mpi_1particle.prm
+++ b/tests/particles/particle_generator_random_uniform_3mpi_1particle.prm
@@ -64,7 +64,6 @@ subsection Initial composition model
 
   subsection Function
     set Variable names      = x,z
-    set Function constants  = pi=3.1415926
     set Function expression = 0.5*(1+tanh((0.2+0.02*cos(pi*x/0.9142)-z)/0.02))
   end
 end

--- a/tests/particles/particle_generator_random_uniform_3mpi_2particle.prm
+++ b/tests/particles/particle_generator_random_uniform_3mpi_2particle.prm
@@ -64,7 +64,6 @@ subsection Initial composition model
 
   subsection Function
     set Variable names      = x,z
-    set Function constants  = pi=3.1415926
     set Function expression = 0.5*(1+tanh((0.2+0.02*cos(pi*x/0.9142)-z)/0.02))
   end
 end

--- a/tests/particles/particle_generator_random_uniform_3mpi_3particle.prm
+++ b/tests/particles/particle_generator_random_uniform_3mpi_3particle.prm
@@ -64,7 +64,6 @@ subsection Initial composition model
 
   subsection Function
     set Variable names      = x,z
-    set Function constants  = pi=3.1415926
     set Function expression = 0.5*(1+tanh((0.2+0.02*cos(pi*x/0.9142)-z)/0.02))
   end
 end

--- a/tests/particles/particle_generator_random_uniform_3mpi_4particle.prm
+++ b/tests/particles/particle_generator_random_uniform_3mpi_4particle.prm
@@ -64,7 +64,6 @@ subsection Initial composition model
 
   subsection Function
     set Variable names      = x,z
-    set Function constants  = pi=3.1415926
     set Function expression = 0.5*(1+tanh((0.2+0.02*cos(pi*x/0.9142)-z)/0.02))
   end
 end

--- a/tests/particles/particle_generator_random_uniform_deterministic_cell.prm
+++ b/tests/particles/particle_generator_random_uniform_deterministic_cell.prm
@@ -65,7 +65,6 @@ subsection Initial composition model
 
   subsection Function
     set Variable names      = x,z
-    set Function constants  = pi=3.1415926
     set Function expression = 0.5*(1+tanh((0.2+0.02*cos(pi*x/0.9142)-z)/0.02))
   end
 end

--- a/tests/particles/particle_generator_random_uniform_empty_rank.prm
+++ b/tests/particles/particle_generator_random_uniform_empty_rank.prm
@@ -64,7 +64,6 @@ subsection Initial composition model
 
   subsection Function
     set Variable names      = x,z
-    set Function constants  = pi=3.1415926
     set Function expression = 0.5*(1+tanh((0.2+0.02*cos(pi*x/0.9142)-z)/0.02))
   end
 end

--- a/tests/particles/particle_generator_reference_cell.prm
+++ b/tests/particles/particle_generator_reference_cell.prm
@@ -67,7 +67,6 @@ subsection Initial composition model
 
   subsection Function
     set Variable names      = x,z
-    set Function constants  = pi=3.1415926
     set Function expression = 0.5*(1+tanh((0.2+0.02*cos(pi*x/0.9142)-z)/0.02))
   end
 end

--- a/tests/particles/particle_handler_copy.prm
+++ b/tests/particles/particle_handler_copy.prm
@@ -57,7 +57,6 @@ subsection Initial composition model
 
   subsection Function
     set Variable names      = x,z
-    set Function constants  = pi=3.1415926
     set Function expression = 0.5*(1+tanh((0.2+0.02*cos(pi*x/0.9142)-z)/0.02))
   end
 end

--- a/tests/particles/particle_histogram_addition.prm
+++ b/tests/particles/particle_histogram_addition.prm
@@ -25,7 +25,6 @@ subsection Initial temperature model
 
   subsection Function
     set Variable names      = x,y
-    set Function constants  =
     set Function expression = 1
   end
 end

--- a/tests/particles/particle_histogram_addition_3d.prm
+++ b/tests/particles/particle_histogram_addition_3d.prm
@@ -39,7 +39,6 @@ subsection Initial temperature model
 
   subsection Function
     set Variable names      = x,y,z
-    set Function constants  =
     set Function expression = 1
   end
 end

--- a/tests/particles/particle_histogram_addition_singlecell.prm
+++ b/tests/particles/particle_histogram_addition_singlecell.prm
@@ -39,7 +39,6 @@ subsection Initial temperature model
 
   subsection Function
     set Variable names      = x,y
-    set Function constants  =
     set Function expression = 1
   end
 end

--- a/tests/particles/particle_initial_adaptive_output.prm
+++ b/tests/particles/particle_initial_adaptive_output.prm
@@ -64,7 +64,6 @@ subsection Initial composition model
 
   subsection Function
     set Variable names      = x,z
-    set Function constants  = pi=3.1415926
     set Function expression = 0.5*(1+tanh((0.2+0.02*cos(pi*x/0.9142)-z)/0.02))
   end
 end

--- a/tests/particles/particle_initial_adaptive_refinement.prm
+++ b/tests/particles/particle_initial_adaptive_refinement.prm
@@ -65,7 +65,6 @@ subsection Initial composition model
 
   subsection Function
     set Variable names      = x,z
-    set Function constants  = pi=3.1415926
     set Function expression = 0.5*(1+tanh((0.2+0.02*cos(pi*x/0.9142)-z)/0.02))
   end
 end

--- a/tests/particles/particle_integrator_euler.prm
+++ b/tests/particles/particle_integrator_euler.prm
@@ -65,7 +65,6 @@ subsection Initial composition model
 
   subsection Function
     set Variable names      = x,z
-    set Function constants  = pi=3.1415926
     set Function expression = 0.5*(1+tanh((0.2+0.02*cos(pi*x/0.9142)-z)/0.02))
   end
 end

--- a/tests/particles/particle_integrator_rk4.prm
+++ b/tests/particles/particle_integrator_rk4.prm
@@ -65,7 +65,6 @@ subsection Initial composition model
 
   subsection Function
     set Variable names      = x,z
-    set Function constants  = pi=3.1415926
     set Function expression = 0.5*(1+tanh((0.2+0.02*cos(pi*x/0.9142)-z)/0.02))
   end
 end

--- a/tests/particles/particle_interpolator_cell_average.prm
+++ b/tests/particles/particle_interpolator_cell_average.prm
@@ -68,7 +68,6 @@ subsection Initial composition model
 
   subsection Function
     set Variable names      = x,z
-    set Function constants  = pi=3.1415926
     set Function expression = 0.5*(1+tanh((0.2+0.02*cos(pi*x/0.9142)-z)/0.02));0.0;0.0
   end
 end

--- a/tests/particles/particle_interpolator_cell_average_2.prm
+++ b/tests/particles/particle_interpolator_cell_average_2.prm
@@ -37,7 +37,6 @@ subsection Boundary velocity model
 
   subsection Function
     set Variable names      = x,z,t
-    set Function constants  = pi=3.1415926
     set Function expression = if(x>1+sin(0.5*pi*t), 1, -1); 0
   end
 end

--- a/tests/particles/particle_interpolator_distance_weighted_average.prm
+++ b/tests/particles/particle_interpolator_distance_weighted_average.prm
@@ -68,7 +68,6 @@ subsection Initial composition model
 
   subsection Function
     set Variable names      = x,z
-    set Function constants  = pi=3.1415926
     set Function expression = 0.5*(1+tanh((0.2+0.02*cos(pi*x/0.9142)-z)/0.02));0.0;0.0
   end
 end

--- a/tests/particles/particle_interpolator_harmonic_average_solkz.prm
+++ b/tests/particles/particle_interpolator_harmonic_average_solkz.prm
@@ -78,7 +78,7 @@ subsection Initial composition model
 
   subsection Function
     set Variable names      = x,z
-    set Function constants  = pi=3.1415926, eta_b=1e6
+    set Function constants  =  eta_b=1e6
     set Function expression = 1 - sin(2*z) * cos(3*pi*x); exp(log(eta_b)*z)
   end
 end
@@ -106,7 +106,7 @@ subsection Particles
   subsection Function
     set Number of components = 2
     set Variable names      = x, z
-    set Function constants  = pi=3.1415926, eta_b=1e6
+    set Function constants  =  eta_b=1e6
     set Function expression = 1 - sin(2*z) * cos(3*pi*x); exp(log(eta_b)*z)
   end
 

--- a/tests/particles/particle_interpolator_linear_add_particles.prm
+++ b/tests/particles/particle_interpolator_linear_add_particles.prm
@@ -70,7 +70,7 @@ subsection Initial composition model
 
   subsection Function
     set Variable names      = x,z
-    set Function constants  = pi=3.1415926, eta_b=1e6
+    set Function constants  = eta_b=1e6
     set Function expression = -1 * sin(2*z) * cos(3*pi*x); exp(log(eta_b)*z)
   end
 end
@@ -98,7 +98,7 @@ subsection Particles
   subsection Function
     set Number of components = 2
     set Variable names      = x, z
-    set Function constants  = pi=3.1415926, eta_b=1e6
+    set Function constants  = eta_b=1e6
     set Function expression =  -1 * sin(2*z) * cos(3*pi*x); exp(log(eta_b)*z)
   end
 

--- a/tests/particles/particle_interpolator_linear_least_squares_solkz.prm
+++ b/tests/particles/particle_interpolator_linear_least_squares_solkz.prm
@@ -70,7 +70,7 @@ subsection Initial composition model
 
   subsection Function
     set Variable names      = x,z
-    set Function constants  = pi=3.1415926, eta_b=1e6
+    set Function constants  = eta_b=1e6
     set Function expression = -1 * sin(2*z) * cos(3*pi*x); exp(log(eta_b)*z)
   end
 end
@@ -96,7 +96,7 @@ subsection Particles
   subsection Function
     set Number of components = 2
     set Variable names      = x, z
-    set Function constants  = pi=3.1415926, eta_b=1e6
+    set Function constants  = eta_b=1e6
     set Function expression =  -1 * sin(2*z) * cos(3*pi*x); exp(log(eta_b)*z)
   end
 

--- a/tests/particles/particle_interpolator_nearest_neighbor.prm
+++ b/tests/particles/particle_interpolator_nearest_neighbor.prm
@@ -68,7 +68,6 @@ subsection Initial composition model
 
   subsection Function
     set Variable names      = x,z
-    set Function constants  = pi=3.1415926
     set Function expression = if(z>(0.4+0.02*cos(pi*x/0.9142)),1,0);0.0;0.0
   end
 end

--- a/tests/particles/particle_interpolator_quadratic_least_squares_2d_add_particles.prm
+++ b/tests/particles/particle_interpolator_quadratic_least_squares_2d_add_particles.prm
@@ -73,7 +73,7 @@ subsection Initial composition model
 
   subsection Function
     set Variable names      = x,z
-    set Function constants  = pi=3.1415926, eta_b=1e6
+    set Function constants  = eta_b=1e6
     set Function expression = -1 * sin(2*z) * cos(3*pi*x); exp(log(eta_b)*z)
   end
 end
@@ -101,7 +101,7 @@ subsection Particles
   subsection Function
     set Number of components = 2
     set Variable names      = x, z
-    set Function constants  = pi=3.1415926, eta_b=1e6
+    set Function constants  = eta_b=1e6
     set Function expression =  -1 * sin(2*z) * cos(3*pi*x); exp(log(eta_b)*z)
   end
 

--- a/tests/particles/particle_load_balancing_none.prm
+++ b/tests/particles/particle_load_balancing_none.prm
@@ -66,7 +66,6 @@ subsection Initial composition model
 
   subsection Function
     set Variable names      = x,z
-    set Function constants  = pi=3.1415926
     set Function expression = 0.5*(1+tanh((0.2+0.02*cos(pi*x/0.9142)-z)/0.02))
   end
 end

--- a/tests/particles/particle_load_balancing_refinement.prm
+++ b/tests/particles/particle_load_balancing_refinement.prm
@@ -63,7 +63,6 @@ subsection Initial composition model
 
   subsection Function
     set Variable names      = x,z
-    set Function constants  = pi=3.1415926
     set Function expression = 0.5*(1+tanh((0.2+0.02*cos(pi*x/0.9142)-z)/0.02))
   end
 end

--- a/tests/particles/particle_load_balancing_refinement_02.prm
+++ b/tests/particles/particle_load_balancing_refinement_02.prm
@@ -63,7 +63,6 @@ subsection Initial composition model
 
   subsection Function
     set Variable names      = x,z
-    set Function constants  = pi=3.1415926
     set Function expression = 0.5*(1+tanh((0.2+0.02*cos(pi*x/0.9142)-z)/0.02))
   end
 end

--- a/tests/particles/particle_load_balancing_removal.prm
+++ b/tests/particles/particle_load_balancing_removal.prm
@@ -63,7 +63,6 @@ subsection Initial composition model
 
   subsection Function
     set Variable names      = x,z
-    set Function constants  = pi=3.1415926
     set Function expression = 0.5*(1+tanh((0.2+0.02*cos(pi*x/0.9142)-z)/0.02))
   end
 end

--- a/tests/particles/particle_load_balancing_removal_addition.prm
+++ b/tests/particles/particle_load_balancing_removal_addition.prm
@@ -65,7 +65,6 @@ subsection Initial composition model
 
   subsection Function
     set Variable names      = x,z
-    set Function constants  = pi=3.1415926
     set Function expression = 0.5*(1+tanh((0.2+0.02*cos(pi*x/0.9142)-z)/0.02))
   end
 end

--- a/tests/particles/particle_load_balancing_removal_addition_properties.prm
+++ b/tests/particles/particle_load_balancing_removal_addition_properties.prm
@@ -64,7 +64,6 @@ subsection Initial composition model
 
   subsection Function
     set Variable names      = x,z
-    set Function constants  = pi=3.1415926
     set Function expression = 0.5*(1+tanh((0.2+0.02*cos(pi*x/0.9142)-z)/0.02))
   end
 end

--- a/tests/particles/particle_load_balancing_repartition_multiple_systems.prm
+++ b/tests/particles/particle_load_balancing_repartition_multiple_systems.prm
@@ -76,7 +76,6 @@ subsection Initial composition model
 
   subsection Function
     set Variable names      = x,z
-    set Function constants  = pi=3.1415926
     set Function expression = 0.5*(1+tanh((0.2+0.02*cos(pi*x/0.9142)-z)/0.02))
   end
 end

--- a/tests/particles/particle_melt_advection.prm
+++ b/tests/particles/particle_melt_advection.prm
@@ -91,7 +91,7 @@ subsection Initial composition model
 
   subsection Function
     set Variable names      = x,y
-    set Function constants  = pi=3.1415926,x0=100000,y0=50000,c=10000
+    set Function constants  = x0=100000,y0=50000,c=10000
     set Function expression = 0.2 * exp(-((x-x0)*(x-x0)+(y-y0)*(y-y0))/(2*c*c)); 0.2 * exp(-((x-x0)*(x-x0)+(y-y0)*(y-y0))/(2*c*c))
   end
 end

--- a/tests/particles/particle_multiple_systems.prm
+++ b/tests/particles/particle_multiple_systems.prm
@@ -58,7 +58,6 @@ subsection Initial composition model
 
   subsection Function
     set Variable names      = x,z
-    set Function constants  = pi=3.1415926
     set Function expression = 0.5*(1+tanh((0.2+0.02*cos(pi*x/0.9142)-z)/0.02))
   end
 end
@@ -100,7 +99,6 @@ subsection Particles 2
 
   subsection Function
     set Variable names      = x,z
-    set Function constants  = pi=3.1415926
     set Function expression = 0.5*(1+tanh((0.2+0.02*cos(pi*x/0.9142)-z)/0.02))
   end
 

--- a/tests/particles/particle_multiple_systems_hdf5.prm
+++ b/tests/particles/particle_multiple_systems_hdf5.prm
@@ -59,7 +59,6 @@ subsection Initial composition model
 
   subsection Function
     set Variable names      = x,z
-    set Function constants  = pi=3.1415926
     set Function expression = 0.5*(1+tanh((0.2+0.02*cos(pi*x/0.9142)-z)/0.02))
   end
 end
@@ -101,7 +100,6 @@ subsection Particles 2
 
   subsection Function
     set Variable names      = x,z
-    set Function constants  = pi=3.1415926
     set Function expression = 0.5*(1+tanh((0.2+0.02*cos(pi*x/0.9142)-z)/0.02))
   end
 

--- a/tests/particles/particle_multiple_systems_hdf5_gnuplot.prm
+++ b/tests/particles/particle_multiple_systems_hdf5_gnuplot.prm
@@ -60,7 +60,6 @@ subsection Initial composition model
 
   subsection Function
     set Variable names      = x,z
-    set Function constants  = pi=3.1415926
     set Function expression = 0.5*(1+tanh((0.2+0.02*cos(pi*x/0.9142)-z)/0.02))
   end
 end
@@ -102,7 +101,6 @@ subsection Particles 2
 
   subsection Function
     set Variable names      = x,z
-    set Function constants  = pi=3.1415926
     set Function expression = 0.5*(1+tanh((0.2+0.02*cos(pi*x/0.9142)-z)/0.02))
   end
 

--- a/tests/particles/particle_multiple_systems_interpolation.prm
+++ b/tests/particles/particle_multiple_systems_interpolation.prm
@@ -59,7 +59,6 @@ subsection Initial composition model
 
   subsection Function
     set Variable names      = x,z
-    set Function constants  = pi=3.1415926
     set Function expression = 0.5*(1+tanh((0.2+0.02*cos(pi*x/0.9142)-z)/0.02)); 0.0
   end
 end
@@ -101,7 +100,6 @@ subsection Particles 2
 
   subsection Function
     set Variable names      = x,z
-    set Function constants  = pi=3.1415926
     set Function expression = x
   end
 end

--- a/tests/particles/particle_multiple_systems_interpolation_fail_1.prm
+++ b/tests/particles/particle_multiple_systems_interpolation_fail_1.prm
@@ -70,7 +70,6 @@ subsection Initial composition model
 
   subsection Function
     set Variable names      = x,z
-    set Function constants  = pi=3.1415926
     set Function expression = 0.5*(1+tanh((0.2+0.02*cos(pi*x/0.9142)-z)/0.02)); 0.0
   end
 end
@@ -114,7 +113,6 @@ subsection Particles 2
 
   subsection Function
     set Variable names      = x,z
-    set Function constants  = pi=3.1415926
     set Function expression = x
   end
 end

--- a/tests/particles/particle_multiple_systems_interpolation_fail_2.prm
+++ b/tests/particles/particle_multiple_systems_interpolation_fail_2.prm
@@ -70,7 +70,6 @@ subsection Initial composition model
 
   subsection Function
     set Variable names      = x,z
-    set Function constants  = pi=3.1415926
     set Function expression = 0.5*(1+tanh((0.2+0.02*cos(pi*x/0.9142)-z)/0.02)); 0.0
   end
 end
@@ -114,7 +113,6 @@ subsection Particles 2
 
   subsection Function
     set Variable names      = x,z
-    set Function constants  = pi=3.1415926
     set Function expression = x
   end
 end

--- a/tests/particles/particle_multiple_systems_vtu.prm
+++ b/tests/particles/particle_multiple_systems_vtu.prm
@@ -59,7 +59,6 @@ subsection Initial composition model
 
   subsection Function
     set Variable names      = x,z
-    set Function constants  = pi=3.1415926
     set Function expression = 0.5*(1+tanh((0.2+0.02*cos(pi*x/0.9142)-z)/0.02))
   end
 end
@@ -101,7 +100,6 @@ subsection Particles 2
 
   subsection Function
     set Variable names      = x,z
-    set Function constants  = pi=3.1415926
     set Function expression = 0.5*(1+tanh((0.2+0.02*cos(pi*x/0.9142)-z)/0.02))
   end
 

--- a/tests/particles/particle_output_gnuplot.prm
+++ b/tests/particles/particle_output_gnuplot.prm
@@ -63,7 +63,6 @@ subsection Initial composition model
 
   subsection Function
     set Variable names      = x,z
-    set Function constants  = pi=3.1415926
     set Function expression = 0.5*(1+tanh((0.2+0.02*cos(pi*x/0.9142)-z)/0.02))
   end
 end

--- a/tests/particles/particle_output_hdf5.prm
+++ b/tests/particles/particle_output_hdf5.prm
@@ -63,7 +63,6 @@ subsection Initial composition model
 
   subsection Function
     set Variable names      = x,z
-    set Function constants  = pi=3.1415926
     set Function expression = 0.5*(1+tanh((0.2+0.02*cos(pi*x/0.9142)-z)/0.02))
   end
 end

--- a/tests/particles/particle_output_multiple_formats.prm
+++ b/tests/particles/particle_output_multiple_formats.prm
@@ -62,7 +62,6 @@ subsection Initial composition model
 
   subsection Function
     set Variable names      = x,z
-    set Function constants  = pi=3.1415926
     set Function expression = 0.5*(1+tanh((0.2+0.02*cos(pi*x/0.9142)-z)/0.02))
   end
 end

--- a/tests/particles/particle_output_none.prm
+++ b/tests/particles/particle_output_none.prm
@@ -66,7 +66,6 @@ subsection Initial composition model
 
   subsection Function
     set Variable names      = x,y,z
-    set Function constants  = pi=3.1415926
     set Function expression = 0.5*(1+tanh((0.2+0.02*cos(pi*x/0.9142)-z)/0.02))
   end
 end

--- a/tests/particles/particle_output_vtu.prm
+++ b/tests/particles/particle_output_vtu.prm
@@ -63,7 +63,6 @@ subsection Initial composition model
 
   subsection Function
     set Variable names      = x,z
-    set Function constants  = pi=3.1415926
     set Function expression = 0.5*(1+tanh((0.2+0.02*cos(pi*x/0.9142)-z)/0.02))
   end
 end

--- a/tests/particles/particle_output_vtu_group.prm
+++ b/tests/particles/particle_output_vtu_group.prm
@@ -65,7 +65,6 @@ subsection Initial composition model
 
   subsection Function
     set Variable names      = x,z
-    set Function constants  = pi=3.1415926
     set Function expression = 0.5*(1+tanh((0.2+0.02*cos(pi*x/0.9142)-z)/0.02))
   end
 end

--- a/tests/particles/particle_output_vtu_temp.prm
+++ b/tests/particles/particle_output_vtu_temp.prm
@@ -64,7 +64,6 @@ subsection Initial composition model
 
   subsection Function
     set Variable names      = x,z
-    set Function constants  = pi=3.1415926
     set Function expression = 0.5*(1+tanh((0.2+0.02*cos(pi*x/0.9142)-z)/0.02))
   end
 end

--- a/tests/particles/particle_periodic_boundaries.prm
+++ b/tests/particles/particle_periodic_boundaries.prm
@@ -71,7 +71,6 @@ subsection Initial composition model
 
   subsection Function
     set Variable names      = x,z
-    set Function constants  = pi=3.1415926
     set Function expression = 0.5*(1+tanh((0.2+0.02*cos(pi*x/0.9142)-z)/0.02))
   end
 end

--- a/tests/particles/particle_periodic_boundaries_rk4.prm
+++ b/tests/particles/particle_periodic_boundaries_rk4.prm
@@ -70,7 +70,6 @@ subsection Initial composition model
 
   subsection Function
     set Variable names      = x,z
-    set Function constants  = pi=3.1415926
     set Function expression = 0.5*(1+tanh((0.2+0.02*cos(pi*x/0.9142)-z)/0.02))
   end
 end

--- a/tests/particles/particle_periodic_half_shell.prm
+++ b/tests/particles/particle_periodic_half_shell.prm
@@ -70,7 +70,6 @@ subsection Initial composition model
 
   subsection Function
     set Variable names = r, phi
-    set Function constants  = pi=3.1415926
     set Coordinate system = spherical
     set Function expression = if( r < 4.195 + (0.3*sin(3*phi)) + (0.3*cos(3*phi)), 1, 0)
   end

--- a/tests/particles/particle_periodic_half_shell_2.prm
+++ b/tests/particles/particle_periodic_half_shell_2.prm
@@ -74,7 +74,6 @@ subsection Initial composition model
 
   subsection Function
     set Variable names = r, phi
-    set Function constants  = pi=3.1415926
     set Coordinate system = spherical
     set Function expression = if( r < 4.195 + (0.3*sin(3*phi)) + (0.3*cos(3*phi)), 1, 0)
   end

--- a/tests/particles/particle_periodic_quarter_shell.prm
+++ b/tests/particles/particle_periodic_quarter_shell.prm
@@ -70,7 +70,6 @@ subsection Initial composition model
 
   subsection Function
     set Variable names = r, phi
-    set Function constants  = pi=3.1415926
     set Coordinate system = spherical
     set Function expression = if( r < 4.195 + (0.3*sin(3*phi)) + (0.3*cos(3*phi)), 1, 0)
   end

--- a/tests/particles/particle_periodic_quarter_shell_2.prm
+++ b/tests/particles/particle_periodic_quarter_shell_2.prm
@@ -77,7 +77,6 @@ subsection Initial composition model
 
   subsection Function
     set Variable names = r, phi
-    set Function constants  = pi=3.1415926
     set Coordinate system = spherical
     set Function expression = if( r < 4.195 + (0.3*sin(3*phi)) + (0.3*cos(3*phi)), 1, 0)
   end

--- a/tests/particles/particle_property_composition_reaction.prm
+++ b/tests/particles/particle_property_composition_reaction.prm
@@ -72,7 +72,6 @@ subsection Initial composition model
 
   subsection Function
     set Variable names      = x,z
-    set Function constants  = pi=3.1415926
     set Function expression = 0.5*(1+tanh((0.2+0.02*cos(pi*x/0.9142)-z)/0.02));x;0.0
   end
 end

--- a/tests/particles/particle_property_function.prm
+++ b/tests/particles/particle_property_function.prm
@@ -67,7 +67,6 @@ subsection Initial composition model
 
   subsection Function
     set Variable names      = x,z
-    set Function constants  = pi=3.1415926
     set Function expression = 0.5*(1+tanh((0.2+0.02*cos(pi*x/0.9142)-z)/0.02))
   end
 end

--- a/tests/particles/particle_property_initial_composition.prm
+++ b/tests/particles/particle_property_initial_composition.prm
@@ -68,7 +68,6 @@ subsection Initial composition model
 
   subsection Function
     set Variable names      = x,z
-    set Function constants  = pi=3.1415926
     set Function expression = 0.5*(1+tanh((0.2+0.02*cos(pi*x/0.9142)-z)/0.02))
   end
 end

--- a/tests/particles/particle_property_initial_composition_boundary.prm
+++ b/tests/particles/particle_property_initial_composition_boundary.prm
@@ -59,7 +59,6 @@ subsection Initial composition model
 
   subsection Function
     set Variable names      = x,z
-    set Function constants  = pi=3.1415926
     set Function expression = 0.5*(1+tanh((0.2+0.02*cos(pi*x/0.9142)-z)/0.02))
   end
 end

--- a/tests/particles/particle_property_multiple_functions.prm
+++ b/tests/particles/particle_property_multiple_functions.prm
@@ -68,7 +68,6 @@ subsection Initial composition model
 
   subsection Function
     set Variable names      = x,z
-    set Function constants  = pi=3.1415926
     set Function expression = 0.5*(1+tanh((0.2+0.02*cos(pi*x/0.9142)-z)/0.02))
   end
 end

--- a/tests/particles/particle_property_multiple_functions_with_interpolation.prm
+++ b/tests/particles/particle_property_multiple_functions_with_interpolation.prm
@@ -70,7 +70,6 @@ subsection Initial composition model
 
   subsection Function
     set Variable names      = x,z
-    set Function constants  = pi=3.1415926
     set Function expression = 0.5*(1+tanh((0.2+0.02*cos(pi*x/0.9142)-z)/0.02));0.0;0.0
   end
 end

--- a/tests/particles/particle_property_post_initialize_function.prm
+++ b/tests/particles/particle_property_post_initialize_function.prm
@@ -33,7 +33,6 @@ subsection Boundary velocity model
 
   subsection Function
     set Variable names      = x,z,t
-    set Function constants  = pi=3.1415926
     set Function expression = if(x>1+sin(0.5*pi*t), 1, -1); 0
   end
 end

--- a/tests/particles/particle_score_statistics_multiple_particle_managers.prm
+++ b/tests/particles/particle_score_statistics_multiple_particle_managers.prm
@@ -24,7 +24,6 @@ subsection Initial temperature model
 
   subsection Function
     set Variable names      = x,y
-    set Function constants  =
     set Function expression = 1
   end
 end

--- a/tests/particles/particle_timing_information.prm
+++ b/tests/particles/particle_timing_information.prm
@@ -66,7 +66,6 @@ subsection Initial composition model
 
   subsection Function
     set Variable names      = x,z
-    set Function constants  = pi=3.1415926
     set Function expression = 0.5*(1+tanh((0.2+0.02*cos(pi*x/0.9142)-z)/0.02))
   end
 end

--- a/tests/particles/particle_visualization_particle_count.prm
+++ b/tests/particles/particle_visualization_particle_count.prm
@@ -63,7 +63,6 @@ subsection Initial composition model
 
   subsection Function
     set Variable names      = x,z
-    set Function constants  = pi=3.1415926
     set Function expression = 0.5*(1+tanh((0.2+0.02*cos(pi*x/0.9142)-z)/0.02))
   end
 end

--- a/tests/passive_comp.prm
+++ b/tests/passive_comp.prm
@@ -214,7 +214,6 @@ subsection Boundary velocity model
     set Variable names      = x,y
 
     # Any constant used inside the function which is not a variable name.
-    set Function constants  = pi=3.1415926
 
     # Vector valued expression for the velocity; separate components by ';'
     set Function expression = if(x>0,-1.e-14*sqrt(x*x+y*y)*sin(atan(y/x)),1.e-14*sqrt(x*x+y*y)*sin(atan(y/x))); if(x>0,1.e-14*sqrt(x*x+y*y)*cos(atan(y/x)),-1.e-14*sqrt(x*x+y*y)*cos(atan(y/x)))

--- a/tests/postprocess_initial.prm
+++ b/tests/postprocess_initial.prm
@@ -34,7 +34,6 @@ subsection Boundary velocity model
 
   subsection Function
     set Variable names      = x,z,t
-    set Function constants  = pi=3.1415926
     set Function expression = if(x>1+sin(0.5*pi*t), 1, -1); 0
   end
 end

--- a/tests/postprocess_iterations_iterated_advection_and_stokes.prm
+++ b/tests/postprocess_iterations_iterated_advection_and_stokes.prm
@@ -72,7 +72,7 @@ subsection Initial temperature model
   set Model name = function
 
   subsection Function
-    set Function constants  = pi=3.1415926,x0=150000,a = 0.2, b = 75000, c = 10000, d=0.0
+    set Function constants  = x0=150000,a = 0.2, b = 75000, c = 10000, d=0.0
     set Function expression = d + a * exp(-((x-b)*(x-b)+y*y)/(2*c*c))
     set Variable names      = x,y
   end
@@ -82,7 +82,7 @@ subsection Initial composition model
   set Model name = function
 
   subsection Function
-    set Function constants  = pi=3.1415926,x0=150000,a = 0.2, b = 75000, c = 10000, d=0.0
+    set Function constants  = x0=150000,a = 0.2, b = 75000, c = 10000, d=0.0
     set Function expression = d + a * exp(-((x-b)*(x-b)+y*y)/(2*c*c))
     set Variable names      = x,y
   end

--- a/tests/prescribed_stokes_solution.prm
+++ b/tests/prescribed_stokes_solution.prm
@@ -33,7 +33,7 @@ subsection Initial temperature model
 
   subsection Function
     set Variable names      = x,z
-    set Function constants  = p=0.01, L=1, pi=3.1415926536, k=1
+    set Function constants  = p=0.01, L=1, k=1
     set Function expression = (1.0-z) - p*cos(k*pi*x/L)*sin(pi*z)
   end
 end

--- a/tests/prescribed_stokes_solution_DG_periodic.prm
+++ b/tests/prescribed_stokes_solution_DG_periodic.prm
@@ -31,7 +31,6 @@ subsection Initial temperature model
 
   subsection Function
     set Variable names      = x,y
-    set Function constants  = pi=3.1415926536
     set Function expression = cos(2*pi*x)*sin(2*pi*y)
   end
 end

--- a/tests/prescribed_stokes_solution_melt.prm
+++ b/tests/prescribed_stokes_solution_melt.prm
@@ -46,7 +46,7 @@ subsection Initial temperature model
 
   subsection Function
     set Variable names      = x,z
-    set Function constants  = p=0.01, L=1, pi=3.1415926536, k=1
+    set Function constants  = p=0.01, L=1, k=1
     set Function expression = (1.0-z) - p*cos(k*pi*x/L)*sin(pi*z)
   end
 end

--- a/tests/pressure_compatibility.prm
+++ b/tests/pressure_compatibility.prm
@@ -37,7 +37,6 @@ subsection Boundary velocity model
 
   subsection Function
     set Variable names      = x,z,t
-    set Function constants  = pi=3.1415926
     set Function expression = if(x>1+sin(0.5*pi*t), 1, -1); 0
   end
 end

--- a/tests/refinement_switch.prm
+++ b/tests/refinement_switch.prm
@@ -19,7 +19,7 @@ subsection Initial temperature model
 
   subsection Function
     set Variable names      = x,z
-    set Function constants  = p=0.01, L=1, pi=3.1415926536, k=1
+    set Function constants  = p=0.01, L=1, k=1
     set Function expression = (1.0-z) - p*cos(k*pi*x/L)*sin(pi*z)
   end
 end

--- a/tests/rising_melt_blob.prm
+++ b/tests/rising_melt_blob.prm
@@ -95,7 +95,7 @@ subsection Initial composition model
 
   subsection Function
     set Variable names      = x,y
-    set Function constants  = pi=3.1415926,x0=100000,y0=50000,c=10000
+    set Function constants  = x0=100000,y0=50000,c=10000
     set Function expression = 0.2 * exp(-((x-x0)*(x-x0)+(y-y0)*(y-y0))/(2*c*c)); 0.2 * exp(-((x-x0)*(x-x0)+(y-y0)*(y-y0))/(2*c*c))
   end
 end

--- a/tests/rising_melt_blob_freezing.prm
+++ b/tests/rising_melt_blob_freezing.prm
@@ -93,7 +93,7 @@ subsection Initial composition model
 
   subsection Function
     set Variable names      = x,y
-    set Function constants  = pi=3.1415926,x0=50000,y0=50000,c=10000
+    set Function constants  = x0=50000,y0=50000,c=10000
     set Function expression = 0.2 * exp(-((x-x0)*(x-x0)+(y-y0)*(y-y0))/(2*c*c)); 0.0 * exp(-((x-x0)*(x-x0)+(y-y0)*(y-y0))/(2*c*c))
   end
 end

--- a/tests/sea_level_postprocessor.prm
+++ b/tests/sea_level_postprocessor.prm
@@ -61,7 +61,6 @@ subsection Initial composition model
 
   subsection Function
     set Variable names      = x,y,z
-    set Function constants  =
     set Function expression = 0; 0; 0; 0; 0; 0; 0; 0; 0; 0; 0; 0;
   end
 end

--- a/tests/shear_heating_with_melt.prm
+++ b/tests/shear_heating_with_melt.prm
@@ -128,7 +128,7 @@ subsection Initial composition model
   set Model name = function
 
   subsection Function
-    set Function constants  = pi=3.1415926,a = 1e-6, b = 300000, c = 20000, d=0.0
+    set Function constants  = a = 1e-6, b = 300000, c = 20000, d=0.0
     set Function expression = 0;0 #d + a * exp(-((x-b)*(x-b)+y*y)/(2*c*c)); d + a * exp(-((x-b)*(x-b)+y*y)/(2*c*c))
     set Variable names      = x,y
   end

--- a/tests/signals_post_constraints.prm
+++ b/tests/signals_post_constraints.prm
@@ -39,7 +39,7 @@ subsection Initial temperature model
   set Model name = function
 
   subsection Function
-    set Function constants  = z1=0.102367, z2=0.897633, pi=3.14159265359
+    set Function constants  = z1=0.102367, z2=0.897633
     set Function expression = if(z<z1,0.5+0.5*(z1-z)/z1,if(z>z2,0.5*(1-z)/(1-z2),0.5)) + 0.1 * cos(x*pi) * sin(z*pi)
     set Variable names      = x,z
   end

--- a/tests/single_Advection_iterated_defect_correction_Stokes.prm
+++ b/tests/single_Advection_iterated_defect_correction_Stokes.prm
@@ -72,7 +72,7 @@ subsection Initial temperature model
   set Model name = function
 
   subsection Function
-    set Function constants  = pi=3.1415926,x0=150000,a = 0.2, b = 75000, c = 10000, d=0.0
+    set Function constants  = x0=150000,a = 0.2, b = 75000, c = 10000, d=0.0
     set Function expression = d + a * exp(-((x-b)*(x-b)+y*y)/(2*c*c))
     set Variable names      = x,y
   end
@@ -82,7 +82,7 @@ subsection Initial composition model
   set Model name = function
 
   subsection Function
-    set Function constants  = pi=3.1415926,x0=150000,a = 0.2, b = 75000, c = 10000, d=0.0
+    set Function constants  = x0=150000,a = 0.2, b = 75000, c = 10000, d=0.0
     set Function expression = d + a * exp(-((x-b)*(x-b)+y*y)/(2*c*c))
     set Variable names      = x,y
   end

--- a/tests/skip_refinement.prm
+++ b/tests/skip_refinement.prm
@@ -118,7 +118,6 @@ subsection Initial composition model
 
   subsection Function
     set Variable names      = x,y
-    set Function constants  =
     set Function expression = 0; 0; 0; 0; 0; 0; if(y<=2221e3,1,0); if(y<=2471e3 && y>2221e3,1,0); if(y<=2821e3 && y>2471e3,1,0); if(y>2821e3,1,0);
   end
 end

--- a/tests/slab_tip_depth.prm
+++ b/tests/slab_tip_depth.prm
@@ -117,7 +117,6 @@ subsection Initial temperature model
   set List of model names = function
 
   subsection Function
-    set Function constants  =
     set Function expression = 0
     set Variable names      = x,y,t
   end

--- a/tests/smoothing.prm
+++ b/tests/smoothing.prm
@@ -36,7 +36,6 @@ subsection Initial temperature model
 
   subsection Function
     set Variable names      = x,y
-    set Function constants  =
     set Function expression =  if((sqrt((x-0)^2+(y-0.5)^2)<0.3)&(abs(x)>=0.05|y>=0.7),1,if(sqrt((x-0)^2+(y+0.5)^2)<0.3,1-sqrt((x-0)^2+(y+0.5)^2)/0.3,if(sqrt((x+0.5)^2+(y+0)^2)<0.3,1.0/4.0*(1+cos(pi*min(sqrt((x+0.5)^2+(y+0)^2)/0.3,1))),0)))
   end
 end

--- a/tests/smoothing_composition_passive.prm
+++ b/tests/smoothing_composition_passive.prm
@@ -45,7 +45,6 @@ subsection Boundary velocity model
 
   subsection Function
     set Variable names      = x,z,t
-    set Function constants  = pi=3.1415926
     set Function expression = if(x>1+sin(0.5*pi*t), 1, -1); 0
   end
 end

--- a/tests/steinberger_latent_heat_2.prm
+++ b/tests/steinberger_latent_heat_2.prm
@@ -34,7 +34,6 @@ subsection Initial composition model
 
   subsection Function
     set Variable names      = x,z
-    set Function constants  =
     set Function expression = 8e-5
   end
 end

--- a/tests/supg.prm
+++ b/tests/supg.prm
@@ -36,7 +36,6 @@ subsection Initial temperature model
 
   subsection Function
     set Variable names      = x,y
-    set Function constants  =
     set Function expression =  if((sqrt((x-0)^2+(y-0.5)^2)<0.3)&(abs(x)>=0.05|y>=0.7),1,if(sqrt((x-0)^2+(y+0.5)^2)<0.3,1-sqrt((x-0)^2+(y+0.5)^2)/0.3,if(sqrt((x+0.5)^2+(y+0)^2)<0.3,1.0/4.0*(1+cos(pi*min(sqrt((x+0.5)^2+(y+0)^2)/0.3,1))),0)))
   end
 end

--- a/tests/supg_compositional_passive.prm
+++ b/tests/supg_compositional_passive.prm
@@ -45,7 +45,6 @@ subsection Boundary velocity model
 
   subsection Function
     set Variable names      = x,z,t
-    set Function constants  = pi=3.1415926
     set Function expression = if(x>1+sin(0.5*pi*t), 1, -1); 0
   end
 end

--- a/tests/time_stepping_repeat.prm
+++ b/tests/time_stepping_repeat.prm
@@ -35,7 +35,6 @@ subsection Boundary velocity model
 
   subsection Function
     set Variable names      = x,z,t
-    set Function constants  = pi=3.1415926
     set Function expression = if(t<0.75, if(x<0.5,-1,1), 100); 0
   end
 end

--- a/tests/time_stepping_repeat_particles.prm
+++ b/tests/time_stepping_repeat_particles.prm
@@ -31,7 +31,6 @@ subsection Boundary velocity model
 
   subsection Function
     set Variable names      = x,z,t
-    set Function constants  = pi=3.1415926
     set Function expression = if(t<0.75, if(x<0.5,-1,1), 100); 0
   end
 end

--- a/tests/time_stepping_repeat_particles_iterated_advection.prm
+++ b/tests/time_stepping_repeat_particles_iterated_advection.prm
@@ -24,7 +24,6 @@ subsection Boundary velocity model
 
   subsection Function
     set Variable names      = x,z,t
-    set Function constants  = pi=3.1415926
     set Function expression = if(t<0.75, if(x<0.5,-1,1), if(x<0.5,-15,15)); 0
   end
 end

--- a/tests/topo_box.prm
+++ b/tests/topo_box.prm
@@ -21,7 +21,7 @@ subsection Boundary velocity model
   set Prescribed velocity boundary indicators = left: function, right:function
 
   subsection Function
-    set Function constants  = cm=0.01, year=3.155e7, pi=3.141593, angle=60, total_depth=512e3, crustal_depth=30e3, lithospheric_depth=120e3
+    set Function constants  = cm=0.01, year=3.155e7, angle=60, total_depth=512e3, crustal_depth=30e3, lithospheric_depth=120e3
     set Function expression = if (x<50e3, if (z > total_depth-lithospheric_depth, 1*cm, -(lithospheric_depth/(total_depth-lithospheric_depth))*cm), if (z > total_depth-lithospheric_depth, -1*cm, (lithospheric_depth/(total_depth-lithospheric_depth))*cm)); 0
     set Variable names      = x,z
   end
@@ -65,7 +65,7 @@ subsection Initial temperature model
   set Model name = function
 
   subsection Function
-    set Function constants  = reference_t=293, crustal_t = 420, lith_t = 1350, mantle_t = 1470, total_depth=512e3, crustal_depth=30e3, lithospheric_depth=120e3,
+    set Function constants  = reference_t=293, crustal_t = 420, lith_t = 1350, mantle_t = 1470, total_depth=512e3, crustal_depth=30e3, lithospheric_depth=120e3
     set Function expression = if (z>total_depth-crustal_depth,reference_t+(total_depth-z)*(crustal_t/crustal_depth), if (z>total_depth-lithospheric_depth,reference_t+crustal_t+(total_depth-crustal_depth-z)*(lith_t-crustal_t)/(lithospheric_depth-crustal_depth), reference_t+lith_t+(total_depth-lithospheric_depth-z)*(mantle_t-lith_t)/(total_depth-lithospheric_depth)))
     set Variable names      = x,z
   end

--- a/tests/van_keken_smooth_particle.prm
+++ b/tests/van_keken_smooth_particle.prm
@@ -65,7 +65,6 @@ subsection Initial composition model
 
   subsection Function
     set Variable names      = x,z
-    set Function constants  = pi=3.1415926
     set Function expression = 0.5*(1+tanh((0.2+0.02*cos(pi*x/0.9142)-z)/0.02))
   end
 end

--- a/tests/velocity_divergence.prm
+++ b/tests/velocity_divergence.prm
@@ -97,7 +97,7 @@ subsection Initial composition model
   set Model name = function
 
   subsection Function
-    set Function constants  = pi=3.1415926,a = 1e-5, b = 35000, c = 2000, d=17500
+    set Function constants  = a = 1e-5, b = 35000, c = 2000, d=17500
     set Function expression = a * exp(-((x-b)*(x-b)+(y-d)*(y-d))/(2*c*c))
     set Variable names      = x,y
   end

--- a/tests/velocity_in_years.prm
+++ b/tests/velocity_in_years.prm
@@ -42,7 +42,6 @@ subsection Boundary velocity model
 
   subsection Function
     set Variable names      = x,z,t
-    set Function constants  = pi=3.1415926
     set Function expression = if(x>1+sin(0.5*pi*t), 1, -1); 0
   end
 end

--- a/tests/visco_elastic_top_beam.prm
+++ b/tests/visco_elastic_top_beam.prm
@@ -85,7 +85,6 @@ subsection Initial composition model
 
   subsection Function
     set Variable names      = x,y
-    set Function constants  =
     set Function expression = 0; 0; 0; 0; 0; 0; if (x>=3.5e3 && x<=4.0e3 && y>=3.0e3, 1, 0)
   end
 end

--- a/tests/visco_plastic_vep_brick_extension.prm
+++ b/tests/visco_plastic_vep_brick_extension.prm
@@ -36,7 +36,6 @@ subsection Initial composition model
 
   subsection Function
     set Variable names      = x,y
-    set Function constants  =
     set Function expression = 0; 0; 0; 0; 0; 0; 0; \
                               if (y<=2.0e3 && x>=18.0e3 && x<=22.0e3, 1, 0);
   end

--- a/tests/viscous_top_beam.prm
+++ b/tests/viscous_top_beam.prm
@@ -85,7 +85,6 @@ subsection Initial composition model
 
   subsection Function
     set Variable names      = x,y
-    set Function constants  =
     set Function expression = 0; 0; 0; if (x>=3.5e3 && x<=4.0e3 && y>=3.0e3, 1, 0)
   end
 end

--- a/tests/visualization_vertical_heat_flux.prm
+++ b/tests/visualization_vertical_heat_flux.prm
@@ -21,7 +21,7 @@ subsection Initial temperature model
 
   subsection Function
     set Variable names      = x,z
-    set Function constants  = p=0.01, L=1, pi=3.1415926536, k=1
+    set Function constants  = p=0.01, L=1, k=1
     set Function expression = (1.0-z) - p*cos(k*pi*x/L)*sin(pi*z)
   end
 end


### PR DESCRIPTION
It turns out that we (inaccurately) define "pi" in the "Function constants" throughout many prm files. This is redundant as it is already defined in ``ParsedFunction``. Furthermore, it causes the crash in #7148 as fewer digits of pi used in that prm file cause a slightly negative pressure triggering the error.

  - [X] Significant parts of this PR were written by AI (please add a sentence below).

> Edits were done by codex with gpt 5.6. I reviewed them.

fixes #7148
