### PR TITLE
Avoid modifying vectors with ghost entries.

### DIFF
--- a/source/mesh_deformation/diffusion.cc
+++ b/source/mesh_deformation/diffusion.cc
@@ -440,10 +440,18 @@ namespace aspect
       // Therefore, we compute v=d_displacement/d_t.
       // d_displacement are the new mesh node locations
       // minus the old locations, which are initial_topography + displacements.
-      LinearAlgebra::Vector velocity(mesh_locally_owned, mesh_locally_relevant, this->get_mpi_communicator());
+      LinearAlgebra::Vector velocity(mesh_locally_owned, this->get_mpi_communicator());
       velocity = solution;
-      velocity -= initial_topography;
-      velocity -= displacements;
+      {
+        LinearAlgebra::Vector initial_topography_distributed(mesh_locally_owned, this->get_mpi_communicator());
+        initial_topography_distributed = initial_topography;
+        velocity -= initial_topography_distributed;
+      }
+      {
+        LinearAlgebra::Vector displacements_distributed(mesh_locally_owned, this->get_mpi_communicator());
+        displacements_distributed = displacements;
+        velocity -= displacements_distributed;
+      }
 
       // The velocity
       if (this->get_timestep() > 0.)

--- a/tests/surface_diffusion_ghost_entries.prm
+++ b/tests/surface_diffusion_ghost_entries.prm
@@ -1,0 +1,25 @@
+####
+# This test is based on the Continental Extension Cookbook.
+#
+# This test used to trigger an assertion in the surface diffusion
+# functionality where we were adding together vectors with ghost
+# entries. That used to be invalid but not checked, but newer deal.II
+# have assertions to make sure it doesn't happen.
+
+# MPI: 4
+
+include $ASPECT_SOURCE_DIR/cookbooks/continental_extension/continental_extension.prm
+
+####  Global parameters
+set End time                               = 30000
+set Max nonlinear iterations               = 2
+
+# Globally refine the mesh to 2.5 km spacing, and then
+# adaptively refine the mesh to 1.25 km spacing above y=50 km
+# and between x=40 and x=160 km. These values ensure areas
+# undergoing brittle deformation are in the high-resolution
+# region.
+subsection Mesh refinement
+  set Initial adaptive refinement        = 0
+  set Initial global refinement          = 1
+end

--- a/tests/surface_diffusion_ghost_entries/screen-output
+++ b/tests/surface_diffusion_ghost_entries/screen-output
@@ -1,0 +1,158 @@
+-----------------------------------------------------------------------------
+-----------------------------------------------------------------------------
+-----------------------------------------------------------------------------
+
+-----------------------------------------------------------------------------
+-----------------------------------------------------------------------------
+Number of active cells: 200 (on 2 levels)
+Number of degrees of freedom: 7,119 (1,722+231+861+861+861+861+861+861)
+
+Number of mesh deformation degrees of freedom: 1,722
+   Solving mesh displacement system... 0 iterations.
+*** Timestep 0:  t=0 years, dt=0 years
+   Solving mesh displacement system... 0 iterations.
+   Solving temperature system... 0 iterations.
+   Advecting particles...  done.
+   Rebuilding Stokes preconditioner...
+   Solving Stokes system (AMG)... 25+0 iterations.
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 1.88397e-16, 0, 0, 0, 0, 0, 1
+      Relative nonlinear residual (total system) after nonlinear iteration 1: 1
+
+   Solving temperature system... 0 iterations.
+   Advecting particles...  done.
+   Rebuilding Stokes preconditioner...
+   Solving Stokes system (AMG)... 22+0 iterations.
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 1.88397e-16, 0, 0, 0, 0, 0, 0.0731626
+      Relative nonlinear residual (total system) after nonlinear iteration 2: 0.0731626
+
+
+   WARNING: The nonlinear solver in the current timestep failed to converge.
+   Acting according to the parameter 'Nonlinear solver failure strategy':
+   Continuing to the next timestep even though solution is not fully converged.
+
+   Postprocessing:
+     Compositions min/max/mass:                         0/0/0 // 0/1.22/5.138e+09 // 0/1/4.333e+09 // 0/1/4e+09 // 0/1/1.167e+10
+     Heat flux densities for boundaries:                0.19 W/m, 0.19 W/m, -0.3441 W/m, 0.05501 W/m
+     Heat fluxes through boundary parts:                1.9e+04 W, 1.9e+04 W, -6.881e+04 W, 1.1e+04 W
+     Average density / Average viscosity / Total mass:  3042 kg/m^3, 7.557e+22 Pa s, 6.084e+13 kg
+     Mass fluxes through boundary parts:                7.605e+05 kg/yr, 7.605e+05 kg/yr, -1.606e+06 kg/yr, 0.01054 kg/yr
+     Writing particle output:                           output-surface_diffusion_ghost_entries/particles/particles-00000
+     Pressure min/avg/max:                              -1.807e+07 Pa, 1.421e+09 Pa, 2.985e+09 Pa
+     Temperature min/avg/max:                           273 K, 998.3 K, 1613 K
+     Topography min/max:                                0 m, 0 m
+     RMS, max velocity:                                 0.00207 m/year, 0.00354 m/year
+     Writing graphical output:                          output-surface_diffusion_ghost_entries/solution/solution-00000
+
+*** Timestep 1:  t=10000 years, dt=10000 years
+   Solving mesh surface diffusion
+   Solving mesh displacement system... 1 iterations.
+   Solving temperature system... 11 iterations.
+   Advecting particles...  done.
+   Rebuilding Stokes preconditioner...
+   Solving Stokes system (AMG)... 22+0 iterations.
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0.000169243, 0, 0, 0, 0, 0, 0.0729002
+      Relative nonlinear residual (total system) after nonlinear iteration 1: 0.0729002
+
+   Solving temperature system... 9 iterations.
+   Advecting particles...  done.
+   Rebuilding Stokes preconditioner...
+   Solving Stokes system (AMG)... 20+0 iterations.
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 1.15283e-05, 0, 0, 0, 0, 0, 0.0229147
+      Relative nonlinear residual (total system) after nonlinear iteration 2: 0.0229147
+
+
+   WARNING: The nonlinear solver in the current timestep failed to converge.
+   Acting according to the parameter 'Nonlinear solver failure strategy':
+   Continuing to the next timestep even though solution is not fully converged.
+
+   Postprocessing:
+     Compositions min/max/mass:                         0/0.0005023/1.764e+06 // 0/1.22/5.139e+09 // 0/1/4.333e+09 // 0/1/4e+09 // 0/1/1.167e+10
+     Heat flux densities for boundaries:                0.19 W/m, 0.19 W/m, -0.345 W/m, 0.05502 W/m
+     Heat fluxes through boundary parts:                1.9e+04 W, 1.9e+04 W, -6.9e+04 W, 1.1e+04 W
+     Average density / Average viscosity / Total mass:  3042 kg/m^3, 7.972e+22 Pa s, 6.084e+13 kg
+     Mass fluxes through boundary parts:                7.605e+05 kg/yr, 7.605e+05 kg/yr, -1.606e+06 kg/yr, -8.583 kg/yr
+     Number of advected particles:                      9800
+     Pressure min/avg/max:                              -1.598e+07 Pa, 1.365e+09 Pa, 2.985e+09 Pa
+     Temperature min/avg/max:                           273 K, 998.5 K, 1613 K
+     Topography min/max:                                -1.62 m, 1.137 m
+     RMS, max velocity:                                 0.00213 m/year, 0.00354 m/year
+
+*** Timestep 2:  t=20000 years, dt=10000 years
+   Solving mesh surface diffusion
+   Solving mesh displacement system... 1 iterations.
+   Solving temperature system... 10 iterations.
+   Advecting particles...  done.
+   Rebuilding Stokes preconditioner...
+   Solving Stokes system (AMG)... 24+0 iterations.
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 1.7514e-05, 0, 0, 0, 0, 0, 0.0288623
+      Relative nonlinear residual (total system) after nonlinear iteration 1: 0.0288623
+
+   Solving temperature system... 8 iterations.
+   Advecting particles...  done.
+   Rebuilding Stokes preconditioner...
+   Solving Stokes system (AMG)... 21+0 iterations.
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 2.17887e-06, 0, 0, 0, 0, 0, 0.0107044
+      Relative nonlinear residual (total system) after nonlinear iteration 2: 0.0107044
+
+
+   WARNING: The nonlinear solver in the current timestep failed to converge.
+   Acting according to the parameter 'Nonlinear solver failure strategy':
+   Continuing to the next timestep even though solution is not fully converged.
+
+   Postprocessing:
+     Compositions min/max/mass:                         0/0.001439/3.639e+06 // 0/1.22/5.141e+09 // 0/1/4.333e+09 // 0/1/4e+09 // 0/1/1.167e+10
+     Heat flux densities for boundaries:                0.19 W/m, 0.19 W/m, -0.3448 W/m, 0.05504 W/m
+     Heat fluxes through boundary parts:                1.9e+04 W, 1.9e+04 W, -6.895e+04 W, 1.101e+04 W
+     Average density / Average viscosity / Total mass:  3042 kg/m^3, 3.357e+23 Pa s, 6.084e+13 kg
+     Mass fluxes through boundary parts:                7.605e+05 kg/yr, 7.605e+05 kg/yr, -1.606e+06 kg/yr, -29.4 kg/yr
+     Number of advected particles:                      9800
+     Pressure min/avg/max:                              -2.298e+07 Pa, 1.357e+09 Pa, 2.986e+09 Pa
+     Temperature min/avg/max:                           273 K, 998.6 K, 1613 K
+     Topography min/max:                                -4.959 m, 3.471 m
+     RMS, max velocity:                                 0.00225 m/year, 0.00354 m/year
+
+*** Timestep 3:  t=30000 years, dt=10000 years
+   Solving mesh surface diffusion
+   Solving mesh displacement system... 1 iterations.
+   Solving temperature system... 10 iterations.
+   Advecting particles...  done.
+   Rebuilding Stokes preconditioner...
+   Solving Stokes system (AMG)... 25+0 iterations.
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 2.21593e-05, 0, 0, 0, 0, 0, 0.021241
+      Relative nonlinear residual (total system) after nonlinear iteration 1: 0.021241
+
+   Solving temperature system... 10 iterations.
+   Advecting particles...  done.
+   Rebuilding Stokes preconditioner...
+   Solving Stokes system (AMG)... 22+0 iterations.
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 1.73506e-05, 0, 0, 0, 0, 0, 0.00759714
+      Relative nonlinear residual (total system) after nonlinear iteration 2: 0.00759714
+
+
+   WARNING: The nonlinear solver in the current timestep failed to converge.
+   Acting according to the parameter 'Nonlinear solver failure strategy':
+   Continuing to the next timestep even though solution is not fully converged.
+
+   Postprocessing:
+     Compositions min/max/mass:                         0/0.00245/5.518e+06 // 0/1.221/5.142e+09 // 0/1/4.333e+09 // 0/1/4e+09 // 0/1/1.167e+10
+     Heat flux densities for boundaries:                0.19 W/m, 0.19 W/m, -0.3445 W/m, 0.05504 W/m
+     Heat fluxes through boundary parts:                1.9e+04 W, 1.9e+04 W, -6.891e+04 W, 1.101e+04 W
+     Average density / Average viscosity / Total mass:  3042 kg/m^3, 3.367e+23 Pa s, 6.084e+13 kg
+     Mass fluxes through boundary parts:                7.606e+05 kg/yr, 7.605e+05 kg/yr, -1.606e+06 kg/yr, -73.74 kg/yr
+     Number of advected particles:                      9800
+     Pressure min/avg/max:                              -2.299e+07 Pa, 1.358e+09 Pa, 2.986e+09 Pa
+     Temperature min/avg/max:                           273 K, 998.8 K, 1613 K
+     Topography min/max:                                -11.17 m, 7.615 m
+     RMS, max velocity:                                 0.0023 m/year, 0.00354 m/year
+
+Termination requested by criterion: end time
+
+
++----------------------------------------------+------------+------------+
++----------------------------------+-----------+------------+------------+
++----------------------------------+-----------+------------+------------+
+
+
+WARNING: During this computation 4 nonlinear solver failures occurred!
+-----------------------------------------------------------------------------
+-----------------------------------------------------------------------------


### PR DESCRIPTION
@MFraters points out in https://github.com/geodynamics/aspect/pull/7115#issuecomment-5095567394 that with Tpetra we run into an assertion where we modify a vector with ghost entries by calling `operator-=()`. This is true by looking at the existing code:
```
      LinearAlgebra::Vector velocity(mesh_locally_owned, mesh_locally_relevant, this->get_mpi_communicator());
      velocity = solution;
      velocity -= initial_topography;
```
The vector clearly has ghost entries, and we then call its `operator-=()`. 

This patch avoids that by making `velocity` a fully distributed vector. I do wonder whether we need to convert `initial_topography` to a non-ghosted vector (and same for the operations that follow), but let's see what this here leads to first.


### Before your first pull request:

* [x] I have read the guidelines in our [CONTRIBUTING.md](../blob/main/CONTRIBUTING.md) document.

### For all pull requests:

* [x] I have followed the [instructions for indenting my code](../blob/main/CONTRIBUTING.md#making-aspect-better).
* I followed the [AI Policy](../blob/main/CONTRIBUTING.md#policy-on-usage-of-ai):
  - [ ] Significant parts of this PR were written by AI (please add a sentence below).
  - [x] AI has not been used in significant ways.

*If yes, please describe your usage of AI models in the creation of this pull request*

### For new features/models or changes of existing features:

* [ ] I have tested my new feature locally to ensure it is correct.
* [ ] I have [created a testcase](https://aspect-documentation.readthedocs.io/en/latest/user/extending/testing/writing-tests.html) for the new feature/benchmark in the [tests/](../blob/main/tests/) directory.
* [ ] I have added a changelog entry in the [doc/modules/changes](../blob/main/doc/modules/changes) directory that will inform other users of my change.
