### PR TITLE
Let particle managers know their respective index.

### DIFF
--- a/include/aspect/particle/manager.h
+++ b/include/aspect/particle/manager.h
@@ -87,9 +87,20 @@ namespace aspect
     {
       public:
         /**
-         * Default constructor.
+         * Default constructor. This constructor creates an invalid object, which
+         * is only useful for deserialization if you next want to fill the object
+         * with content read back from a previously generated checkpoint.
+         *
+         * The other constructor should be used in all other cases.
          */
         Manager();
+
+        /**
+         * Constructor. The argument denotes the how many-th particle manager this
+         * is in the simulation. This is used to distinguish between multiple particle
+         * managers in the same simulation.
+         */
+        Manager(const unsigned int particle_manager_index);
 
         /**
          * Default destructor.
@@ -284,16 +295,24 @@ namespace aspect
         declare_parameters (ParameterHandler &prm);
 
         /**
-         * Read the parameters this class declares from the parameter file.
+         * Read the parameters this class declares from the parameter file, using the
+         * particle manager index to distinguish between multiple particle managers
+         * in the same simulation.
          *
          * @param prm The ParameterHandler.
-         * @param particle_manager Parse the parameters for the Particle manager with this index.
          */
         virtual
         void
-        parse_parameters (ParameterHandler &prm, const unsigned int particle_manager);
+        parse_parameters (ParameterHandler &prm);
 
       private:
+
+        /**
+         * The index of this particle manager. This is used to distinguish between multiple
+         * particle managers in the same simulation.
+         */
+        unsigned int particle_manager_index;
+
         struct ParticleLoadBalancing
         {
           enum Kind
@@ -534,6 +553,8 @@ namespace aspect
     template <class Archive>
     void Manager<dim>::serialize (Archive &ar, const unsigned int)
     {
+      ar &particle_manager_index;
+
       // Note that although Boost claims to handle serialization of pointers
       // correctly, at least for the case of unique_ptr it seems to not work.
       // It works correctly when archiving the content of the pointer instead.

--- a/include/aspect/simulator.h
+++ b/include/aspect/simulator.h
@@ -1967,7 +1967,7 @@ namespace aspect
       Postprocess::Manager<dim>                                 postprocess_manager;
 
       /**
-       * The managers holding different sets of particles
+       * The managers holding different sets of particles.
        */
       std::vector<Particle::Manager<dim>>                       particle_managers;
 

--- a/source/material_model/visco_plastic.cc
+++ b/source/material_model/visco_plastic.cc
@@ -90,7 +90,7 @@ namespace aspect
        */
       const IsostrainViscosities isostrain_viscosities = rheology->calculate_isostrain_viscosities(in, 0, volume_fractions, phase_function_values, phase_function.n_phase_transitions_for_each_composition());
 
-      std::vector<double>::const_iterator max_composition = std::max_element(volume_fractions.begin(), volume_fractions.end());
+      const std::vector<double>::const_iterator max_composition = std::max_element(volume_fractions.begin(), volume_fractions.end());
       const bool plastic_yielding = isostrain_viscosities.composition_yielding[std::distance(volume_fractions.begin(), max_composition)];
 
       return plastic_yielding;

--- a/source/particle/manager.cc
+++ b/source/particle/manager.cc
@@ -41,7 +41,20 @@ namespace aspect
   {
     template <int dim>
     Manager<dim>::Manager()
-      = default;
+    // Set the manager index to an invalid value, but otherwise do what the other
+    // constructor does. This is necessary to allow for default construction of
+    // the class, which is required to be able to de-serialize objects.
+      : Manager(numbers::invalid_unsigned_int)
+    {}
+
+
+
+    template <int dim>
+    Manager<dim>::Manager(const unsigned int particle_manager_index)
+      : particle_manager_index(particle_manager_index)
+    {}
+
+
 
     template <int dim>
     Manager<dim>::~Manager()
@@ -50,16 +63,17 @@ namespace aspect
     template <int dim>
     Manager<dim>::Manager(Manager &&other) noexcept
   :
-    generator(std::move(other.generator)),
-              integrator(std::move(other.integrator)),
-              interpolator(std::move(other.interpolator)),
-              particle_handler(std::move(other.particle_handler)),
-              particle_handler_backup(), // can not move
-              property_manager(std::move(other.property_manager)),
-              particle_load_balancing(other.particle_load_balancing),
-              min_particles_per_cell(other.min_particles_per_cell),
-              max_particles_per_cell(other.max_particles_per_cell),
-              particle_weight(other.particle_weight)
+    particle_manager_index(other.particle_manager_index),
+                           generator(std::move(other.generator)),
+                           integrator(std::move(other.integrator)),
+                           interpolator(std::move(other.interpolator)),
+                           particle_handler(std::move(other.particle_handler)),
+                           particle_handler_backup(), // can not move
+                           property_manager(std::move(other.property_manager)),
+                           particle_load_balancing(other.particle_load_balancing),
+                           min_particles_per_cell(other.min_particles_per_cell),
+                           max_particles_per_cell(other.max_particles_per_cell),
+                           particle_weight(other.particle_weight)
     {}
 
 
@@ -68,6 +82,13 @@ namespace aspect
     void
     Manager<dim>::initialize()
     {
+      // Verify that the object was either created by the constructor
+      // that creates a valid object right away, or that the particle
+      // manager index was set to a valid value through de-serialization.
+      // If not, we have an invalid object that we shouldn't be using.
+      Assert (particle_manager_index != numbers::invalid_unsigned_int,
+              ExcInternalError());
+
       CitationInfo::add("particles");
 
       // Create a particle handler that stores the future particles.
@@ -90,6 +111,13 @@ namespace aspect
     void
     Manager<dim>::update()
     {
+      // Verify that the object was either created by the constructor
+      // that creates a valid object right away, or that the particle
+      // manager index was set to a valid value through de-serialization.
+      // If not, we have an invalid object that we shouldn't be using.
+      Assert (particle_manager_index != numbers::invalid_unsigned_int,
+              ExcInternalError());
+
       generator->update();
       integrator->update();
       interpolator->update();
@@ -1153,7 +1181,7 @@ namespace aspect
 
     template <int dim>
     void
-    Manager<dim>::parse_parameters (ParameterHandler &prm, const unsigned int particle_manager)
+    Manager<dim>::parse_parameters (ParameterHandler &prm)
     {
       // First do some error checking. The current algorithm does not find
       // the cells around particles, if the particles moved more than one
@@ -1170,13 +1198,13 @@ namespace aspect
                              "diameter in one time step and therefore skip the layer "
                              "of ghost cells around the local subdomain."));
 
-      if (particle_manager == 0)
+      if (particle_manager_index == 0)
         {
           prm.enter_subsection("Particles");
         }
       else
         {
-          prm.enter_subsection("Particles " + std::to_string(particle_manager+1));
+          prm.enter_subsection("Particles " + std::to_string(particle_manager_index+1));
         }
       {
         min_particles_per_cell = prm.get_integer("Minimum particles per cell");
@@ -1228,13 +1256,13 @@ namespace aspect
 
         if (particle_load_balancing & ParticleLoadBalancing::repartition)
           this->get_triangulation().signals.weight.connect(
-            [ &, particle_manager] (const typename parallel::distributed::Triangulation<dim>::cell_iterator &cell,
-                                    const CellStatus status)
+            [&] (const typename parallel::distributed::Triangulation<dim>::cell_iterator &cell,
+                 const CellStatus status)
             -> unsigned int
           {
             // Only add the base weight of cells in particle manager 0, because all weights will be summed
             // across all particle managers.
-            return (particle_manager == 0) ? 1000 + this->cell_weight(cell, status) : this->cell_weight(cell, status);
+            return (particle_manager_index == 0) ? 1000 + this->cell_weight(cell, status) : this->cell_weight(cell, status);
           });
 
         // The bandwidth to use with the kernel function
@@ -1299,7 +1327,7 @@ namespace aspect
         generator = Generator::create_particle_generator<dim> (prm);
         if (SimulatorAccess<dim> *sim = dynamic_cast<SimulatorAccess<dim>*>(generator.get()))
           sim->initialize_simulator (this->get_simulator());
-        generator->set_particle_manager_index(particle_manager);
+        generator->set_particle_manager_index(particle_manager_index);
         generator->parse_parameters(prm);
         generator->initialize();
 
@@ -1307,7 +1335,7 @@ namespace aspect
         property_manager = std::make_unique<Property::Manager<dim>> ();
         SimulatorAccess<dim> *sim = dynamic_cast<SimulatorAccess<dim>*>(property_manager.get());
         sim->initialize_simulator (this->get_simulator());
-        property_manager->set_particle_manager_index(particle_manager);
+        property_manager->set_particle_manager_index(particle_manager_index);
         property_manager->parse_parameters(prm);
         property_manager->initialize();
 
@@ -1315,7 +1343,7 @@ namespace aspect
         integrator = Integrator::create_particle_integrator<dim> (prm);
         if (SimulatorAccess<dim> *sim = dynamic_cast<SimulatorAccess<dim>*>(integrator.get()))
           sim->initialize_simulator (this->get_simulator());
-        integrator->set_particle_manager_index(particle_manager);
+        integrator->set_particle_manager_index(particle_manager_index);
         integrator->parse_parameters(prm);
         integrator->initialize();
 
@@ -1323,7 +1351,7 @@ namespace aspect
         interpolator = Interpolator::create_particle_interpolator<dim> (prm);
         if (SimulatorAccess<dim> *sim = dynamic_cast<SimulatorAccess<dim>*>(interpolator.get()))
           sim->initialize_simulator (this->get_simulator());
-        interpolator->set_particle_manager_index(particle_manager);
+        interpolator->set_particle_manager_index(particle_manager_index);
         interpolator->parse_parameters(prm);
         interpolator->initialize();
 

--- a/source/simulator/core.cc
+++ b/source/simulator/core.cc
@@ -484,20 +484,25 @@ namespace aspect
 
     if (particles_are_needed)
       {
-        particle_managers.resize(parameters.n_particle_managers);
-
-        AssertThrow(particle_managers.size() <= ASPECT_MAX_NUM_PARTICLE_SYSTEMS,
-                    ExcMessage("You have selected " + std::to_string(particle_managers.size()) + " particle managers, but ASPECT "
+        AssertThrow(parameters.n_particle_managers <= ASPECT_MAX_NUM_PARTICLE_SYSTEMS,
+                    ExcMessage("You have selected " + std::to_string(parameters.n_particle_managers) + " particle managers, but ASPECT "
                                "has been compiled with a maximum of " + std::to_string(ASPECT_MAX_NUM_PARTICLE_SYSTEMS) + ". "
                                "Please recompile ASPECT with a higher value for ASPECT_MAX_NUM_PARTICLE_SYSTEMS. You can set a higher number "
                                "specifying the CMake variable -DASPECT_MAX_NUM_PARTICLE_SYSTEMS=<number>"));
 
-        for (unsigned int particle_manager_index = 0 ; particle_manager_index < particle_managers.size(); ++particle_manager_index)
+        // Create the particle managers:
+        for (unsigned int particle_manager_index = 0; particle_manager_index < parameters.n_particle_managers; ++particle_manager_index)
+          {
+            particle_managers.emplace_back(Particle::Manager<dim>(particle_manager_index));
+          }
+
+        // And then initialize them:
+        for (unsigned int particle_manager_index = 0; particle_manager_index < particle_managers.size(); ++particle_manager_index)
           {
             if (SimulatorAccess<dim> *sim = dynamic_cast<SimulatorAccess<dim>*>(&particle_managers[particle_manager_index]))
               sim->initialize_simulator (*this);
 
-            particle_managers[particle_manager_index].parse_parameters(prm,particle_manager_index);
+            particle_managers[particle_manager_index].parse_parameters(prm);
             particle_managers[particle_manager_index].initialize();
           }
       }


### PR DESCRIPTION
This requires giving it a non-default constructor, which in turn requires that we can't just store *objects* in the vector of managers, but have to store pointers. Minor inconvenience ensues.

I'd like this so that particle managers can output their respective index without having to pass it to these functions on every call.


### For all pull requests:

* [x] I have followed the [instructions for indenting my code](../blob/main/CONTRIBUTING.md#making-aspect-better).
* I followed the [AI Policy](../blob/main/CONTRIBUTING.md#policy-on-usage-of-ai):
  - [ ] Significant parts of this PR were written by AI (please add a sentence below).
  - [ ] AI has not been used in significant ways.

*If yes, please describe your usage of AI models in the creation of this pull request*

### For new features/models or changes of existing features:

* [x] I have tested my new feature locally to ensure it is correct.
* [ ] I have [created a testcase](https://aspect-documentation.readthedocs.io/en/latest/user/extending/testing/writing-tests.html) for the new feature/benchmark in the [tests/](../blob/main/tests/) directory.
* [ ] I have added a changelog entry in the [doc/modules/changes](../blob/main/doc/modules/changes) directory that will inform other users of my change.
