### PR TITLE
Provide resize() functions for material inputs and outputs

### DIFF
--- a/include/aspect/material_model/interface.h
+++ b/include/aspect/material_model/interface.h
@@ -302,6 +302,26 @@ namespace aspect
                             const bool compute_strain_rate = true);
 
         /**
+         * Resize the internal data structures to provide sufficient memory
+         * to store (at least) @p n_points. If the data structures were
+         * smaller than @p n_points the new items will be filled with invalid
+         * signaling NaNs. If the data structures were larger than @p n_points
+         * they will be shrunk, but the reserved memory will remain available
+         * for later use (after enlargening the structure again).
+         * This function is not supported if AdditionalMaterialInputs are
+         * attached.
+         *
+         * @param n_points The number of quadrature points for which input
+         * quantities will be provided.
+         * @param n_comp The number of vector quantities (in the order in which
+         * the Introspection class reports them) for which input will be
+         * provided.
+         */
+        void
+        resize(const unsigned int n_points,
+               const unsigned int n_comp);
+
+        /**
          * Copy constructor. This constructor copies all data members of the
          * source object except for the additional input data (of type
          * AdditionalMaterialInputs) pointers, stored in the
@@ -519,11 +539,31 @@ namespace aspect
          * @param n_points The number of quadrature points for which input
          * quantities will be provided.
          * @param n_comp The number of vector quantities (in the order in which
-         * the Introspection class reports them) for which input will be
+         * the Introspection class reports them) for which output will be
          * provided.
          */
         MaterialModelOutputs (const unsigned int n_points,
                               const unsigned int n_comp);
+
+        /**
+         * Resize the internal data structures to provide sufficient memory
+         * to store (at least) @p n_points. If the data structures were
+         * smaller than @p n_points the new items will be filled with invalid
+         * signaling NaNs. If the data structures were larger than @p n_points
+         * they will be shrunk, but the reserved memory will remain available
+         * for later use (after enlargening the structure again).
+         * This function is not supported if AdditionalMaterialOutputs are
+         * attached.
+         *
+         * @param n_points The number of quadrature points for which input
+         * quantities will be provided.
+         * @param n_comp The number of vector quantities (in the order in which
+         * the Introspection class reports them) for which output will be
+         * provided.
+         */
+        void
+        resize(const unsigned int n_points,
+               const unsigned int n_comp);
 
         /**
          * Copy constructor. This constructor copies all data members of the

--- a/source/material_model/interface.cc
+++ b/source/material_model/interface.cc
@@ -321,6 +321,25 @@ namespace aspect
 
     template <int dim>
     void
+    MaterialModelInputs<dim>::resize(const unsigned int n_points,
+                                     const unsigned int n_comp)
+    {
+      AssertThrow(additional_inputs.size() == 0,
+                  ExcMessage("The resize() function is not implemented if additional material inputs are attached."));
+
+      position.resize(n_points, Point<dim>(numbers::signaling_nan<Tensor<1,dim>>()));
+      temperature.resize(n_points, numbers::signaling_nan<double>());
+      pressure.resize(n_points, numbers::signaling_nan<double>());
+      pressure_gradient.resize(n_points, numbers::signaling_nan<Tensor<1,dim>>());
+      velocity.resize(n_points, numbers::signaling_nan<Tensor<1,dim>>());
+      composition.resize(n_points, std::vector<double>(n_comp, numbers::signaling_nan<double>()));
+      strain_rate.resize(n_points, numbers::signaling_nan<SymmetricTensor<2,dim>>());
+    }
+
+
+
+    template <int dim>
+    void
     MaterialModelInputs<dim>::reinit(const FEValuesBase<dim,dim> &fe_values,
                                      const typename DoFHandler<dim>::active_cell_iterator &cell_x,
                                      const Introspection<dim> &introspection,
@@ -382,17 +401,10 @@ namespace aspect
     template <int dim>
     MaterialModelOutputs<dim>::MaterialModelOutputs(const unsigned int n_points,
                                                     const unsigned int n_comp)
-      :
-      viscosities(n_points, numbers::signaling_nan<double>()),
-      densities(n_points, numbers::signaling_nan<double>()),
-      thermal_expansion_coefficients(n_points, numbers::signaling_nan<double>()),
-      specific_heat(n_points, numbers::signaling_nan<double>()),
-      thermal_conductivities(n_points, numbers::signaling_nan<double>()),
-      compressibilities(n_points, numbers::signaling_nan<double>()),
-      entropy_derivative_pressure(n_points, numbers::signaling_nan<double>()),
-      entropy_derivative_temperature(n_points, numbers::signaling_nan<double>()),
-      reaction_terms(n_points, std::vector<double>(n_comp, numbers::signaling_nan<double>()))
-    {}
+    {
+      resize(n_points,n_comp);
+    }
+
 
 
     template <int dim>
@@ -412,6 +424,26 @@ namespace aspect
       Assert (source.additional_outputs.size() == 0,
               ExcMessage ("You can not copy MaterialModelOutputs objects that have "
                           "additional output objects attached"));
+    }
+
+
+
+    template <int dim>
+    void
+    MaterialModelOutputs<dim>::resize(const unsigned int n_points, const unsigned int n_comp)
+    {
+      AssertThrow(additional_outputs.size() == 0,
+                  ExcMessage("The resize() function is not implemented if additional material outputs are attached."));
+
+      viscosities.resize(n_points, numbers::signaling_nan<double>());
+      densities.resize(n_points, numbers::signaling_nan<double>());
+      thermal_expansion_coefficients.resize(n_points, numbers::signaling_nan<double>());
+      specific_heat.resize(n_points, numbers::signaling_nan<double>());
+      thermal_conductivities.resize(n_points, numbers::signaling_nan<double>());
+      compressibilities.resize(n_points, numbers::signaling_nan<double>());
+      entropy_derivative_pressure.resize(n_points, numbers::signaling_nan<double>());
+      entropy_derivative_temperature.resize(n_points, numbers::signaling_nan<double>());
+      reaction_terms.resize(n_points, std::vector<double>(n_comp, numbers::signaling_nan<double>()));
     }
 
 

--- a/source/material_model/interface.cc
+++ b/source/material_model/interface.cc
@@ -327,13 +327,13 @@ namespace aspect
       AssertThrow(additional_inputs.size() == 0,
                   ExcMessage("The resize() function is not implemented if additional material inputs are attached."));
 
-      position.resize(n_points, Point<dim>(numbers::signaling_nan<Tensor<1,dim>>()));
-      temperature.resize(n_points, numbers::signaling_nan<double>());
-      pressure.resize(n_points, numbers::signaling_nan<double>());
-      pressure_gradient.resize(n_points, numbers::signaling_nan<Tensor<1,dim>>());
-      velocity.resize(n_points, numbers::signaling_nan<Tensor<1,dim>>());
-      composition.resize(n_points, std::vector<double>(n_comp, numbers::signaling_nan<double>()));
-      strain_rate.resize(n_points, numbers::signaling_nan<SymmetricTensor<2,dim>>());
+      position.assign(n_points, Point<dim>(numbers::signaling_nan<Tensor<1,dim>>()));
+      temperature.assign(n_points, numbers::signaling_nan<double>());
+      pressure.assign(n_points, numbers::signaling_nan<double>());
+      pressure_gradient.assign(n_points, numbers::signaling_nan<Tensor<1,dim>>());
+      velocity.assign(n_points, numbers::signaling_nan<Tensor<1,dim>>());
+      composition.assign(n_points, std::vector<double>(n_comp, numbers::signaling_nan<double>()));
+      strain_rate.assign(n_points, numbers::signaling_nan<SymmetricTensor<2,dim>>());
     }
 
 
@@ -435,15 +435,15 @@ namespace aspect
       AssertThrow(additional_outputs.size() == 0,
                   ExcMessage("The resize() function is not implemented if additional material outputs are attached."));
 
-      viscosities.resize(n_points, numbers::signaling_nan<double>());
-      densities.resize(n_points, numbers::signaling_nan<double>());
-      thermal_expansion_coefficients.resize(n_points, numbers::signaling_nan<double>());
-      specific_heat.resize(n_points, numbers::signaling_nan<double>());
-      thermal_conductivities.resize(n_points, numbers::signaling_nan<double>());
-      compressibilities.resize(n_points, numbers::signaling_nan<double>());
-      entropy_derivative_pressure.resize(n_points, numbers::signaling_nan<double>());
-      entropy_derivative_temperature.resize(n_points, numbers::signaling_nan<double>());
-      reaction_terms.resize(n_points, std::vector<double>(n_comp, numbers::signaling_nan<double>()));
+      viscosities.assign(n_points, numbers::signaling_nan<double>());
+      densities.assign(n_points, numbers::signaling_nan<double>());
+      thermal_expansion_coefficients.assign(n_points, numbers::signaling_nan<double>());
+      specific_heat.assign(n_points, numbers::signaling_nan<double>());
+      thermal_conductivities.assign(n_points, numbers::signaling_nan<double>());
+      compressibilities.assign(n_points, numbers::signaling_nan<double>());
+      entropy_derivative_pressure.assign(n_points, numbers::signaling_nan<double>());
+      entropy_derivative_temperature.assign(n_points, numbers::signaling_nan<double>());
+      reaction_terms.assign(n_points, std::vector<double>(n_comp, numbers::signaling_nan<double>()));
     }
 
 

--- a/source/particle/property/grain_size.cc
+++ b/source/particle/property/grain_size.cc
@@ -31,8 +31,8 @@ namespace aspect
       template <int dim>
       GrainSize<dim>::GrainSize ()
         :
-        material_inputs(1,0),
-        material_outputs(1,0)
+        material_inputs(0,0),
+        material_outputs(0,0)
       {}
 
 
@@ -42,9 +42,6 @@ namespace aspect
       GrainSize<dim>::initialize ()
       {
         CitationInfo::add("grainsize");
-
-        material_inputs  = MaterialModel::MaterialModelInputs<dim>(1, this->n_compositional_fields());
-        material_outputs = MaterialModel::MaterialModelOutputs<dim>(1, this->n_compositional_fields());
 
         AssertThrow(this->introspection().compositional_name_exists("grain_size"),
                     ExcMessage("This particle property only makes sense if "
@@ -71,8 +68,8 @@ namespace aspect
       GrainSize<dim>::update_particle_properties(const ParticleUpdateInputs<dim> &inputs,
                                                  typename ParticleHandler<dim>::particle_iterator_range &particles) const
       {
-        material_inputs  = MaterialModel::MaterialModelInputs<dim>(inputs.solution.size(), this->n_compositional_fields());
-        material_outputs = MaterialModel::MaterialModelOutputs<dim>(inputs.solution.size(), this->n_compositional_fields());
+        material_inputs.resize(inputs.solution.size(), this->n_compositional_fields());
+        material_outputs.resize(inputs.solution.size(), this->n_compositional_fields());
         material_inputs.requested_properties = MaterialModel::MaterialProperties::reaction_terms;
         material_inputs.current_cell = inputs.current_cell;
 


### PR DESCRIPTION
In our usual assembly operations the structures `MaterialModelInputs` and `MaterialModelOutputs` have a fixed size (depending on number of quadrature points and compositional fields). But if we use them for particle plugins we want to resize them frequently adjusting their size to the number of particles in the current cell. This PR introduces such a function, which makes it possible to reuse memory that was allocated before without reallocating space for these structures.

@Arijitchkc could you take a look at the changes I made in grain_size.cc in this PR and include the same changes in your PR #7161?