### PR TITLE
Make a ptr const

### DIFF
--- a/source/mesh_refinement/compaction_length.cc
+++ b/source/mesh_refinement/compaction_length.cc
@@ -67,7 +67,7 @@ namespace aspect
             in.reinit(fe_values, cell, this->introspection(), this->get_solution());
             this->get_material_model().evaluate(in, out);
 
-            const std::shared_ptr<MaterialModel::MeltOutputs<dim>> melt_out
+            const std::shared_ptr<const MaterialModel::MeltOutputs<dim>> melt_out
               = out.template get_additional_output_object<MaterialModel::MeltOutputs<dim>>();
             AssertThrow(melt_out != nullptr,
                         ExcMessage("Need MeltOutputs from the material model for computing the melt properties."));

--- a/source/postprocess/fluid_velocity_statistics.cc
+++ b/source/postprocess/fluid_velocity_statistics.cc
@@ -105,7 +105,7 @@ namespace aspect
 
                 this->get_material_model().evaluate(in, out);
 
-                const std::shared_ptr<MaterialModel::MeltOutputs<dim>> fluid_out
+                const std::shared_ptr<const MaterialModel::MeltOutputs<dim>> fluid_out
                   = out.template get_additional_output_object<MaterialModel::MeltOutputs<dim>>();
 
                 for (unsigned int q = 0; q < n_q_points; ++q)

--- a/source/postprocess/visualization/darcy_velocity.cc
+++ b/source/postprocess/visualization/darcy_velocity.cc
@@ -73,7 +73,7 @@ namespace aspect
         MaterialModel::MaterialModelOutputs<dim> out(in.n_evaluation_points(), this->n_compositional_fields());
         MeltHandler<dim>::create_material_model_outputs(out);
         this->get_material_model().evaluate(in, out);
-        const std::shared_ptr<MaterialModel::MeltOutputs<dim>> fluid_out
+        const std::shared_ptr<const MaterialModel::MeltOutputs<dim>> fluid_out
           = out.template get_additional_output_object<MaterialModel::MeltOutputs<dim>>();
         AssertThrow(std::isfinite(fluid_out->fluid_viscosities[0]),
                     ExcMessage("To compute the Darcy velocity the material model needs to provide the melt material model "

--- a/source/postprocess/visualization/melt.cc
+++ b/source/postprocess/visualization/melt.cc
@@ -126,7 +126,7 @@ namespace aspect
         MeltHandler<dim>::create_material_model_outputs(out);
 
         this->get_material_model().evaluate(in, out);
-        const std::shared_ptr<MaterialModel::MeltOutputs<dim>> melt_outputs
+        const std::shared_ptr<const MaterialModel::MeltOutputs<dim>> melt_outputs
           = out.template get_additional_output_object<MaterialModel::MeltOutputs<dim>>();
         AssertThrow(melt_outputs != nullptr,
                     ExcMessage("Need MeltOutputs from the material model for computing the melt properties."));

--- a/source/simulator/assemblers/advection.cc
+++ b/source/simulator/assemblers/advection.cc
@@ -662,7 +662,7 @@ namespace aspect
                                                      (time_step + old_time_step)) : 1.0;
       const unsigned int solution_component = advection_field.component_index(introspection);
       const FEValuesExtractors::Scalar solution_field = advection_field.scalar_extractor(introspection);
-      const std::shared_ptr<MaterialModel::MeltOutputs<dim>> melt_outputs
+      const std::shared_ptr<const MaterialModel::MeltOutputs<dim>> melt_outputs
         = scratch.material_model_outputs.template get_additional_output_object<MaterialModel::MeltOutputs<dim>>();
 
       for (unsigned int q=0; q<n_q_points; ++q)

--- a/source/simulator/helper_functions.cc
+++ b/source/simulator/helper_functions.cc
@@ -2246,7 +2246,7 @@ namespace aspect
     MaterialModel::MaterialModelInputs<dim> in(fe_face_values.n_quadrature_points, introspection.n_compositional_fields);
     MaterialModel::MaterialModelOutputs<dim> out(fe_face_values.n_quadrature_points, introspection.n_compositional_fields);
     MeltHandler<dim>::create_material_model_outputs(out);
-    std::shared_ptr<MaterialModel::MeltOutputs<dim>> fluid_out
+    std::shared_ptr<const MaterialModel::MeltOutputs<dim>> fluid_out
       = out.template get_additional_output_object<MaterialModel::MeltOutputs<dim>>();
 
     const auto &tangential_velocity_boundaries =

--- a/source/simulator/melt.cc
+++ b/source/simulator/melt.cc
@@ -229,7 +229,7 @@ namespace aspect
                                                                        this->get_melt_handler(),
                                                                        true);
 
-      const std::shared_ptr<MaterialModel::MeltOutputs<dim>> melt_outputs
+      const std::shared_ptr<const MaterialModel::MeltOutputs<dim>> melt_outputs
         = scratch.material_model_outputs.template get_additional_output_object<MaterialModel::MeltOutputs<dim>>();
 
       const FEValuesExtractors::Scalar ex_p_f = introspection.variable("fluid pressure").extractor_scalar();
@@ -399,7 +399,7 @@ namespace aspect
       const unsigned int p_f_component_index = introspection.variable("fluid pressure").first_component_index;
       const unsigned int p_c_component_index = introspection.variable("compaction pressure").first_component_index;
 
-      const std::shared_ptr<MaterialModel::MeltOutputs<dim>> melt_outputs
+      const std::shared_ptr<const MaterialModel::MeltOutputs<dim>> melt_outputs
         = scratch.material_model_outputs.template get_additional_output_object<MaterialModel::MeltOutputs<dim>>();
       const std::shared_ptr<const MaterialModel::AdditionalMaterialOutputsStokesRHS<dim>> force
         = scratch.material_model_outputs.template get_additional_output_object<MaterialModel::AdditionalMaterialOutputsStokesRHS<dim>>();
@@ -575,7 +575,7 @@ namespace aspect
 
       const typename DoFHandler<dim>::face_iterator face = scratch.face_material_model_inputs.current_cell->face(scratch.face_number);
 
-      const std::shared_ptr<MaterialModel::MeltOutputs<dim>> melt_outputs
+      const std::shared_ptr<const MaterialModel::MeltOutputs<dim>> melt_outputs
         = scratch.face_material_model_outputs.template get_additional_output_object<MaterialModel::MeltOutputs<dim>>();
 
       std::vector<double> grad_p_f(n_face_q_points);
@@ -686,7 +686,7 @@ namespace aspect
 
       const FEValuesExtractors::Scalar solution_field = scratch.advection_field->scalar_extractor(introspection);
 
-      const std::shared_ptr<MaterialModel::MeltOutputs<dim>> melt_outputs
+      const std::shared_ptr<const MaterialModel::MeltOutputs<dim>> melt_outputs
         = scratch.material_model_outputs.template get_additional_output_object<MaterialModel::MeltOutputs<dim>>();
 
       Assert(melt_outputs->fluid_densities[0] > 0.0,

--- a/source/time_stepping/convection_time_step.cc
+++ b/source/time_stepping/convection_time_step.cc
@@ -66,7 +66,7 @@ namespace aspect
       MaterialModel::MaterialModelInputs<dim> in(fe_values.n_quadrature_points, this->n_compositional_fields());
       MaterialModel::MaterialModelOutputs<dim> out(fe_values.n_quadrature_points, this->n_compositional_fields());
       MeltHandler<dim>::create_material_model_outputs(out);
-      std::shared_ptr<MaterialModel::MeltOutputs<dim>> fluid_out;
+      std::shared_ptr<const MaterialModel::MeltOutputs<dim>> fluid_out;
 
       double max_local_speed_over_meshsize = 0;
 

--- a/tests/melt_transport_adaptive.cc
+++ b/tests/melt_transport_adaptive.cc
@@ -133,7 +133,7 @@ namespace aspect
 
               this->get_material_model().evaluate(in, out);
 
-              const std::shared_ptr<MaterialModel::MeltOutputs<dim>> melt_out
+              const std::shared_ptr<const MaterialModel::MeltOutputs<dim>> melt_out
                 = out.template get_additional_output_object<MaterialModel::MeltOutputs<dim>>();
               AssertThrow(melt_out != nullptr,
                           ExcMessage("Need MeltOutputs from the material model for computing the melt properties."));


### PR DESCRIPTION
In several places, MeltOutputs are stored in shared_ptr<MeltOutputs<dim>>, and in others it is stored in shared_ptr<const MeltOutputs<dim>>. This PR ensures that they are all shared_ptr<const MeltOutputs<dim>>