### PR TITLE
default test script: remove -- lines

### DIFF
--- a/tests/cmake/default
+++ b/tests/cmake/default
@@ -16,8 +16,9 @@ while ( <STDIN> )
   # following lines inside the cmake script, but this makes it easier
   # to generate screen-output files from scratch because the useless
   # lines are already removed.
-  next if $_ =~ m/^-- /;
+  next if $_ =~ m/^--/;
   next if $_ =~ m/^\|/;
+  next if $_ =~ m/^\+--/;
 
   if ($skip>0)
   {


### PR DESCRIPTION
Fix script that processes screen-output in the output directory and also remove the following kind of lines:
```
---------
+--------
```
These are ignored when comparing test output, but there is not need for us to keep them when creating reference output

  - [x] AI has not been used in significant ways.
