### PR TITLE
replaced 0.0 with start time in rigid_shear benchmark

### DIFF
--- a/benchmarks/rigid_shear/plugin/rigid_shear.cc
+++ b/benchmarks/rigid_shear/plugin/rigid_shear.cc
@@ -126,7 +126,7 @@ namespace aspect
         void evaluate(const MaterialModel::MaterialModelInputs<dim> &in,
                       MaterialModel::MaterialModelOutputs<dim> &out) const override
         {
-          const double t = (this->simulator_is_past_initialization()) ? this->get_time() : 0.0;
+          const double t = (this->simulator_is_past_initialization()) ? this->get_time() : this->get_parameters().start_time;
 
           for (unsigned int i=0; i < in.n_evaluation_points(); ++i)
             {
@@ -220,7 +220,7 @@ namespace aspect
         Tensor<1,dim> gravity_vector (const Point<dim> &pos) const override
         {
           const double pi = numbers::PI;
-          const double t = (this->simulator_is_past_initialization()) ? this->get_time() : 0.0;
+          const double t = (this->simulator_is_past_initialization()) ? this->get_time() : this->get_parameters().start_time;
 
           const RigidShearMaterial<dim> &
           material_model


### PR DESCRIPTION
This pull request updates the initialization logic for the time variable in the `rigid_shear` benchmark plugin. Instead of defaulting to 0.0 before simulation initialization, the code now uses the user-specified start time.

This PR addresses Issue #6531.

* [x] I have read the guidelines in our [CONTRIBUTING.md](../blob/main/CONTRIBUTING.md) document.
* [x] I have followed the [instructions for indenting my code](../blob/main/CONTRIBUTING.md#making-aspect-better).
* [x] AI has not been used in significant ways.
* [x] I have tested my new feature locally to ensure it is correct.
