### PR TITLE
Add coordinate system to mesh deformation function

### DIFF
--- a/doc/sphinx/parameters/Mesh_20deformation.md
+++ b/doc/sphinx/parameters/Mesh_20deformation.md
@@ -79,6 +79,15 @@ This surface velocity is used to deform the surface and as a boundary condition 
 
 (parameters:Mesh_20deformation/Boundary_20function)=
 ## **Subsection:** Mesh deformation / Boundary function
+::::{dropdown} __Parameter:__ {ref}`Coordinate system<parameters:Mesh_20deformation/Boundary_20function/Coordinate_20system>`
+:name: parameters:Mesh_20deformation/Boundary_20function/Coordinate_20system
+**Default value:** cartesian
+
+**Pattern:** [Selection cartesian|spherical|depth ]
+
+**Documentation:** A selection that determines the assumed coordinate system for the function variables. Allowed values are &lsquo;cartesian&rsquo;, &lsquo;spherical&rsquo;, and &lsquo;depth&rsquo;. &lsquo;spherical&rsquo; coordinates are interpreted as r,phi or r,phi,theta in 2d/3d respectively with theta being the polar angle. &lsquo;depth&rsquo; will create a function, in which only the first parameter is non-zero, which is interpreted to be the depth of the point.
+::::
+
 ::::{dropdown} __Parameter:__ {ref}`Function constants<parameters:Mesh_20deformation/Boundary_20function/Function_20constants>`
 :name: parameters:Mesh_20deformation/Boundary_20function/Function_20constants
 **Default value:**

--- a/include/aspect/mesh_deformation/function.h
+++ b/include/aspect/mesh_deformation/function.h
@@ -24,6 +24,7 @@
 
 #include <aspect/mesh_deformation/interface.h>
 #include <aspect/simulator_access.h>
+#include <aspect/utilities.h>
 
 #include <deal.II/base/parsed_function.h>
 
@@ -83,6 +84,12 @@ namespace aspect
          * A function object representing the mesh deformation.
          */
         Functions::ParsedFunction<dim> function;
+
+        /**
+         * The coordinate representation to evaluate the function. Possible
+         * choices are depth, cartesian and spherical.
+         */
+        Utilities::Coordinates::CoordinateSystem coordinate_system;
     };
   }
 }

--- a/source/mesh_deformation/function.cc
+++ b/source/mesh_deformation/function.cc
@@ -20,6 +20,7 @@
 
 
 #include <aspect/mesh_deformation/function.h>
+#include <aspect/geometry_model/interface.h>
 
 #include <deal.II/numerics/vector_tools.h>
 
@@ -70,8 +71,11 @@ namespace aspect
           {
             Tensor<1,dim> velocity;
 
+            // convert the position into the selected coordinate system
+            const Utilities::NaturalCoordinate<dim> point = this->get_geometry_model().cartesian_to_other_coordinates(x, coordinate_system);
+
             for (unsigned int d=0; d<dim; ++d)
-              velocity[d] = function.value(x, d);
+              velocity[d] = function.value(Utilities::convert_array_to_point<dim>(point.get_coordinates()), d);
 
             if (this->convert_output_to_years())
               velocity /= year_in_seconds;
@@ -106,6 +110,16 @@ namespace aspect
       {
         prm.enter_subsection ("Boundary function");
         {
+          prm.declare_entry ("Coordinate system", "cartesian",
+                             Patterns::Selection ("cartesian|spherical|depth"),
+                             "A selection that determines the assumed coordinate "
+                             "system for the function variables. Allowed values "
+                             "are `cartesian', `spherical', and `depth'. `spherical' coordinates "
+                             "are interpreted as r,phi or r,phi,theta in 2d/3d "
+                             "respectively with theta being the polar angle. `depth' "
+                             "will create a function, in which only the first "
+                             "parameter is non-zero, which is interpreted to "
+                             "be the depth of the point.");
           Functions::ParsedFunction<dim>::declare_parameters (prm, dim);
         }
         prm.leave_subsection();
@@ -134,6 +148,8 @@ namespace aspect
                         << "is shown below.\n";
               throw;
             }
+
+          coordinate_system = Utilities::Coordinates::string_to_coordinate_system(prm.get("Coordinate system"));
         }
         prm.leave_subsection();
       }

--- a/tests/function_mesh_deformation_tangential_mesh_velocity_spherical_spherical_coordinates.prm
+++ b/tests/function_mesh_deformation_tangential_mesh_velocity_spherical_spherical_coordinates.prm
@@ -1,0 +1,17 @@
+# This test is identical to function_mesh_deformation_tangential_mesh_velocity_spherical.prm
+# but with spherical coordinates.
+
+include $ASPECT_SOURCE_DIR/tests/function_mesh_deformation_tangential_mesh_velocity_spherical.prm
+
+
+subsection Mesh deformation
+  set Mesh deformation boundary indicators = top: boundary function, bottom: boundary function
+
+  subsection Boundary function
+    set Coordinate system   = spherical
+    set Variable names      = r, phi, t
+    # year_in_seconds = 60*60*24*365.2425
+    set Function constants  = m_per_yr=1, rm=5371000, ra=6371000, year_in_seconds=31556952
+    set Function expression = 0.0 ; (r < rm) ? 0.0 : 3 * (r * sin(phi)) / 6371000 * sin(t/1e6) / 1e8 * year_in_seconds
+  end
+end

--- a/tests/function_mesh_deformation_tangential_mesh_velocity_spherical_spherical_coordinates/screen-output
+++ b/tests/function_mesh_deformation_tangential_mesh_velocity_spherical_spherical_coordinates/screen-output
@@ -1,0 +1,45 @@
+
+Number of active cells: 12 (on 1 levels)
+Number of degrees of freedom: 240 (144+24+72)
+
+Number of mesh deformation degrees of freedom: 144
+   Solving mesh displacement system... 0 iterations.
+*** Timestep 0:  t=0 years, dt=0 years
+   Solving mesh displacement system... 0 iterations.
+   Solving temperature system... 0 iterations.
+   Solving Stokes system (GMG)... 18+0 iterations.
+
+   Postprocessing:
+     Topography min/max:                 -9.313e-10 m, 0 m
+     Writing graphical output:           output-function_mesh_deformation_tangential_mesh_velocity_spherical_spherical_coordinates/solution/solution-00000
+     RMS, max velocity:                  1.47 m/year, 1.87 m/year
+     Temperature min/avg/max:            273 K, 1507 K, 3000 K
+     Heat fluxes through boundary parts: -2.074e+05 W, 3.32e+05 W
+
+*** Timestep 1:  t=450000 years, dt=450000 years
+   Solving mesh displacement system... 2 iterations.
+   Solving temperature system... 14 iterations.
+   Solving Stokes system (GMG)... 35+0 iterations.
+
+   Postprocessing:
+     Topography min/max:                 0 m, 1.853e+05 m
+     RMS, max velocity:                  1.48 m/year, 1.92 m/year
+     Temperature min/avg/max:            273 K, 1468 K, 3000 K
+     Heat fluxes through boundary parts: 6.538e+07 W, 1.32e+08 W
+
+*** Timestep 2:  t=900000 years, dt=450000 years
+   Solving mesh displacement system... 2 iterations.
+   Solving temperature system... 12 iterations.
+   Solving Stokes system (GMG)... 34+0 iterations.
+
+   Postprocessing:
+     Topography min/max:                 0 m, 5.287e+05 m
+     Writing graphical output:           output-function_mesh_deformation_tangential_mesh_velocity_spherical_spherical_coordinates/solution/solution-00001
+     RMS, max velocity:                  1.46 m/year, 1.99 m/year
+     Temperature min/avg/max:            273 K, 1411 K, 3000 K
+     Heat fluxes through boundary parts: 1.188e+08 W, 2.364e+08 W
+
+Termination requested by criterion: end time
+
+
+

--- a/tests/function_mesh_deformation_tangential_mesh_velocity_spherical_spherical_coordinates/statistics
+++ b/tests/function_mesh_deformation_tangential_mesh_velocity_spherical_spherical_coordinates/statistics
@@ -1,0 +1,24 @@
+# 1: Time step number
+# 2: Time (years)
+# 3: Time step size (years)
+# 4: Number of mesh cells
+# 5: Number of Stokes degrees of freedom
+# 6: Number of temperature degrees of freedom
+# 7: Iterations for temperature solver
+# 8: Iterations for Stokes solver
+# 9: Velocity iterations in Stokes preconditioner
+# 10: Schur complement iterations in Stokes preconditioner
+# 11: Minimum topography (m)
+# 12: Maximum topography (m)
+# 13: Visualization file name
+# 14: RMS velocity (m/year)
+# 15: Max. velocity (m/year)
+# 16: Minimal temperature (K)
+# 17: Average temperature (K)
+# 18: Maximal temperature (K)
+# 19: Average nondimensional temperature (K)
+# 20: Outward heat flux through boundary with indicator 0 ("bottom") (W)
+# 21: Outward heat flux through boundary with indicator 1 ("top") (W)
+0 0.000000000000e+00 0.000000000000e+00 12 168 72  0 18 19 19 -9.31322575e-10 0.00000000e+00 output-function_mesh_deformation_tangential_mesh_velocity_spherical_spherical_coordinates/solution/solution-00000 1.46809633e+00 1.86569954e+00 2.73000000e+02 1.50681968e+03 3.00000000e+03 4.52445793e-01 -2.07390902e+05 3.32012967e+05 
+1 4.500000000000e+05 4.500000000000e+05 12 168 72 14 35 36 36  0.00000000e+00 1.85303518e+05                                                                                                                "" 1.47708114e+00 1.92429450e+00 2.73000000e+02 1.46786651e+03 3.00000000e+03 4.38161538e-01  6.53820506e+07 1.32049815e+08 
+2 9.000000000000e+05 4.500000000000e+05 12 168 72 12 34 35 35  0.00000000e+00 5.28721719e+05 output-function_mesh_deformation_tangential_mesh_velocity_spherical_spherical_coordinates/solution/solution-00001 1.45956011e+00 1.98958997e+00 2.73000000e+02 1.41065516e+03 3.00000000e+03 4.17181942e-01  1.18784748e+08 2.36426323e+08 


### PR DESCRIPTION
This PR adds a coordinate system option to source/mesh_deformation/function.cc. It follows from the starter pack issue https://github.com/geodynamics/aspect/issues/5626.