### PR TITLE
Change viscosity unit rendering.

### DIFF
--- a/doc/sphinx/parameters/Material_20model.md
+++ b/doc/sphinx/parameters/Material_20model.md
@@ -528,7 +528,7 @@ Viscous stress may also be limited by a non-linear stress limiter that has a for
 
 **Pattern:** [Double 0...MAX_DOUBLE (inclusive)]
 
-**Documentation:** The value of the constant viscosity. Units: \si{\kilogram\per\meter\per\second}.
+**Documentation:** The value of the constant viscosity. Units: \si{\pascal\second}.
 ::::
 
 (parameters:Material_20model/Depth_20dependent_20model)=

--- a/source/material_model/composition_reaction.cc
+++ b/source/material_model/composition_reaction.cc
@@ -148,7 +148,7 @@ namespace aspect
                              "The reference temperature $T_0$. Units: \\si{\\kelvin}.");
           prm.declare_entry ("Viscosity", "5e24",
                              Patterns::Double (0.),
-                             "The value of the constant viscosity. Units: \\si{\\kilogram\\per\\meter\\per\\second}.");
+                             "The value of the constant viscosity. Units: \\si{\\pascal\\second}.");
           prm.declare_entry ("Composition viscosity prefactor 1", "1.0",
                              Patterns::Double (0.),
                              "A linear dependency of viscosity on the first compositional field. "


### PR DESCRIPTION
While this isn't technically wrong, I don't think we want to express viscosity in units of kg m $^{-1}$ s $^{-1}$.