### PR TITLE
Improve wording.

### DIFF
--- a/source/simulator/core.cc
+++ b/source/simulator/core.cc
@@ -1827,7 +1827,7 @@ namespace aspect
       const bool mesh_changed = Utilities::MPI::max(any_flags_set?1:0,mpi_communicator) == 1 ? true : false;
       if (!mesh_changed)
         {
-          pcout << "Skipping mesh refinement, because the mesh did not change.\n" << std::endl;
+          pcout << "Skipping mesh refinement, because no cells were flagged for refinement/coarsening.\n" << std::endl;
           computing_timer.leave_subsection("Refine mesh structure, part 1");
           return;
         }

--- a/tests/always_refine/screen-output
+++ b/tests/always_refine/screen-output
@@ -27,7 +27,7 @@ Number of degrees of freedom: 1,020 (386+55+193+193+193)
      Temperature min/avg/max:   0 K, 0.5011 K, 1 K
      Compositions min/max/mass: -0.006514/1.046/0.4591 // -0.01399/1.066/0.4168
 
-Skipping mesh refinement, because the mesh did not change.
+Skipping mesh refinement, because no cells were flagged for refinement/coarsening.
 
 *** Timestep 2:  t=0.181875 seconds, dt=0.119375 seconds
    Solving temperature system... 9 iterations.
@@ -40,7 +40,7 @@ Skipping mesh refinement, because the mesh did not change.
      Temperature min/avg/max:   0 K, 0.5035 K, 1 K
      Compositions min/max/mass: -0.007355/1.061/0.46 // -0.0199/1.072/0.4161
 
-Skipping mesh refinement, because the mesh did not change.
+Skipping mesh refinement, because no cells were flagged for refinement/coarsening.
 
 *** Timestep 3:  t=0.306875 seconds, dt=0.125 seconds
    Solving temperature system... 11 iterations.
@@ -53,7 +53,7 @@ Skipping mesh refinement, because the mesh did not change.
      Temperature min/avg/max:   0 K, 0.5059 K, 1 K
      Compositions min/max/mass: -0.003499/1.052/0.4603 // -0.01649/1.051/0.4154
 
-Skipping mesh refinement, because the mesh did not change.
+Skipping mesh refinement, because no cells were flagged for refinement/coarsening.
 
 *** Timestep 4:  t=0.431875 seconds, dt=0.125 seconds
    Solving temperature system... 9 iterations.
@@ -66,7 +66,7 @@ Skipping mesh refinement, because the mesh did not change.
      Temperature min/avg/max:   0 K, 0.5078 K, 1 K
      Compositions min/max/mass: -0.003148/1.041/0.4605 // -0.01899/1.023/0.4148
 
-Skipping mesh refinement, because the mesh did not change.
+Skipping mesh refinement, because no cells were flagged for refinement/coarsening.
 
 *** Timestep 5:  t=0.5 seconds, dt=0.068125 seconds
    Solving temperature system... 9 iterations.
@@ -79,7 +79,7 @@ Skipping mesh refinement, because the mesh did not change.
      Temperature min/avg/max:   0 K, 0.5083 K, 1 K
      Compositions min/max/mass: -0.003033/1.035/0.4605 // -0.01536/0.9925/0.4153
 
-Skipping mesh refinement, because the mesh did not change.
+Skipping mesh refinement, because no cells were flagged for refinement/coarsening.
 
 Termination requested by criterion: end time
 

--- a/tests/box_steady_temperature_terminate/screen-output
+++ b/tests/box_steady_temperature_terminate/screen-output
@@ -90,7 +90,7 @@ Number of degrees of freedom: 948 (578+81+289)
      Temperature min/avg/max: 0.1706 K, 0.2969 K, 0.4524 K
      RMS, max velocity:       0.231 m/s, 0.378 m/s
 
-Skipping mesh refinement, because the mesh did not change.
+Skipping mesh refinement, because no cells were flagged for refinement/coarsening.
 
 *** Timestep 11:  t=0.177317 seconds, dt=0.0164806 seconds
    Solving temperature system... 20 iterations.
@@ -172,7 +172,7 @@ Skipping mesh refinement, because the mesh did not change.
      Temperature min/avg/max: 0.2558 K, 0.2966 K, 0.3393 K
      RMS, max velocity:       0.0807 m/s, 0.129 m/s
 
-Skipping mesh refinement, because the mesh did not change.
+Skipping mesh refinement, because no cells were flagged for refinement/coarsening.
 
 *** Timestep 21:  t=0.343296 seconds, dt=0.0166573 seconds
    Solving temperature system... 19 iterations.
@@ -254,7 +254,7 @@ Skipping mesh refinement, because the mesh did not change.
      Temperature min/avg/max: 0.2836 K, 0.2966 K, 0.3097 K
      RMS, max velocity:       0.0277 m/s, 0.0441 m/s
 
-Skipping mesh refinement, because the mesh did not change.
+Skipping mesh refinement, because no cells were flagged for refinement/coarsening.
 
 *** Timestep 31:  t=0.51017 seconds, dt=0.0167036 seconds
    Solving temperature system... 17 iterations.
@@ -336,7 +336,7 @@ Skipping mesh refinement, because the mesh did not change.
      Temperature min/avg/max: 0.2924 K, 0.2966 K, 0.3008 K
      RMS, max velocity:       0.00946 m/s, 0.0151 m/s
 
-Skipping mesh refinement, because the mesh did not change.
+Skipping mesh refinement, because no cells were flagged for refinement/coarsening.
 
 *** Timestep 41:  t=0.677295 seconds, dt=0.0167175 seconds
    Solving temperature system... 16 iterations.
@@ -418,7 +418,7 @@ Skipping mesh refinement, because the mesh did not change.
      Temperature min/avg/max: 0.2952 K, 0.2966 K, 0.298 K
      RMS, max velocity:       0.00323 m/s, 0.00514 m/s
 
-Skipping mesh refinement, because the mesh did not change.
+Skipping mesh refinement, because no cells were flagged for refinement/coarsening.
 
 *** Timestep 51:  t=0.844498 seconds, dt=0.0167219 seconds
    Solving temperature system... 15 iterations.
@@ -500,7 +500,7 @@ Skipping mesh refinement, because the mesh did not change.
      Temperature min/avg/max: 0.2961 K, 0.2966 K, 0.2971 K
      RMS, max velocity:       0.0011 m/s, 0.00175 m/s
 
-Skipping mesh refinement, because the mesh did not change.
+Skipping mesh refinement, because no cells were flagged for refinement/coarsening.
 
 *** Timestep 61:  t=1.01173 seconds, dt=0.0167233 seconds
    Solving temperature system... 14 iterations.
@@ -582,7 +582,7 @@ Skipping mesh refinement, because the mesh did not change.
      Temperature min/avg/max: 0.2964 K, 0.2966 K, 0.2968 K
      RMS, max velocity:       0.000376 m/s, 0.000599 m/s
 
-Skipping mesh refinement, because the mesh did not change.
+Skipping mesh refinement, because no cells were flagged for refinement/coarsening.
 
 *** Timestep 71:  t=1.17896 seconds, dt=0.0167238 seconds
    Solving temperature system... 13 iterations.
@@ -664,7 +664,7 @@ Skipping mesh refinement, because the mesh did not change.
      Temperature min/avg/max: 0.2965 K, 0.2966 K, 0.2967 K
      RMS, max velocity:       0.000128 m/s, 0.000204 m/s
 
-Skipping mesh refinement, because the mesh did not change.
+Skipping mesh refinement, because no cells were flagged for refinement/coarsening.
 
 *** Timestep 81:  t=1.3462 seconds, dt=0.016724 seconds
    Solving temperature system... 12 iterations.
@@ -746,7 +746,7 @@ Skipping mesh refinement, because the mesh did not change.
      Temperature min/avg/max: 0.2966 K, 0.2966 K, 0.2966 K
      RMS, max velocity:       4.37e-05 m/s, 6.97e-05 m/s
 
-Skipping mesh refinement, because the mesh did not change.
+Skipping mesh refinement, because no cells were flagged for refinement/coarsening.
 
 *** Timestep 91:  t=1.51344 seconds, dt=0.016724 seconds
    Solving temperature system... 11 iterations.
@@ -828,7 +828,7 @@ Skipping mesh refinement, because the mesh did not change.
      Temperature min/avg/max: 0.2966 K, 0.2966 K, 0.2966 K
      RMS, max velocity:       1.49e-05 m/s, 2.38e-05 m/s
 
-Skipping mesh refinement, because the mesh did not change.
+Skipping mesh refinement, because no cells were flagged for refinement/coarsening.
 
 
 
@@ -913,7 +913,7 @@ Skipping mesh refinement, because the mesh did not change.
      Temperature min/avg/max: 0.2966 K, 0.2966 K, 0.2966 K
      RMS, max velocity:       5.09e-06 m/s, 8.11e-06 m/s
 
-Skipping mesh refinement, because the mesh did not change.
+Skipping mesh refinement, because no cells were flagged for refinement/coarsening.
 
 *** Timestep 111:  t=1.84792 seconds, dt=0.0167241 seconds
    Solving temperature system... 9 iterations.
@@ -995,7 +995,7 @@ Skipping mesh refinement, because the mesh did not change.
      Temperature min/avg/max: 0.2966 K, 0.2966 K, 0.2966 K
      RMS, max velocity:       1.74e-06 m/s, 2.77e-06 m/s
 
-Skipping mesh refinement, because the mesh did not change.
+Skipping mesh refinement, because no cells were flagged for refinement/coarsening.
 
 *** Timestep 121:  t=2.01516 seconds, dt=0.0167241 seconds
    Solving temperature system... 8 iterations.

--- a/tests/cells_in_circumference/screen-output
+++ b/tests/cells_in_circumference/screen-output
@@ -9,9 +9,9 @@ Number of degrees of freedom: 400 (240+40+120)
    Postprocessing:
      Writing graphical output: output-cells_in_circumference/solution/solution-00000
 
-Skipping mesh refinement, because the mesh did not change.
+Skipping mesh refinement, because no cells were flagged for refinement/coarsening.
 
-Skipping mesh refinement, because the mesh did not change.
+Skipping mesh refinement, because no cells were flagged for refinement/coarsening.
 
 Termination requested by criterion: end time
 *** Snapshot output-cells_in_circumference/restart/01/ created!

--- a/tests/checkpoint_10_steady_temperature/screen-output
+++ b/tests/checkpoint_10_steady_temperature/screen-output
@@ -17,7 +17,7 @@ Number of degrees of freedom: 948 (578+81+289)
      Temperature min/avg/max: 0.2966 K, 0.2966 K, 0.2966 K
      RMS, max velocity:       1.49e-05 m/s, 2.38e-05 m/s
 
-Skipping mesh refinement, because the mesh did not change.
+Skipping mesh refinement, because no cells were flagged for refinement/coarsening.
 
 
 
@@ -102,7 +102,7 @@ Skipping mesh refinement, because the mesh did not change.
      Temperature min/avg/max: 0.2966 K, 0.2966 K, 0.2966 K
      RMS, max velocity:       5.09e-06 m/s, 8.11e-06 m/s
 
-Skipping mesh refinement, because the mesh did not change.
+Skipping mesh refinement, because no cells were flagged for refinement/coarsening.
 
 *** Timestep 111:  t=1.84792 seconds, dt=0.0167241 seconds
    Solving temperature system... 9 iterations.
@@ -184,7 +184,7 @@ Skipping mesh refinement, because the mesh did not change.
      Temperature min/avg/max: 0.2966 K, 0.2966 K, 0.2966 K
      RMS, max velocity:       1.74e-06 m/s, 2.77e-06 m/s
 
-Skipping mesh refinement, because the mesh did not change.
+Skipping mesh refinement, because no cells were flagged for refinement/coarsening.
 
 *** Timestep 121:  t=2.01516 seconds, dt=0.0167241 seconds
    Solving temperature system... 8 iterations.

--- a/tests/composition_cg_dg_fem/screen-output
+++ b/tests/composition_cg_dg_fem/screen-output
@@ -64,7 +64,7 @@ Number of degrees of freedom: 1,813 (578+81+289+576+289)
      Temperature min/avg/max:   -0.004362 K, 0.5 K, 1 K
      Compositions min/max/mass: -0.1982/1.126/0.4167 // -0.004788/1.019/0.4583
 
-Skipping mesh refinement, because the mesh did not change.
+Skipping mesh refinement, because no cells were flagged for refinement/coarsening.
 
 *** Timestep 5:  t=0.3125 seconds, dt=0.0625 seconds
    Solving temperature system... 12 iterations.
@@ -86,7 +86,7 @@ Skipping mesh refinement, because the mesh did not change.
      Temperature min/avg/max:   -0.01149 K, 0.5 K, 1 K
      Compositions min/max/mass: -0.1629/1.125/0.4167 // -0.006268/1.014/0.4581
 
-Skipping mesh refinement, because the mesh did not change.
+Skipping mesh refinement, because no cells were flagged for refinement/coarsening.
 
 *** Timestep 7:  t=0.4375 seconds, dt=0.0625 seconds
    Solving temperature system... 12 iterations.
@@ -108,7 +108,7 @@ Skipping mesh refinement, because the mesh did not change.
      Temperature min/avg/max:   -0.0157 K, 0.4999 K, 1 K
      Compositions min/max/mass: -0.119/1.125/0.4167 // -0.007126/1.013/0.4581
 
-Skipping mesh refinement, because the mesh did not change.
+Skipping mesh refinement, because no cells were flagged for refinement/coarsening.
 
 *** Timestep 9:  t=0.5625 seconds, dt=0.0625 seconds
    Solving temperature system... 11 iterations.
@@ -130,7 +130,7 @@ Skipping mesh refinement, because the mesh did not change.
      Temperature min/avg/max:   -0.01272 K, 0.4997 K, 1 K
      Compositions min/max/mass: -0.1223/1.125/0.4167 // -0.004574/1.01/0.458
 
-Skipping mesh refinement, because the mesh did not change.
+Skipping mesh refinement, because no cells were flagged for refinement/coarsening.
 
 *** Timestep 11:  t=0.6875 seconds, dt=0.0625 seconds
    Solving temperature system... 11 iterations.
@@ -152,7 +152,7 @@ Skipping mesh refinement, because the mesh did not change.
      Temperature min/avg/max:   -0.0123 K, 0.4996 K, 1 K
      Compositions min/max/mass: -0.1197/1.124/0.4167 // -0.00434/1.012/0.4581
 
-Skipping mesh refinement, because the mesh did not change.
+Skipping mesh refinement, because no cells were flagged for refinement/coarsening.
 
 *** Timestep 13:  t=0.8125 seconds, dt=0.0625 seconds
    Solving temperature system... 11 iterations.
@@ -174,7 +174,7 @@ Skipping mesh refinement, because the mesh did not change.
      Temperature min/avg/max:   -0.007248 K, 0.4996 K, 1 K
      Compositions min/max/mass: -0.09368/1.125/0.4167 // -0.003175/1.007/0.4581
 
-Skipping mesh refinement, because the mesh did not change.
+Skipping mesh refinement, because no cells were flagged for refinement/coarsening.
 
 *** Timestep 15:  t=0.9375 seconds, dt=0.0625 seconds
    Solving temperature system... 11 iterations.
@@ -196,7 +196,7 @@ Skipping mesh refinement, because the mesh did not change.
      Temperature min/avg/max:   -0.006603 K, 0.4996 K, 1 K
      Compositions min/max/mass: -0.2114/1.149/0.4167 // -0.003116/1.006/0.4581
 
-Skipping mesh refinement, because the mesh did not change.
+Skipping mesh refinement, because no cells were flagged for refinement/coarsening.
 
 Termination requested by criterion: end time
 

--- a/tests/compositional_boundary_values/screen-output
+++ b/tests/compositional_boundary_values/screen-output
@@ -101,7 +101,7 @@ Number of degrees of freedom: 1,526 (578+81+289+289+289)
    Postprocessing:
      Compositions min/max/mass: -0.3146/10.66/3.298 // 0.7169/10.59/3.968
 
-Skipping mesh refinement, because the mesh did not change.
+Skipping mesh refinement, because no cells were flagged for refinement/coarsening.
 
 *** Timestep 11:  t=0.6875 seconds, dt=0.0625 seconds
    Solving temperature system... 13 iterations.

--- a/tests/compositional_boundary_values_02/screen-output
+++ b/tests/compositional_boundary_values_02/screen-output
@@ -101,7 +101,7 @@ Number of degrees of freedom: 1,526 (578+81+289+289+289)
    Postprocessing:
      Compositions min/max/mass: -1.223/30/4.262 // -0.1825/30/4.899
 
-Skipping mesh refinement, because the mesh did not change.
+Skipping mesh refinement, because no cells were flagged for refinement/coarsening.
 
 *** Timestep 11:  t=0.6875 seconds, dt=0.0625 seconds
    Solving temperature system... 13 iterations.

--- a/tests/compositional_boundary_values_03/screen-output
+++ b/tests/compositional_boundary_values_03/screen-output
@@ -101,7 +101,7 @@ Number of degrees of freedom: 1,526 (578+81+289+289+289)
    Postprocessing:
      Compositions min/max/mass: -1.223/30/4.262 // -30/2.263/-3.626
 
-Skipping mesh refinement, because the mesh did not change.
+Skipping mesh refinement, because no cells were flagged for refinement/coarsening.
 
 *** Timestep 11:  t=0.6875 seconds, dt=0.0625 seconds
    Solving temperature system... 13 iterations.

--- a/tests/cookbook_mantle_convection_annulus/screen-output
+++ b/tests/cookbook_mantle_convection_annulus/screen-output
@@ -36,7 +36,7 @@ Number of degrees of freedom: 1,272 (480+72+240+240+240)
      Writing stokes residuals            output-cookbook_mantle_convection_annulus/stokes_residuals.txt
      Mobility:                           1.15e-07
 
-Skipping mesh refinement, because the mesh did not change.
+Skipping mesh refinement, because no cells were flagged for refinement/coarsening.
 
 Termination requested by criterion: end time
 

--- a/tests/coupled_two_phase_tian_parameterization_kinematic_slab/screen-output
+++ b/tests/coupled_two_phase_tian_parameterization_kinematic_slab/screen-output
@@ -14,7 +14,7 @@ Number of degrees of freedom: 989 (162+73+162+25+81+81+81+81+81+81+81)
    Solving Stokes system (AMG)... 20+0 iterations.
    Solving fluid velocity system... 1 iterations.
 
-Skipping mesh refinement, because the mesh did not change.
+Skipping mesh refinement, because no cells were flagged for refinement/coarsening.
 
 *** Timestep 0:  t=0 years, dt=0 years
    Solving temperature system... 0 iterations.

--- a/tests/crustal_model_3D/screen-output
+++ b/tests/crustal_model_3D/screen-output
@@ -97,7 +97,7 @@ Number of mesh deformation degrees of freedom: 1,071
      Topography min/max:   0 m, 0 m
      Pressure min/avg/max: -1.005e+08 Pa, 1.869e+08 Pa, 5.418e+08 Pa
 
-Skipping mesh refinement, because the mesh did not change.
+Skipping mesh refinement, because no cells were flagged for refinement/coarsening.
 
 
 

--- a/tests/discontinuous_composition_1/screen-output
+++ b/tests/discontinuous_composition_1/screen-output
@@ -64,7 +64,7 @@ Number of degrees of freedom: 2,100 (578+81+289+576+576)
      Temperature min/avg/max:   -0.004362 K, 0.5 K, 1 K
      Compositions min/max/mass: -0.1982/1.126/0.4167 // -0.2808/1.208/0.4582
 
-Skipping mesh refinement, because the mesh did not change.
+Skipping mesh refinement, because no cells were flagged for refinement/coarsening.
 
 *** Timestep 5:  t=0.3125 seconds, dt=0.0625 seconds
    Solving temperature system... 12 iterations.
@@ -86,7 +86,7 @@ Skipping mesh refinement, because the mesh did not change.
      Temperature min/avg/max:   -0.01149 K, 0.5 K, 1 K
      Compositions min/max/mass: -0.1629/1.125/0.4167 // -0.1426/1.273/0.4581
 
-Skipping mesh refinement, because the mesh did not change.
+Skipping mesh refinement, because no cells were flagged for refinement/coarsening.
 
 *** Timestep 7:  t=0.4375 seconds, dt=0.0625 seconds
    Solving temperature system... 12 iterations.
@@ -108,7 +108,7 @@ Skipping mesh refinement, because the mesh did not change.
      Temperature min/avg/max:   -0.0157 K, 0.4999 K, 1 K
      Compositions min/max/mass: -0.119/1.125/0.4167 // -0.1188/1.327/0.4584
 
-Skipping mesh refinement, because the mesh did not change.
+Skipping mesh refinement, because no cells were flagged for refinement/coarsening.
 
 *** Timestep 9:  t=0.5625 seconds, dt=0.0625 seconds
    Solving temperature system... 11 iterations.
@@ -130,7 +130,7 @@ Skipping mesh refinement, because the mesh did not change.
      Temperature min/avg/max:   -0.01272 K, 0.4997 K, 1 K
      Compositions min/max/mass: -0.1223/1.125/0.4167 // -0.1024/1.368/0.4584
 
-Skipping mesh refinement, because the mesh did not change.
+Skipping mesh refinement, because no cells were flagged for refinement/coarsening.
 
 *** Timestep 11:  t=0.6875 seconds, dt=0.0625 seconds
    Solving temperature system... 11 iterations.
@@ -152,7 +152,7 @@ Skipping mesh refinement, because the mesh did not change.
      Temperature min/avg/max:   -0.0123 K, 0.4996 K, 1 K
      Compositions min/max/mass: -0.1197/1.124/0.4167 // -0.1212/1.235/0.4584
 
-Skipping mesh refinement, because the mesh did not change.
+Skipping mesh refinement, because no cells were flagged for refinement/coarsening.
 
 *** Timestep 13:  t=0.8125 seconds, dt=0.0625 seconds
    Solving temperature system... 11 iterations.
@@ -174,7 +174,7 @@ Skipping mesh refinement, because the mesh did not change.
      Temperature min/avg/max:   -0.007248 K, 0.4996 K, 1 K
      Compositions min/max/mass: -0.09368/1.125/0.4167 // -0.2084/1.374/0.4584
 
-Skipping mesh refinement, because the mesh did not change.
+Skipping mesh refinement, because no cells were flagged for refinement/coarsening.
 
 *** Timestep 15:  t=0.9375 seconds, dt=0.0625 seconds
    Solving temperature system... 11 iterations.
@@ -196,7 +196,7 @@ Skipping mesh refinement, because the mesh did not change.
      Temperature min/avg/max:   -0.006603 K, 0.4996 K, 1 K
      Compositions min/max/mass: -0.2114/1.149/0.4167 // -0.1736/1.403/0.4583
 
-Skipping mesh refinement, because the mesh did not change.
+Skipping mesh refinement, because no cells were flagged for refinement/coarsening.
 
 Termination requested by criterion: end time
 

--- a/tests/discontinuous_composition_bound_preserving_limiter/screen-output
+++ b/tests/discontinuous_composition_bound_preserving_limiter/screen-output
@@ -73,7 +73,7 @@ Number of degrees of freedom: 7,037 (1,988+257+994+1,899+1,899)
      RMS, max velocity:         0.00907 m/year, 0.0205 m/year
      Compositions min/max/mass: -0.02757/1.005/9.858e+09 // -0.02003/2.005/4.241e+10
 
-Skipping mesh refinement, because the mesh did not change.
+Skipping mesh refinement, because no cells were flagged for refinement/coarsening.
 
 *** Timestep 5:  t=971454 years, dt=191051 years
    Skipping temperature solve because RHS is zero.
@@ -85,7 +85,7 @@ Skipping mesh refinement, because the mesh did not change.
      RMS, max velocity:         0.00912 m/year, 0.0206 m/year
      Compositions min/max/mass: -0.02749/1.003/9.859e+09 // -0.02346/2.022/4.241e+10
 
-Skipping mesh refinement, because the mesh did not change.
+Skipping mesh refinement, because no cells were flagged for refinement/coarsening.
 
 *** Timestep 6:  t=1e+06 years, dt=28545.8 years
    Skipping temperature solve because RHS is zero.
@@ -97,7 +97,7 @@ Skipping mesh refinement, because the mesh did not change.
      RMS, max velocity:         0.00913 m/year, 0.0207 m/year
      Compositions min/max/mass: -0.0277/1.003/9.859e+09 // -0.02878/2.017/4.241e+10
 
-Skipping mesh refinement, because the mesh did not change.
+Skipping mesh refinement, because no cells were flagged for refinement/coarsening.
 
 Termination requested by criterion: end time
 

--- a/tests/discontinuous_composition_serial_periodic_amr/screen-output
+++ b/tests/discontinuous_composition_serial_periodic_amr/screen-output
@@ -16,7 +16,7 @@ Number of degrees of freedom: 2,802 (1,098+147+549+1,008)
    Postprocessing:
      Writing graphical output: output-discontinuous_composition_serial_periodic_amr/solution/solution-00000
 
-Skipping mesh refinement, because the mesh did not change.
+Skipping mesh refinement, because no cells were flagged for refinement/coarsening.
 
 *** Timestep 1:  t=0.0625 seconds, dt=0.0625 seconds
    Skipping temperature solve because RHS is zero.
@@ -85,7 +85,7 @@ Number of degrees of freedom: 2,974 (1,138+151+569+1,116)
    Postprocessing:
      Writing graphical output: output-discontinuous_composition_serial_periodic_amr/solution/solution-00007
 
-Skipping mesh refinement, because the mesh did not change.
+Skipping mesh refinement, because no cells were flagged for refinement/coarsening.
 
 *** Timestep 8:  t=0.5 seconds, dt=0.0625 seconds
    Skipping temperature solve because RHS is zero.
@@ -104,7 +104,7 @@ Number of degrees of freedom: 3,509 (1,334+176+667+1,332)
    Postprocessing:
      Writing graphical output: output-discontinuous_composition_serial_periodic_amr/solution/solution-00009
 
-Skipping mesh refinement, because the mesh did not change.
+Skipping mesh refinement, because no cells were flagged for refinement/coarsening.
 
 *** Timestep 10:  t=0.625 seconds, dt=0.0625 seconds
    Skipping temperature solve because RHS is zero.
@@ -113,7 +113,7 @@ Skipping mesh refinement, because the mesh did not change.
    Postprocessing:
      Writing graphical output: output-discontinuous_composition_serial_periodic_amr/solution/solution-00010
 
-Skipping mesh refinement, because the mesh did not change.
+Skipping mesh refinement, because no cells were flagged for refinement/coarsening.
 
 *** Timestep 11:  t=0.6875 seconds, dt=0.0625 seconds
    Skipping temperature solve because RHS is zero.
@@ -122,7 +122,7 @@ Skipping mesh refinement, because the mesh did not change.
    Postprocessing:
      Writing graphical output: output-discontinuous_composition_serial_periodic_amr/solution/solution-00011
 
-Skipping mesh refinement, because the mesh did not change.
+Skipping mesh refinement, because no cells were flagged for refinement/coarsening.
 
 *** Timestep 12:  t=0.75 seconds, dt=0.0625 seconds
    Skipping temperature solve because RHS is zero.
@@ -131,7 +131,7 @@ Skipping mesh refinement, because the mesh did not change.
    Postprocessing:
      Writing graphical output: output-discontinuous_composition_serial_periodic_amr/solution/solution-00012
 
-Skipping mesh refinement, because the mesh did not change.
+Skipping mesh refinement, because no cells were flagged for refinement/coarsening.
 
 *** Timestep 13:  t=0.8125 seconds, dt=0.0625 seconds
    Skipping temperature solve because RHS is zero.
@@ -210,7 +210,7 @@ Number of degrees of freedom: 3,744 (1,410+189+705+1,440)
    Postprocessing:
      Writing graphical output: output-discontinuous_composition_serial_periodic_amr/solution/solution-00020
 
-Skipping mesh refinement, because the mesh did not change.
+Skipping mesh refinement, because no cells were flagged for refinement/coarsening.
 
 *** Timestep 21:  t=1.3125 seconds, dt=0.0625 seconds
    Skipping temperature solve because RHS is zero.
@@ -219,7 +219,7 @@ Skipping mesh refinement, because the mesh did not change.
    Postprocessing:
      Writing graphical output: output-discontinuous_composition_serial_periodic_amr/solution/solution-00021
 
-Skipping mesh refinement, because the mesh did not change.
+Skipping mesh refinement, because no cells were flagged for refinement/coarsening.
 
 *** Timestep 22:  t=1.375 seconds, dt=0.0625 seconds
    Skipping temperature solve because RHS is zero.
@@ -228,7 +228,7 @@ Skipping mesh refinement, because the mesh did not change.
    Postprocessing:
      Writing graphical output: output-discontinuous_composition_serial_periodic_amr/solution/solution-00022
 
-Skipping mesh refinement, because the mesh did not change.
+Skipping mesh refinement, because no cells were flagged for refinement/coarsening.
 
 *** Timestep 23:  t=1.4375 seconds, dt=0.0625 seconds
    Skipping temperature solve because RHS is zero.
@@ -247,7 +247,7 @@ Number of degrees of freedom: 4,359 (1,654+222+827+1,656)
    Postprocessing:
      Writing graphical output: output-discontinuous_composition_serial_periodic_amr/solution/solution-00024
 
-Skipping mesh refinement, because the mesh did not change.
+Skipping mesh refinement, because no cells were flagged for refinement/coarsening.
 
 *** Timestep 25:  t=1.5625 seconds, dt=0.0625 seconds
    Skipping temperature solve because RHS is zero.
@@ -316,7 +316,7 @@ Number of degrees of freedom: 4,359 (1,654+222+827+1,656)
    Postprocessing:
      Writing graphical output: output-discontinuous_composition_serial_periodic_amr/solution/solution-00031
 
-Skipping mesh refinement, because the mesh did not change.
+Skipping mesh refinement, because no cells were flagged for refinement/coarsening.
 
 *** Timestep 32:  t=2 seconds, dt=0.0625 seconds
    Skipping temperature solve because RHS is zero.
@@ -325,7 +325,7 @@ Skipping mesh refinement, because the mesh did not change.
    Postprocessing:
      Writing graphical output: output-discontinuous_composition_serial_periodic_amr/solution/solution-00032
 
-Skipping mesh refinement, because the mesh did not change.
+Skipping mesh refinement, because no cells were flagged for refinement/coarsening.
 
 *** Timestep 33:  t=2.0625 seconds, dt=0.0625 seconds
    Skipping temperature solve because RHS is zero.
@@ -334,7 +334,7 @@ Skipping mesh refinement, because the mesh did not change.
    Postprocessing:
      Writing graphical output: output-discontinuous_composition_serial_periodic_amr/solution/solution-00033
 
-Skipping mesh refinement, because the mesh did not change.
+Skipping mesh refinement, because no cells were flagged for refinement/coarsening.
 
 *** Timestep 34:  t=2.125 seconds, dt=0.0625 seconds
    Skipping temperature solve because RHS is zero.
@@ -343,7 +343,7 @@ Skipping mesh refinement, because the mesh did not change.
    Postprocessing:
      Writing graphical output: output-discontinuous_composition_serial_periodic_amr/solution/solution-00034
 
-Skipping mesh refinement, because the mesh did not change.
+Skipping mesh refinement, because no cells were flagged for refinement/coarsening.
 
 *** Timestep 35:  t=2.1875 seconds, dt=0.0625 seconds
    Skipping temperature solve because RHS is zero.
@@ -362,7 +362,7 @@ Number of degrees of freedom: 3,824 (1,458+197+729+1,440)
    Postprocessing:
      Writing graphical output: output-discontinuous_composition_serial_periodic_amr/solution/solution-00036
 
-Skipping mesh refinement, because the mesh did not change.
+Skipping mesh refinement, because no cells were flagged for refinement/coarsening.
 
 *** Timestep 37:  t=2.3125 seconds, dt=0.0625 seconds
    Skipping temperature solve because RHS is zero.
@@ -371,7 +371,7 @@ Skipping mesh refinement, because the mesh did not change.
    Postprocessing:
      Writing graphical output: output-discontinuous_composition_serial_periodic_amr/solution/solution-00037
 
-Skipping mesh refinement, because the mesh did not change.
+Skipping mesh refinement, because no cells were flagged for refinement/coarsening.
 
 *** Timestep 38:  t=2.375 seconds, dt=0.0625 seconds
    Skipping temperature solve because RHS is zero.
@@ -390,7 +390,7 @@ Number of degrees of freedom: 4,359 (1,654+222+827+1,656)
    Postprocessing:
      Writing graphical output: output-discontinuous_composition_serial_periodic_amr/solution/solution-00039
 
-Skipping mesh refinement, because the mesh did not change.
+Skipping mesh refinement, because no cells were flagged for refinement/coarsening.
 
 *** Timestep 40:  t=2.5 seconds, dt=0.0625 seconds
    Skipping temperature solve because RHS is zero.
@@ -399,7 +399,7 @@ Skipping mesh refinement, because the mesh did not change.
    Postprocessing:
      Writing graphical output: output-discontinuous_composition_serial_periodic_amr/solution/solution-00040
 
-Skipping mesh refinement, because the mesh did not change.
+Skipping mesh refinement, because no cells were flagged for refinement/coarsening.
 
 *** Timestep 41:  t=2.5625 seconds, dt=0.0625 seconds
    Skipping temperature solve because RHS is zero.
@@ -408,7 +408,7 @@ Skipping mesh refinement, because the mesh did not change.
    Postprocessing:
      Writing graphical output: output-discontinuous_composition_serial_periodic_amr/solution/solution-00041
 
-Skipping mesh refinement, because the mesh did not change.
+Skipping mesh refinement, because no cells were flagged for refinement/coarsening.
 
 *** Timestep 42:  t=2.625 seconds, dt=0.0625 seconds
    Skipping temperature solve because RHS is zero.
@@ -417,7 +417,7 @@ Skipping mesh refinement, because the mesh did not change.
    Postprocessing:
      Writing graphical output: output-discontinuous_composition_serial_periodic_amr/solution/solution-00042
 
-Skipping mesh refinement, because the mesh did not change.
+Skipping mesh refinement, because no cells were flagged for refinement/coarsening.
 
 *** Timestep 43:  t=2.6875 seconds, dt=0.0625 seconds
    Skipping temperature solve because RHS is zero.
@@ -466,7 +466,7 @@ Number of degrees of freedom: 4,359 (1,654+222+827+1,656)
    Postprocessing:
      Writing graphical output: output-discontinuous_composition_serial_periodic_amr/solution/solution-00047
 
-Skipping mesh refinement, because the mesh did not change.
+Skipping mesh refinement, because no cells were flagged for refinement/coarsening.
 
 *** Timestep 48:  t=3 seconds, dt=0.0625 seconds
    Skipping temperature solve because RHS is zero.
@@ -475,7 +475,7 @@ Skipping mesh refinement, because the mesh did not change.
    Postprocessing:
      Writing graphical output: output-discontinuous_composition_serial_periodic_amr/solution/solution-00048
 
-Skipping mesh refinement, because the mesh did not change.
+Skipping mesh refinement, because no cells were flagged for refinement/coarsening.
 
 *** Timestep 49:  t=3.0625 seconds, dt=0.0625 seconds
    Skipping temperature solve because RHS is zero.
@@ -484,7 +484,7 @@ Skipping mesh refinement, because the mesh did not change.
    Postprocessing:
      Writing graphical output: output-discontinuous_composition_serial_periodic_amr/solution/solution-00049
 
-Skipping mesh refinement, because the mesh did not change.
+Skipping mesh refinement, because no cells were flagged for refinement/coarsening.
 
 *** Timestep 50:  t=3.125 seconds, dt=0.0625 seconds
    Skipping temperature solve because RHS is zero.
@@ -493,7 +493,7 @@ Skipping mesh refinement, because the mesh did not change.
    Postprocessing:
      Writing graphical output: output-discontinuous_composition_serial_periodic_amr/solution/solution-00050
 
-Skipping mesh refinement, because the mesh did not change.
+Skipping mesh refinement, because no cells were flagged for refinement/coarsening.
 
 *** Timestep 51:  t=3.1875 seconds, dt=0.0625 seconds
    Skipping temperature solve because RHS is zero.
@@ -512,7 +512,7 @@ Number of degrees of freedom: 3,744 (1,410+189+705+1,440)
    Postprocessing:
      Writing graphical output: output-discontinuous_composition_serial_periodic_amr/solution/solution-00052
 
-Skipping mesh refinement, because the mesh did not change.
+Skipping mesh refinement, because no cells were flagged for refinement/coarsening.
 
 *** Timestep 53:  t=3.3125 seconds, dt=0.0625 seconds
    Skipping temperature solve because RHS is zero.
@@ -521,7 +521,7 @@ Skipping mesh refinement, because the mesh did not change.
    Postprocessing:
      Writing graphical output: output-discontinuous_composition_serial_periodic_amr/solution/solution-00053
 
-Skipping mesh refinement, because the mesh did not change.
+Skipping mesh refinement, because no cells were flagged for refinement/coarsening.
 
 *** Timestep 54:  t=3.375 seconds, dt=0.0625 seconds
    Skipping temperature solve because RHS is zero.
@@ -620,7 +620,7 @@ Number of degrees of freedom: 4,303 (1,622+214+811+1,656)
    Postprocessing:
      Writing graphical output: output-discontinuous_composition_serial_periodic_amr/solution/solution-00063
 
-Skipping mesh refinement, because the mesh did not change.
+Skipping mesh refinement, because no cells were flagged for refinement/coarsening.
 
 *** Timestep 64:  t=4 seconds, dt=0.0625 seconds
    Skipping temperature solve because RHS is zero.
@@ -629,7 +629,7 @@ Skipping mesh refinement, because the mesh did not change.
    Postprocessing:
      Writing graphical output: output-discontinuous_composition_serial_periodic_amr/solution/solution-00064
 
-Skipping mesh refinement, because the mesh did not change.
+Skipping mesh refinement, because no cells were flagged for refinement/coarsening.
 
 Termination requested by criterion: end time
 

--- a/tests/discontinuous_temperature/screen-output
+++ b/tests/discontinuous_temperature/screen-output
@@ -64,7 +64,7 @@ Number of degrees of freedom: 1,813 (578+81+576+289+289)
      Temperature min/avg/max:   -0.002034 K, 0.5 K, 1 K
      Compositions min/max/mass: -0.02054/1.11/0.4167 // -0.004788/1.019/0.4583
 
-Skipping mesh refinement, because the mesh did not change.
+Skipping mesh refinement, because no cells were flagged for refinement/coarsening.
 
 *** Timestep 5:  t=0.3125 seconds, dt=0.0625 seconds
    Solving temperature system... 3 iterations.
@@ -86,7 +86,7 @@ Skipping mesh refinement, because the mesh did not change.
      Temperature min/avg/max:   -0.001959 K, 0.5 K, 1 K
      Compositions min/max/mass: -0.01831/1.106/0.4167 // -0.006268/1.014/0.4581
 
-Skipping mesh refinement, because the mesh did not change.
+Skipping mesh refinement, because no cells were flagged for refinement/coarsening.
 
 *** Timestep 7:  t=0.4375 seconds, dt=0.0625 seconds
    Solving temperature system... 3 iterations.
@@ -108,7 +108,7 @@ Skipping mesh refinement, because the mesh did not change.
      Temperature min/avg/max:   -0.005091 K, 0.5 K, 1 K
      Compositions min/max/mass: -0.01676/1.1/0.4167 // -0.007125/1.013/0.4581
 
-Skipping mesh refinement, because the mesh did not change.
+Skipping mesh refinement, because no cells were flagged for refinement/coarsening.
 
 *** Timestep 9:  t=0.5625 seconds, dt=0.0625 seconds
    Solving temperature system... 4 iterations.
@@ -130,7 +130,7 @@ Skipping mesh refinement, because the mesh did not change.
      Temperature min/avg/max:   -0.006984 K, 0.5 K, 1 K
      Compositions min/max/mass: -0.01631/1.093/0.4167 // -0.004574/1.01/0.458
 
-Skipping mesh refinement, because the mesh did not change.
+Skipping mesh refinement, because no cells were flagged for refinement/coarsening.
 
 *** Timestep 11:  t=0.6875 seconds, dt=0.0625 seconds
    Solving temperature system... 4 iterations.
@@ -152,7 +152,7 @@ Skipping mesh refinement, because the mesh did not change.
      Temperature min/avg/max:   -0.007153 K, 0.5 K, 1 K
      Compositions min/max/mass: -0.01569/1.088/0.4167 // -0.00434/1.012/0.4581
 
-Skipping mesh refinement, because the mesh did not change.
+Skipping mesh refinement, because no cells were flagged for refinement/coarsening.
 
 *** Timestep 13:  t=0.8125 seconds, dt=0.0625 seconds
    Solving temperature system... 4 iterations.
@@ -174,7 +174,7 @@ Skipping mesh refinement, because the mesh did not change.
      Temperature min/avg/max:   -0.0074 K, 0.5 K, 1 K
      Compositions min/max/mass: -0.01521/1.085/0.4167 // -0.003175/1.007/0.4581
 
-Skipping mesh refinement, because the mesh did not change.
+Skipping mesh refinement, because no cells were flagged for refinement/coarsening.
 
 *** Timestep 15:  t=0.9375 seconds, dt=0.0625 seconds
    Solving temperature system... 3 iterations.
@@ -196,7 +196,7 @@ Skipping mesh refinement, because the mesh did not change.
      Temperature min/avg/max:   -0.007179 K, 0.5 K, 1 K
      Compositions min/max/mass: -0.01536/1.085/0.4167 // -0.003116/1.006/0.4581
 
-Skipping mesh refinement, because the mesh did not change.
+Skipping mesh refinement, because no cells were flagged for refinement/coarsening.
 
 Termination requested by criterion: end time
 

--- a/tests/dynamic_topography2/screen-output
+++ b/tests/dynamic_topography2/screen-output
@@ -7,7 +7,7 @@ Number of degrees of freedom: 1,237 (578+81+289+289)
    Solving C_1 system ... 0 iterations.
    Solving Stokes system (GMG)... 17+0 iterations.
 
-Skipping mesh refinement, because the mesh did not change.
+Skipping mesh refinement, because no cells were flagged for refinement/coarsening.
 
 *** Timestep 0:  t=0 seconds, dt=0 seconds
    Solving temperature system... 0 iterations.

--- a/tests/edit_parameters/screen-output
+++ b/tests/edit_parameters/screen-output
@@ -14,7 +14,7 @@ Signal start_timestep triggered!
      Temperature min/avg/max: 0 K, 1.159 K, 10 K
      RMS, max velocity:       1.97e-08 m/s, 8.32e-08 m/s
 
-Skipping mesh refinement, because the mesh did not change.
+Skipping mesh refinement, because no cells were flagged for refinement/coarsening.
 
 *** Timestep 1:  t=751090 seconds, dt=751090 seconds
 Signal start_timestep triggered!
@@ -64,7 +64,7 @@ Signal start_timestep triggered!
      Temperature min/avg/max: 0 K, 1.357 K, 10 K
      RMS, max velocity:       3.67e-08 m/s, 1.37e-07 m/s
 
-Skipping mesh refinement, because the mesh did not change.
+Skipping mesh refinement, because no cells were flagged for refinement/coarsening.
 
 *** Timestep 5:  t=2.86541e+06 seconds, dt=456300 seconds
 Signal start_timestep triggered!
@@ -76,7 +76,7 @@ Reducing CFL number!
      Temperature min/avg/max: 0 K, 1.382 K, 10 K
      RMS, max velocity:       3.85e-08 m/s, 1.41e-07 m/s
 
-Skipping mesh refinement, because the mesh did not change.
+Skipping mesh refinement, because no cells were flagged for refinement/coarsening.
 
 *** Timestep 6:  t=3.08768e+06 seconds, dt=222269 seconds
 Signal start_timestep triggered!
@@ -87,7 +87,7 @@ Signal start_timestep triggered!
      Temperature min/avg/max: 0 K, 1.393 K, 10 K
      RMS, max velocity:       3.94e-08 m/s, 1.42e-07 m/s
 
-Skipping mesh refinement, because the mesh did not change.
+Skipping mesh refinement, because no cells were flagged for refinement/coarsening.
 
 *** Timestep 7:  t=3.30732e+06 seconds, dt=219641 seconds
 Signal start_timestep triggered!
@@ -98,7 +98,7 @@ Signal start_timestep triggered!
      Temperature min/avg/max: 0 K, 1.404 K, 10 K
      RMS, max velocity:       4.03e-08 m/s, 1.43e-07 m/s
 
-Skipping mesh refinement, because the mesh did not change.
+Skipping mesh refinement, because no cells were flagged for refinement/coarsening.
 
 *** Timestep 8:  t=3.52459e+06 seconds, dt=217263 seconds
 Signal start_timestep triggered!
@@ -109,7 +109,7 @@ Signal start_timestep triggered!
      Temperature min/avg/max: 0 K, 1.415 K, 10 K
      RMS, max velocity:       4.12e-08 m/s, 1.45e-07 m/s
 
-Skipping mesh refinement, because the mesh did not change.
+Skipping mesh refinement, because no cells were flagged for refinement/coarsening.
 
 *** Timestep 9:  t=3.73957e+06 seconds, dt=214980 seconds
 Signal start_timestep triggered!
@@ -120,7 +120,7 @@ Signal start_timestep triggered!
      Temperature min/avg/max: 0 K, 1.425 K, 10 K
      RMS, max velocity:       4.23e-08 m/s, 1.47e-07 m/s
 
-Skipping mesh refinement, because the mesh did not change.
+Skipping mesh refinement, because no cells were flagged for refinement/coarsening.
 
 *** Timestep 10:  t=3.95222e+06 seconds, dt=212658 seconds
 Signal start_timestep triggered!
@@ -131,7 +131,7 @@ Signal start_timestep triggered!
      Temperature min/avg/max: 0 K, 1.435 K, 10 K
      RMS, max velocity:       4.36e-08 m/s, 1.49e-07 m/s
 
-Skipping mesh refinement, because the mesh did not change.
+Skipping mesh refinement, because no cells were flagged for refinement/coarsening.
 
 Termination requested by criterion: end step
 

--- a/tests/fastscape_test_fixed_ghost_nodes/screen-output
+++ b/tests/fastscape_test_fixed_ghost_nodes/screen-output
@@ -47,7 +47,7 @@ Number of mesh deformation degrees of freedom: 1,722
    Acting according to the parameter 'Nonlinear solver failure strategy':
    Continuing to the next timestep even though solution is not fully converged.
 
-Skipping mesh refinement, because the mesh did not change.
+Skipping mesh refinement, because no cells were flagged for refinement/coarsening.
 
 *** Timestep 0:  t=0 years, dt=0 years
    Solving mesh displacement system... 0 iterations.

--- a/tests/fastscape_test_open_ghost_nodes/screen-output
+++ b/tests/fastscape_test_open_ghost_nodes/screen-output
@@ -47,7 +47,7 @@ Number of mesh deformation degrees of freedom: 1,722
    Acting according to the parameter 'Nonlinear solver failure strategy':
    Continuing to the next timestep even though solution is not fully converged.
 
-Skipping mesh refinement, because the mesh did not change.
+Skipping mesh refinement, because no cells were flagged for refinement/coarsening.
 
 *** Timestep 0:  t=0 years, dt=0 years
    Solving mesh displacement system... 0 iterations.

--- a/tests/fastscape_test_silt_sand_parameters/screen-output
+++ b/tests/fastscape_test_silt_sand_parameters/screen-output
@@ -47,7 +47,7 @@ Number of mesh deformation degrees of freedom: 1,722
    Acting according to the parameter 'Nonlinear solver failure strategy':
    Continuing to the next timestep even though solution is not fully converged.
 
-Skipping mesh refinement, because the mesh did not change.
+Skipping mesh refinement, because no cells were flagged for refinement/coarsening.
 
 *** Timestep 0:  t=0 years, dt=0 years
    Solving mesh displacement system... 0 iterations.

--- a/tests/gmg_mesh_deform_adaptive/screen-output
+++ b/tests/gmg_mesh_deform_adaptive/screen-output
@@ -272,7 +272,7 @@ Number of mesh deformation degrees of freedom: 3,902
    Postprocessing:
      Topography min/max: -300 m, 300 m
 
-Skipping mesh refinement, because the mesh did not change.
+Skipping mesh refinement, because no cells were flagged for refinement/coarsening.
 
 *** Timestep 31:  t=310000 years, dt=10000 years
    Solving mesh displacement system... 4 iterations.
@@ -314,7 +314,7 @@ Skipping mesh refinement, because the mesh did not change.
    Postprocessing:
      Topography min/max: -350 m, 350 m
 
-Skipping mesh refinement, because the mesh did not change.
+Skipping mesh refinement, because no cells were flagged for refinement/coarsening.
 
 *** Timestep 36:  t=360000 years, dt=10000 years
    Solving mesh displacement system... 4 iterations.
@@ -356,7 +356,7 @@ Skipping mesh refinement, because the mesh did not change.
    Postprocessing:
      Topography min/max: -400 m, 400 m
 
-Skipping mesh refinement, because the mesh did not change.
+Skipping mesh refinement, because no cells were flagged for refinement/coarsening.
 
 *** Timestep 41:  t=410000 years, dt=10000 years
    Solving mesh displacement system... 4 iterations.
@@ -398,7 +398,7 @@ Skipping mesh refinement, because the mesh did not change.
    Postprocessing:
      Topography min/max: -450 m, 450 m
 
-Skipping mesh refinement, because the mesh did not change.
+Skipping mesh refinement, because no cells were flagged for refinement/coarsening.
 
 *** Timestep 46:  t=460000 years, dt=10000 years
    Solving mesh displacement system... 4 iterations.
@@ -440,7 +440,7 @@ Skipping mesh refinement, because the mesh did not change.
    Postprocessing:
      Topography min/max: -500 m, 500 m
 
-Skipping mesh refinement, because the mesh did not change.
+Skipping mesh refinement, because no cells were flagged for refinement/coarsening.
 
 Termination requested by criterion: end time
 

--- a/tests/isosurfaces_simple_box_2D_min_max_2/screen-output
+++ b/tests/isosurfaces_simple_box_2D_min_max_2/screen-output
@@ -9,7 +9,7 @@ Number of degrees of freedom: 159 (50+9+25+25+25+25)
 
 *** Timestep 0:  t=0 years, dt=0 years
 
-Skipping mesh refinement, because the mesh did not change.
+Skipping mesh refinement, because no cells were flagged for refinement/coarsening.
 
 *** Timestep 0:  t=0 years, dt=0 years
 

--- a/tests/maximum_horizontal_compressive_stress_case_one/screen-output
+++ b/tests/maximum_horizontal_compressive_stress_case_one/screen-output
@@ -16,7 +16,7 @@ Number of degrees of freedom: 3,041 (2,187+125+729)
      Topography min/max:       0 m, 0 m
      Pressure min/avg/max:     -1.693 Pa, -0.8769 Pa, -0.3025 Pa
 
-Skipping mesh refinement, because the mesh did not change.
+Skipping mesh refinement, because no cells were flagged for refinement/coarsening.
 
 
 

--- a/tests/maximum_horizontal_compressive_stress_case_two/screen-output
+++ b/tests/maximum_horizontal_compressive_stress_case_two/screen-output
@@ -16,7 +16,7 @@ Number of degrees of freedom: 3,041 (2,187+125+729)
      Topography min/max:       0 m, 0 m
      Pressure min/avg/max:     -3.635e-07 Pa, -6.338e-08 Pa, 2.367e-07 Pa
 
-Skipping mesh refinement, because the mesh did not change.
+Skipping mesh refinement, because no cells were flagged for refinement/coarsening.
 
 
 

--- a/tests/maximum_refinement_function_cartesian/screen-output
+++ b/tests/maximum_refinement_function_cartesian/screen-output
@@ -55,7 +55,7 @@ Number of degrees of freedom: 5,784 (3,554+453+1,777)
      Heat fluxes through boundary parts: 4.548e-12 W, 0 W, 0 W, 0.2496 W
      Writing depth average:              output-maximum_refinement_function_cartesian/depth_average
 
-Skipping mesh refinement, because the mesh did not change.
+Skipping mesh refinement, because no cells were flagged for refinement/coarsening.
 
 *** Timestep 0:  t=0 years, dt=0 years
    Solving temperature system... 0 iterations.
@@ -68,7 +68,7 @@ Skipping mesh refinement, because the mesh did not change.
      Heat fluxes through boundary parts: 4.548e-12 W, 0 W, 0 W, 0.2496 W
      Writing depth average:              output-maximum_refinement_function_cartesian/depth_average
 
-Skipping mesh refinement, because the mesh did not change.
+Skipping mesh refinement, because no cells were flagged for refinement/coarsening.
 
 *** Timestep 0:  t=0 years, dt=0 years
    Solving temperature system... 0 iterations.
@@ -96,7 +96,7 @@ Skipping mesh refinement, because the mesh did not change.
      Heat fluxes through boundary parts: 4.548e-12 W, 0 W, 0 W, 0.2496 W
      Writing depth average:              output-maximum_refinement_function_cartesian/depth_average
 
-Skipping mesh refinement, because the mesh did not change.
+Skipping mesh refinement, because no cells were flagged for refinement/coarsening.
 
 Termination requested by criterion: end time
 

--- a/tests/minimum_refinement_function_spherical/screen-output
+++ b/tests/minimum_refinement_function_spherical/screen-output
@@ -70,7 +70,7 @@ Number of degrees of freedom: 7,116 (4,370+561+2,185)
      Heat fluxes through boundary parts: 983.4 W, 1971 W, 0 W, 0 W
      Writing depth average:              output-minimum_refinement_function_spherical/depth_average
 
-Skipping mesh refinement, because the mesh did not change.
+Skipping mesh refinement, because no cells were flagged for refinement/coarsening.
 
 Termination requested by criterion: end time
 

--- a/tests/muparser_temperature_example/screen-output
+++ b/tests/muparser_temperature_example/screen-output
@@ -25,7 +25,7 @@ Number of degrees of freedom: 13,574 (8,322+1,091+4,161)
      RMS, max velocity:        0.00265 m/year, 0.0142 m/year
      Temperature min/avg/max:  273 K, 1621 K, 1683 K
 
-Skipping mesh refinement, because the mesh did not change.
+Skipping mesh refinement, because no cells were flagged for refinement/coarsening.
 
 Termination requested by criterion: end time
 

--- a/tests/no_dirichlet_on_outflow_refine/screen-output
+++ b/tests/no_dirichlet_on_outflow_refine/screen-output
@@ -29,7 +29,7 @@ Number of degrees of freedom: 3,556 (2,178+289+1,089)
      Temperature min/avg/max:            1500 K, 1641 K, 1760 K
      Heat fluxes through boundary parts: 0 W, 0 W, -1.42e+07 W, 1.369e+07 W
 
-Skipping mesh refinement, because the mesh did not change.
+Skipping mesh refinement, because no cells were flagged for refinement/coarsening.
 
 *** Timestep 3:  t=724395 years, dt=240945 years
    Solving temperature system... 14 iterations.
@@ -49,7 +49,7 @@ Skipping mesh refinement, because the mesh did not change.
      Temperature min/avg/max:            1500 K, 1641 K, 1760 K
      Heat fluxes through boundary parts: 0 W, 0 W, -1.42e+07 W, 1.369e+07 W
 
-Skipping mesh refinement, because the mesh did not change.
+Skipping mesh refinement, because no cells were flagged for refinement/coarsening.
 
 *** Timestep 5:  t=1.20579e+06 years, dt=240632 years
    Solving temperature system... 13 iterations.
@@ -69,7 +69,7 @@ Skipping mesh refinement, because the mesh did not change.
      Temperature min/avg/max:            1500 K, 1642 K, 1761 K
      Heat fluxes through boundary parts: 0 W, 0 W, -1.42e+07 W, 1.369e+07 W
 
-Skipping mesh refinement, because the mesh did not change.
+Skipping mesh refinement, because no cells were flagged for refinement/coarsening.
 
 *** Timestep 7:  t=1.68668e+06 years, dt=240382 years
    Solving temperature system... 13 iterations.
@@ -89,7 +89,7 @@ Skipping mesh refinement, because the mesh did not change.
      Temperature min/avg/max:            1500 K, 1642 K, 1761 K
      Heat fluxes through boundary parts: 0 W, 0 W, -1.42e+07 W, 1.369e+07 W
 
-Skipping mesh refinement, because the mesh did not change.
+Skipping mesh refinement, because no cells were flagged for refinement/coarsening.
 
 *** Timestep 9:  t=2e+06 years, dt=73074.7 years
    Solving temperature system... 8 iterations.

--- a/tests/no_flow/screen-output
+++ b/tests/no_flow/screen-output
@@ -79,7 +79,7 @@ Number of degrees of freedom: 268 (162+25+81)
    Postprocessing:
      Writing graphical output: output-no_flow/solution/solution-00010
 
-Skipping mesh refinement, because the mesh did not change.
+Skipping mesh refinement, because no cells were flagged for refinement/coarsening.
 
 *** Timestep 11:  t=0.6875 seconds, dt=0.0625 seconds
    Solving temperature system... 11 iterations.

--- a/tests/nonlinear_failure_strategy_cut_refinement/screen-output
+++ b/tests/nonlinear_failure_strategy_cut_refinement/screen-output
@@ -181,7 +181,7 @@ Repeating the current time step based on the time stepping manager ...
 
    Postprocessing:
 
-Skipping mesh refinement, because the mesh did not change.
+Skipping mesh refinement, because no cells were flagged for refinement/coarsening.
 
 *** Timestep 3:  t=11990.4 years, dt=3521.33 years
    Solving temperature system... 10 iterations.
@@ -243,7 +243,7 @@ Repeating the current time step based on the time stepping manager ...
 
    Postprocessing:
 
-Skipping mesh refinement, because the mesh did not change.
+Skipping mesh refinement, because no cells were flagged for refinement/coarsening.
 
 *** Timestep 4:  t=13592.7 years, dt=3362.87 years
    Solving temperature system... 9 iterations.
@@ -267,7 +267,7 @@ Skipping mesh refinement, because the mesh did not change.
 
    Postprocessing:
 
-Skipping mesh refinement, because the mesh did not change.
+Skipping mesh refinement, because no cells were flagged for refinement/coarsening.
 
 *** Timestep 5:  t=14000 years, dt=407.349 years
    Solving temperature system... 8 iterations.
@@ -285,7 +285,7 @@ Skipping mesh refinement, because the mesh did not change.
 
    Postprocessing:
 
-Skipping mesh refinement, because the mesh did not change.
+Skipping mesh refinement, because no cells were flagged for refinement/coarsening.
 
 Termination requested by criterion: end time
 

--- a/tests/particles/particle_load_balancing_refinement/screen-output
+++ b/tests/particles/particle_load_balancing_refinement/screen-output
@@ -23,7 +23,7 @@ Number of degrees of freedom: 678 (316+46+158+158)
    Postprocessing:
      Writing particle output: output-particle_load_balancing_refinement/particles/particles-00001
 
-Skipping mesh refinement, because the mesh did not change.
+Skipping mesh refinement, because no cells were flagged for refinement/coarsening.
 
 Termination requested by criterion: end time
 

--- a/tests/particles/particle_load_balancing_refinement_02/screen-output
+++ b/tests/particles/particle_load_balancing_refinement_02/screen-output
@@ -23,7 +23,7 @@ Number of degrees of freedom: 678 (316+46+158+158)
    Postprocessing:
      Writing particle output: output-particle_load_balancing_refinement_02/particles/particles-00001
 
-Skipping mesh refinement, because the mesh did not change.
+Skipping mesh refinement, because no cells were flagged for refinement/coarsening.
 
 *** Timestep 2:  t=183.96 seconds, dt=83.0635 seconds
    Skipping temperature solve because RHS is zero.
@@ -46,7 +46,7 @@ Number of degrees of freedom: 246 (114+18+57+57)
    Postprocessing:
      Writing particle output: output-particle_load_balancing_refinement_02/particles/particles-00002
 
-Skipping mesh refinement, because the mesh did not change.
+Skipping mesh refinement, because no cells were flagged for refinement/coarsening.
 
 *** Timestep 4:  t=329.535 seconds, dt=82.6156 seconds
    Skipping temperature solve because RHS is zero.
@@ -57,7 +57,7 @@ Skipping mesh refinement, because the mesh did not change.
    Postprocessing:
      Writing particle output: output-particle_load_balancing_refinement_02/particles/particles-00003
 
-Skipping mesh refinement, because the mesh did not change.
+Skipping mesh refinement, because no cells were flagged for refinement/coarsening.
 
 *** Timestep 5:  t=381.672 seconds, dt=52.1373 seconds
    Skipping temperature solve because RHS is zero.
@@ -68,7 +68,7 @@ Skipping mesh refinement, because the mesh did not change.
    Postprocessing:
      Number of advected particles: 10
 
-Skipping mesh refinement, because the mesh did not change.
+Skipping mesh refinement, because no cells were flagged for refinement/coarsening.
 
 *** Timestep 6:  t=437.294 seconds, dt=55.6217 seconds
    Skipping temperature solve because RHS is zero.
@@ -79,7 +79,7 @@ Skipping mesh refinement, because the mesh did not change.
    Postprocessing:
      Writing particle output: output-particle_load_balancing_refinement_02/particles/particles-00004
 
-Skipping mesh refinement, because the mesh did not change.
+Skipping mesh refinement, because no cells were flagged for refinement/coarsening.
 
 *** Timestep 7:  t=482.628 seconds, dt=45.3338 seconds
    Skipping temperature solve because RHS is zero.
@@ -90,7 +90,7 @@ Skipping mesh refinement, because the mesh did not change.
    Postprocessing:
      Number of advected particles: 10
 
-Skipping mesh refinement, because the mesh did not change.
+Skipping mesh refinement, because no cells were flagged for refinement/coarsening.
 
 *** Timestep 8:  t=500 seconds, dt=17.3721 seconds
    Skipping temperature solve because RHS is zero.
@@ -101,7 +101,7 @@ Skipping mesh refinement, because the mesh did not change.
    Postprocessing:
      Writing particle output: output-particle_load_balancing_refinement_02/particles/particles-00005
 
-Skipping mesh refinement, because the mesh did not change.
+Skipping mesh refinement, because no cells were flagged for refinement/coarsening.
 
 Termination requested by criterion: end time
 

--- a/tests/particles/particle_load_balancing_removal/screen-output
+++ b/tests/particles/particle_load_balancing_removal/screen-output
@@ -23,7 +23,7 @@ Number of degrees of freedom: 246 (114+18+57+57)
    Postprocessing:
      Writing particle output: output-particle_load_balancing_removal/particles/particles-00001
 
-Skipping mesh refinement, because the mesh did not change.
+Skipping mesh refinement, because no cells were flagged for refinement/coarsening.
 
 Termination requested by criterion: end time
 

--- a/tests/particles/particle_load_balancing_removal_addition/screen-output
+++ b/tests/particles/particle_load_balancing_removal_addition/screen-output
@@ -23,7 +23,7 @@ Number of degrees of freedom: 246 (114+18+57+57)
    Postprocessing:
      Writing particle output: output-particle_load_balancing_removal_addition/particles/particles-00001
 
-Skipping mesh refinement, because the mesh did not change.
+Skipping mesh refinement, because no cells were flagged for refinement/coarsening.
 
 Termination requested by criterion: end time
 

--- a/tests/particles/particle_load_balancing_removal_addition_properties/screen-output
+++ b/tests/particles/particle_load_balancing_removal_addition_properties/screen-output
@@ -23,7 +23,7 @@ Number of degrees of freedom: 246 (114+18+57+57)
    Postprocessing:
      Number of advected particles: 70
 
-Skipping mesh refinement, because the mesh did not change.
+Skipping mesh refinement, because no cells were flagged for refinement/coarsening.
 
 *** Timestep 2:  t=456.087 seconds, dt=207.601 seconds
    Skipping temperature solve because RHS is zero.
@@ -34,7 +34,7 @@ Skipping mesh refinement, because the mesh did not change.
    Postprocessing:
      Number of advected particles: 74
 
-Skipping mesh refinement, because the mesh did not change.
+Skipping mesh refinement, because no cells were flagged for refinement/coarsening.
 
 *** Timestep 3:  t=500 seconds, dt=43.9128 seconds
    Skipping temperature solve because RHS is zero.
@@ -45,7 +45,7 @@ Skipping mesh refinement, because the mesh did not change.
    Postprocessing:
      Writing particle output: output-particle_load_balancing_removal_addition_properties/particles/particles-00001
 
-Skipping mesh refinement, because the mesh did not change.
+Skipping mesh refinement, because no cells were flagged for refinement/coarsening.
 
 Termination requested by criterion: end time
 

--- a/tests/point_value_02_mpi/screen-output
+++ b/tests/point_value_02_mpi/screen-output
@@ -380,7 +380,7 @@ Number of degrees of freedom: 349 (162+25+81+81)
      Writing graphical output: output-point_value_02_mpi/solution/solution-00040
      Writing point values:     output-point_value_02_mpi/point_values.txt
 
-Skipping mesh refinement, because the mesh did not change.
+Skipping mesh refinement, because no cells were flagged for refinement/coarsening.
 
 *** Timestep 41:  t=0.000218985 years, dt=1.08647e-05 years
    Skipping temperature solve because RHS is zero.
@@ -472,7 +472,7 @@ Skipping mesh refinement, because the mesh did not change.
      Writing graphical output: output-point_value_02_mpi/solution/solution-00050
      Writing point values:     output-point_value_02_mpi/point_values.txt
 
-Skipping mesh refinement, because the mesh did not change.
+Skipping mesh refinement, because no cells were flagged for refinement/coarsening.
 
 *** Timestep 51:  t=0.000432163 years, dt=1.94605e-05 years
    Skipping temperature solve because RHS is zero.
@@ -564,7 +564,7 @@ Skipping mesh refinement, because the mesh did not change.
      Writing graphical output: output-point_value_02_mpi/solution/solution-00060
      Writing point values:     output-point_value_02_mpi/point_values.txt
 
-Skipping mesh refinement, because the mesh did not change.
+Skipping mesh refinement, because no cells were flagged for refinement/coarsening.
 
 *** Timestep 61:  t=0.000688323 years, dt=1.47148e-05 years
    Skipping temperature solve because RHS is zero.
@@ -656,7 +656,7 @@ Skipping mesh refinement, because the mesh did not change.
      Writing graphical output: output-point_value_02_mpi/solution/solution-00070
      Writing point values:     output-point_value_02_mpi/point_values.txt
 
-Skipping mesh refinement, because the mesh did not change.
+Skipping mesh refinement, because no cells were flagged for refinement/coarsening.
 
 *** Timestep 71:  t=0.000990939 years, dt=2.68441e-05 years
    Skipping temperature solve because RHS is zero.

--- a/tests/point_value_03/screen-output
+++ b/tests/point_value_03/screen-output
@@ -10,9 +10,9 @@ Number of degrees of freedom: 220 (132+22+66)
      Writing graphical output: output-point_value_03/solution/solution-00000
      Writing point values:     output-point_value_03/point_values.txt
 
-Skipping mesh refinement, because the mesh did not change.
+Skipping mesh refinement, because no cells were flagged for refinement/coarsening.
 
-Skipping mesh refinement, because the mesh did not change.
+Skipping mesh refinement, because no cells were flagged for refinement/coarsening.
 
 Termination requested by criterion: end time
 *** Snapshot output-point_value_03/restart/01/ created!

--- a/tests/point_value_specific_output_times/screen-output
+++ b/tests/point_value_specific_output_times/screen-output
@@ -10,9 +10,9 @@ Number of degrees of freedom: 220 (132+22+66)
      Writing graphical output: output-point_value_specific_output_times/solution/solution-00000
      Writing point values:     output-point_value_specific_output_times/point_values.txt
 
-Skipping mesh refinement, because the mesh did not change.
+Skipping mesh refinement, because no cells were flagged for refinement/coarsening.
 
-Skipping mesh refinement, because the mesh did not change.
+Skipping mesh refinement, because no cells were flagged for refinement/coarsening.
 
 *** Timestep 1:  t=3e+16 seconds, dt=3e+16 seconds
    Solving temperature system... 9 iterations.

--- a/tests/refinement_artificial_viscosity_2/screen-output
+++ b/tests/refinement_artificial_viscosity_2/screen-output
@@ -32,7 +32,7 @@ Number of degrees of freedom: 5,734 (2,178+289+1,089+1,089+1,089)
      Temperature min/avg/max:   0.08147 K, 0.1773 K, 0.5327 K
      Compositions min/max/mass: 0.04343/1.054/0.1693 // -4.415/100.6/78.14
 
-Skipping mesh refinement, because the mesh did not change.
+Skipping mesh refinement, because no cells were flagged for refinement/coarsening.
 
 *** Timestep 3:  t=0.0662913 seconds, dt=0.0220971 seconds
    Solving temperature system... 16 iterations.

--- a/tests/refinement_nonadiabatic_temperature/screen-output
+++ b/tests/refinement_nonadiabatic_temperature/screen-output
@@ -195,7 +195,7 @@ Number of degrees of freedom: 6,370 (3,906+511+1,953)
      Temperature min/avg/max:            0 K, 0.5 K, 1 K
      Heat fluxes through boundary parts: 0 W, 0 W, -1.2 W, 1.2 W
 
-Skipping mesh refinement, because the mesh did not change.
+Skipping mesh refinement, because no cells were flagged for refinement/coarsening.
 
 *** Timestep 15:  t=0.0183368 seconds, dt=0.000322007 seconds
    Solving temperature system... 13 iterations.

--- a/tests/shear_heating_with_melt/screen-output
+++ b/tests/shear_heating_with_melt/screen-output
@@ -31,7 +31,7 @@ Number of degrees of freedom: 1,663 (486+202+486+82+243+82+82)
       Relative nonlinear residual (total system) after nonlinear iteration 3: 4.81749e-06
 
 
-Skipping mesh refinement, because the mesh did not change.
+Skipping mesh refinement, because no cells were flagged for refinement/coarsening.
 
 *** Timestep 0:  t=0 years, dt=0 years
    Solving temperature system... 0 iterations.

--- a/tests/skip_refinement/screen-output
+++ b/tests/skip_refinement/screen-output
@@ -113,7 +113,7 @@ Number of mesh deformation degrees of freedom: 1,158
       Relative nonlinear residual (total system) after nonlinear iteration 2: 7.50815e-10
 
 
-Skipping mesh refinement, because the mesh did not change.
+Skipping mesh refinement, because no cells were flagged for refinement/coarsening.
 
 *** Timestep 0:  t=0 years, dt=0 years
    Solving mesh displacement system... 0 iterations.
@@ -155,7 +155,7 @@ Skipping mesh refinement, because the mesh did not change.
      Topography min/max:        0 m, 0 m
      RMS, max velocity:         0.388 m/year, 1.57 m/year
 
-Skipping mesh refinement, because the mesh did not change.
+Skipping mesh refinement, because no cells were flagged for refinement/coarsening.
 
 *** Timestep 1:  t=50 years, dt=50 years
    Solving mesh displacement system... 5 iterations.
@@ -212,7 +212,7 @@ Skipping mesh refinement, because the mesh did not change.
      Topography min/max:        -3.064e-06 m, 1.045e-06 m
      RMS, max velocity:         0.161 m/year, 0.663 m/year
 
-Skipping mesh refinement, because the mesh did not change.
+Skipping mesh refinement, because no cells were flagged for refinement/coarsening.
 
 *** Timestep 2:  t=100 years, dt=50 years
    Solving mesh displacement system... 4 iterations.
@@ -269,7 +269,7 @@ Skipping mesh refinement, because the mesh did not change.
      Topography min/max:        -5.838e-06 m, -1.655e-06 m
      RMS, max velocity:         0.0995 m/year, 0.45 m/year
 
-Skipping mesh refinement, because the mesh did not change.
+Skipping mesh refinement, because no cells were flagged for refinement/coarsening.
 
 Termination requested by criterion: end time
 

--- a/tests/time_stepping_function/screen-output
+++ b/tests/time_stepping_function/screen-output
@@ -68,7 +68,7 @@ Number of degrees of freedom: 948 (578+81+289)
 
    Postprocessing:
 
-Skipping mesh refinement, because the mesh did not change.
+Skipping mesh refinement, because no cells were flagged for refinement/coarsening.
 
 *** Timestep 11:  t=2202.27 seconds, dt=113.055 seconds
    Solving temperature system... 2 iterations.
@@ -130,7 +130,7 @@ Skipping mesh refinement, because the mesh did not change.
 
    Postprocessing:
 
-Skipping mesh refinement, because the mesh did not change.
+Skipping mesh refinement, because no cells were flagged for refinement/coarsening.
 
 *** Timestep 21:  t=3293.51 seconds, dt=132.505 seconds
    Solving temperature system... 2 iterations.
@@ -192,7 +192,7 @@ Skipping mesh refinement, because the mesh did not change.
 
    Postprocessing:
 
-Skipping mesh refinement, because the mesh did not change.
+Skipping mesh refinement, because no cells were flagged for refinement/coarsening.
 
 *** Timestep 31:  t=5654.66 seconds, dt=305.349 seconds
    Solving temperature system... 3 iterations.
@@ -254,7 +254,7 @@ Skipping mesh refinement, because the mesh did not change.
 
    Postprocessing:
 
-Skipping mesh refinement, because the mesh did not change.
+Skipping mesh refinement, because no cells were flagged for refinement/coarsening.
 
 *** Timestep 41:  t=8724.99 seconds, dt=308.417 seconds
    Solving temperature system... 3 iterations.
@@ -316,7 +316,7 @@ Skipping mesh refinement, because the mesh did not change.
 
    Postprocessing:
 
-Skipping mesh refinement, because the mesh did not change.
+Skipping mesh refinement, because no cells were flagged for refinement/coarsening.
 
 *** Timestep 51:  t=11826.2 seconds, dt=311.515 seconds
    Solving temperature system... 3 iterations.
@@ -378,7 +378,7 @@ Skipping mesh refinement, because the mesh did not change.
 
    Postprocessing:
 
-Skipping mesh refinement, because the mesh did not change.
+Skipping mesh refinement, because no cells were flagged for refinement/coarsening.
 
 *** Timestep 61:  t=14958.5 seconds, dt=314.644 seconds
    Solving temperature system... 3 iterations.

--- a/tests/time_stepping_function_years/screen-output
+++ b/tests/time_stepping_function_years/screen-output
@@ -68,7 +68,7 @@ Number of degrees of freedom: 948 (578+81+289)
 
    Postprocessing:
 
-Skipping mesh refinement, because the mesh did not change.
+Skipping mesh refinement, because no cells were flagged for refinement/coarsening.
 
 *** Timestep 11:  t=2202.27 years, dt=113.055 years
    Solving temperature system... 22 iterations.
@@ -130,7 +130,7 @@ Skipping mesh refinement, because the mesh did not change.
 
    Postprocessing:
 
-Skipping mesh refinement, because the mesh did not change.
+Skipping mesh refinement, because no cells were flagged for refinement/coarsening.
 
 *** Timestep 21:  t=3293.51 years, dt=132.505 years
    Solving temperature system... 2 iterations.
@@ -192,7 +192,7 @@ Skipping mesh refinement, because the mesh did not change.
 
    Postprocessing:
 
-Skipping mesh refinement, because the mesh did not change.
+Skipping mesh refinement, because no cells were flagged for refinement/coarsening.
 
 *** Timestep 31:  t=5654.66 years, dt=305.349 years
    Solving temperature system... 12 iterations.
@@ -254,7 +254,7 @@ Skipping mesh refinement, because the mesh did not change.
 
    Postprocessing:
 
-Skipping mesh refinement, because the mesh did not change.
+Skipping mesh refinement, because no cells were flagged for refinement/coarsening.
 
 *** Timestep 41:  t=8724.99 years, dt=308.417 years
    Solving temperature system... 1 iterations.
@@ -316,7 +316,7 @@ Skipping mesh refinement, because the mesh did not change.
 
    Postprocessing:
 
-Skipping mesh refinement, because the mesh did not change.
+Skipping mesh refinement, because no cells were flagged for refinement/coarsening.
 
 *** Timestep 51:  t=11826.2 years, dt=311.515 years
    Solving temperature system... 2 iterations.
@@ -378,7 +378,7 @@ Skipping mesh refinement, because the mesh did not change.
 
    Postprocessing:
 
-Skipping mesh refinement, because the mesh did not change.
+Skipping mesh refinement, because no cells were flagged for refinement/coarsening.
 
 *** Timestep 61:  t=14958.5 years, dt=314.644 years
    Solving temperature system... 6 iterations.

--- a/tests/time_stepping_min/screen-output
+++ b/tests/time_stepping_min/screen-output
@@ -68,7 +68,7 @@ Number of degrees of freedom: 948 (578+81+289)
 
    Postprocessing:
 
-Skipping mesh refinement, because the mesh did not change.
+Skipping mesh refinement, because no cells were flagged for refinement/coarsening.
 
 *** Timestep 11:  t=2202.27 seconds, dt=113.055 seconds
    Solving temperature system... 2 iterations.
@@ -130,7 +130,7 @@ Skipping mesh refinement, because the mesh did not change.
 
    Postprocessing:
 
-Skipping mesh refinement, because the mesh did not change.
+Skipping mesh refinement, because no cells were flagged for refinement/coarsening.
 
 *** Timestep 21:  t=3295.41 seconds, dt=132.666 seconds
    Solving temperature system... 2 iterations.
@@ -192,7 +192,7 @@ Skipping mesh refinement, because the mesh did not change.
 
    Postprocessing:
 
-Skipping mesh refinement, because the mesh did not change.
+Skipping mesh refinement, because no cells were flagged for refinement/coarsening.
 
 *** Timestep 31:  t=5658.77 seconds, dt=305.353 seconds
    Solving temperature system... 3 iterations.
@@ -254,7 +254,7 @@ Skipping mesh refinement, because the mesh did not change.
 
    Postprocessing:
 
-Skipping mesh refinement, because the mesh did not change.
+Skipping mesh refinement, because no cells were flagged for refinement/coarsening.
 
 *** Timestep 41:  t=8729.15 seconds, dt=308.421 seconds
    Solving temperature system... 3 iterations.
@@ -316,7 +316,7 @@ Skipping mesh refinement, because the mesh did not change.
 
    Postprocessing:
 
-Skipping mesh refinement, because the mesh did not change.
+Skipping mesh refinement, because no cells were flagged for refinement/coarsening.
 
 *** Timestep 51:  t=11830.4 seconds, dt=311.519 seconds
    Solving temperature system... 3 iterations.
@@ -378,7 +378,7 @@ Skipping mesh refinement, because the mesh did not change.
 
    Postprocessing:
 
-Skipping mesh refinement, because the mesh did not change.
+Skipping mesh refinement, because no cells were flagged for refinement/coarsening.
 
 *** Timestep 61:  t=14962.7 seconds, dt=314.648 seconds
    Solving temperature system... 3 iterations.

--- a/tests/uncoupled_two_phase_tian_parameterization_kinematic_slab/screen-output
+++ b/tests/uncoupled_two_phase_tian_parameterization_kinematic_slab/screen-output
@@ -12,7 +12,7 @@ Number of degrees of freedom: 754 (162+25+81+81+81+81+81+81+81)
    Skipping sediment composition solve because RHS is zero.
    Solving Stokes system (GMG)... 25+0 iterations.
 
-Skipping mesh refinement, because the mesh did not change.
+Skipping mesh refinement, because no cells were flagged for refinement/coarsening.
 
 *** Timestep 0:  t=0 years, dt=0 years
    Solving temperature system... 0 iterations.

--- a/tests/vof_circle_amr/screen-output
+++ b/tests/vof_circle_amr/screen-output
@@ -68,7 +68,7 @@ Number of degrees of freedom: 6,623 (2,194+283+1,097+1,097+244+732+976)
    Postprocessing:
      Global volume of fluid volumes (m^3): 0.785
 
-Skipping mesh refinement, because the mesh did not change.
+Skipping mesh refinement, because no cells were flagged for refinement/coarsening.
 
 *** Timestep 4:  t=0.0883883 seconds, dt=0.0220971 seconds
    Skipping temperature solve because RHS is zero.
@@ -100,7 +100,7 @@ Number of degrees of freedom: 6,773 (2,242+289+1,121+1,121+250+750+1,000)
    Postprocessing:
      Global volume of fluid volumes (m^3): 0.785
 
-Skipping mesh refinement, because the mesh did not change.
+Skipping mesh refinement, because no cells were flagged for refinement/coarsening.
 
 *** Timestep 7:  t=0.15468 seconds, dt=0.0220971 seconds
    Skipping temperature solve because RHS is zero.
@@ -110,7 +110,7 @@ Skipping mesh refinement, because the mesh did not change.
    Postprocessing:
      Global volume of fluid volumes (m^3): 0.785
 
-Skipping mesh refinement, because the mesh did not change.
+Skipping mesh refinement, because no cells were flagged for refinement/coarsening.
 
 *** Timestep 8:  t=0.176777 seconds, dt=0.0220971 seconds
    Skipping temperature solve because RHS is zero.
@@ -131,7 +131,7 @@ Number of degrees of freedom: 6,623 (2,194+283+1,097+1,097+244+732+976)
    Postprocessing:
      Global volume of fluid volumes (m^3): 0.785
 
-Skipping mesh refinement, because the mesh did not change.
+Skipping mesh refinement, because no cells were flagged for refinement/coarsening.
 
 *** Timestep 10:  t=0.220971 seconds, dt=0.0220971 seconds
    Skipping temperature solve because RHS is zero.


### PR DESCRIPTION
This wording has bothered me for a while: "Skipping mesh refinement, because the mesh did not change". That's just poorly phrased.


### For all pull requests:

* [x] I have followed the [instructions for indenting my code](../blob/main/CONTRIBUTING.md#making-aspect-better).
* I followed the [AI Policy](../blob/main/CONTRIBUTING.md#policy-on-usage-of-ai):
  - [ ] Significant parts of this PR were written by AI (please add a sentence below).
  - [x] AI has not been used in significant ways.

*If yes, please describe your usage of AI models in the creation of this pull request*

### For new features/models or changes of existing features:

* [ ] I have tested my new feature locally to ensure it is correct.
* [ ] I have [created a testcase](https://aspect-documentation.readthedocs.io/en/latest/user/extending/testing/writing-tests.html) for the new feature/benchmark in the [tests/](../blob/main/tests/) directory.
* [ ] I have added a changelog entry in the [doc/modules/changes](../blob/main/doc/modules/changes) directory that will inform other users of my change.
