### PR TITLE
Add FastScape documentation to manual and tester

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -48,6 +48,13 @@ jobs:
         cd
         rm -rf astyle*
         astyle --version
+
+        git clone --single-branch --branch aspect_tester https://github.com/anne-glerum/fastscapelib-fortran.git
+        cd fastscapelib-fortran
+        mkdir build
+        cd build
+        /usr/bin/cmake -DBUILD_FASTSCAPELIB_SHARED=ON ..
+        make
     - name: make indent
       run: |
         ./contrib/utilities/indent
@@ -72,6 +79,7 @@ jobs:
         mkdir build
         cd build
         /usr/bin/cmake -D CMAKE_BUILD_TYPE=Debug -D ASPECT_PRECOMPILE_HEADERS=OFF -D ASPECT_UNITY_BUILD=OFF \
+                       -D ASPECT_WITH_FASTSCAPE=ON -D FASTSCAPE_DIR=/home/runner/fastscapelib-fortran/build \
                        -D CMAKE_CXX_FLAGS='-Werror' -D ASPECT_ADDITIONAL_CXX_FLAGS='-Wdeprecated-declarations' -D ASPECT_INSTALL_EXAMPLES=ON ..
         make -j 4
         ./aspect --test

--- a/doc/sphinx/parameters/Mesh_20deformation.md
+++ b/doc/sphinx/parameters/Mesh_20deformation.md
@@ -36,6 +36,12 @@ Using this definition, the plugin then solves for one time step, i.e., using as 
 
 This surface velocity is used to deform the surface and as a boundary condition for solving the Laplace equation to determine the mesh velocity in the domain interior. Diffusion can be applied every timestep, mimicking surface processes of erosion and deposition, or at a user-defined timestep interval to purely smooth the surface topography to avoid too great a distortion of mesh elements when a free surface is also used.
 
+&lsquo;fastscape&rsquo;: A plugin that uses the program FastScape to compute the deformation of the mesh surface. FastScape is a surface processes code that computes the erosion, transport and deposition of sediments both on land and in the marine domain. These surface processes include river incision (through the stream power law), hillslope diffusion and marine diffusion, as described in Braun and Willett 2013; Yuan et al. 2019; Yuan et al. 2019b.
+Upon initialization, FastScape requires the initial topography of the surface boundary of ASPECT&rsquo;s model domain and several user-specified erosional and depositional parameters. In each ASPECT timestep, FastScape is then fed ASPECT&rsquo;s material velocity at the surface boundary. The z-component of this velocity is used to uplift the FastScape surface, while the horizontal components are used to advect the topography in the x-y plane.
+After solving its governing equations (this can be done in several timesteps that are smaller than the ASPECT timestep), FastScape returns a new topography of the surface. The difference in topography before and after the call to FastScape divided by the ASPECT timestep provides the mesh velocity at the domain&rsquo;s surface that is used to displace the surface and internal mesh nodes.
+FastScape can be used in both 2D and 3D ASPECT simulations. In 2D, one can think of the coupled model as a T-model.The ASPECT domain spans the x - z plane, while FastScape acts on the horizontal x-y plane. This means that to communicate ASPECT&rsquo;s material velocities to FastScape, FastScape mesh nodes with the same x-coordinate (so lying along the y-direction) get the same velocities. In turn, the FastScape topography is collapsed back onto the line of the ASPECT surface boundary by averaging the topography over the y-direction. In 3D no such actions are necessary.
+The FastScape manual (https://fastscape.org/fastscapelib-fortran/) provides more information on the input parameters.
+
 &lsquo;free surface&rsquo;: A plugin that computes the deformation of surface vertices according to the solution of the flow problem. In particular this means if the surface of the domain is left open to flow, this flow will carry the mesh with it. The implementation was described in {cite}`rose_freesurface`, with the stabilization of the free surface originally described in {cite}`kaus:etal:2010`.
 ::::
 
@@ -128,6 +134,629 @@ If the function you are describing represents a vector-valued function with mult
 **Pattern:** [Integer range 0...2147483647 (inclusive)]
 
 **Documentation:** The number of time steps between each application of diffusion.
+::::
+
+(parameters:Mesh_20deformation/Fastscape)=
+## **Subsection:** Mesh deformation / Fastscape
+::::{dropdown} __Parameter:__ {ref}`Additional fastscape refinement<parameters:Mesh_20deformation/Fastscape/Additional_20fastscape_20refinement>`
+:name: parameters:Mesh_20deformation/Fastscape/Additional_20fastscape_20refinement
+**Default value:** 0
+
+**Pattern:** [Integer range -2147483648...2147483647 (inclusive)]
+
+**Documentation:** How many levels above the ASPECT mesh the FastScape mesh should be refined.
+::::
+
+::::{dropdown} __Parameter:__ {ref}`Additional output variables<parameters:Mesh_20deformation/Fastscape/Additional_20output_20variables>`
+:name: parameters:Mesh_20deformation/Fastscape/Additional_20output_20variables
+**Default value:** river incision rate
+
+**Pattern:** [Selection river incision rate|transport coefficient|uplift rate ]
+
+**Documentation:** Select one additional Fastscape variable to output in the Fastcape vtk. Output are in units of per year.
+::::
+
+::::{dropdown} __Parameter:__ {ref}`Average out of plane surface topography in 2d<parameters:Mesh_20deformation/Fastscape/Average_20out_20of_20plane_20surface_20topography_20in_202d>`
+:name: parameters:Mesh_20deformation/Fastscape/Average_20out_20of_20plane_20surface_20topography_20in_202d
+**Default value:** true
+
+**Pattern:** [Bool]
+
+**Documentation:** If this is set to false, then a 2D model will only consider the center slice FastScape gives. If set to true, then ASPECT will average the mesh along Y excluding the ghost nodes.
+::::
+
+::::{dropdown} __Parameter:__ {ref}`Fastscape seed<parameters:Mesh_20deformation/Fastscape/Fastscape_20seed>`
+:name: parameters:Mesh_20deformation/Fastscape/Fastscape_20seed
+**Default value:** 1000
+
+**Pattern:** [Integer range -2147483648...2147483647 (inclusive)]
+
+**Documentation:** Seed used for adding an initial noise to FastScape topography based on the initial noise magnitude.
+::::
+
+::::{dropdown} __Parameter:__ {ref}`Initial noise magnitude<parameters:Mesh_20deformation/Fastscape/Initial_20noise_20magnitude>`
+:name: parameters:Mesh_20deformation/Fastscape/Initial_20noise_20magnitude
+**Default value:** 5
+
+**Pattern:** [Double -MAX_DOUBLE...MAX_DOUBLE (inclusive)]
+
+**Documentation:** Maximum topography change from the initial noise. Units: ${m}$
+::::
+
+::::{dropdown} __Parameter:__ {ref}`Maximum surface refinement level<parameters:Mesh_20deformation/Fastscape/Maximum_20surface_20refinement_20level>`
+:name: parameters:Mesh_20deformation/Fastscape/Maximum_20surface_20refinement_20level
+**Default value:** 1
+
+**Pattern:** [Integer range -2147483648...2147483647 (inclusive)]
+
+**Documentation:** This should be set to the highest ASPECT refinement level expected at the surface.
+::::
+
+::::{dropdown} __Parameter:__ {ref}`Maximum timestep length<parameters:Mesh_20deformation/Fastscape/Maximum_20timestep_20length>`
+:name: parameters:Mesh_20deformation/Fastscape/Maximum_20timestep_20length
+**Default value:** 10e3
+
+**Pattern:** [Double 0...MAX_DOUBLE (inclusive)]
+
+**Documentation:** Maximum timestep for FastScape. Units: ${yrs}$
+::::
+
+::::{dropdown} __Parameter:__ {ref}`Node tolerance<parameters:Mesh_20deformation/Fastscape/Node_20tolerance>`
+:name: parameters:Mesh_20deformation/Fastscape/Node_20tolerance
+**Default value:** 0.001
+
+**Pattern:** [Double -MAX_DOUBLE...MAX_DOUBLE (inclusive)]
+
+**Documentation:** Node tolerance for how close an ASPECT node must be to a FastScape node for the value to be transferred.
+::::
+
+::::{dropdown} __Parameter:__ {ref}`Number of fastscape timesteps per aspect timestep<parameters:Mesh_20deformation/Fastscape/Number_20of_20fastscape_20timesteps_20per_20aspect_20timestep>`
+:name: parameters:Mesh_20deformation/Fastscape/Number_20of_20fastscape_20timesteps_20per_20aspect_20timestep
+**Default value:** 5
+
+**Pattern:** [Integer range -2147483648...2147483647 (inclusive)]
+
+**Documentation:** Initial number of fastscape time steps per ASPECT timestep, this value will double if the FastScape timestep is above the maximum FastScape timestep.
+::::
+
+::::{dropdown} __Parameter:__ {ref}`Sediment rain rates<parameters:Mesh_20deformation/Fastscape/Sediment_20rain_20rates>`
+:name: parameters:Mesh_20deformation/Fastscape/Sediment_20rain_20rates
+**Default value:** 0,0
+
+**Pattern:** [List of <[Double 0...MAX_DOUBLE (inclusive)]> of length 0...4294967295 (inclusive)]
+
+**Documentation:** Sediment rain rates given as a list 1 greater than the number of sediment rain time intervals. E.g, If the time interval is given at 5 Myr, there will be one value for 0-5 Myr model time and a second value for 5+ Myr. Units: ${m/yr}$
+::::
+
+::::{dropdown} __Parameter:__ {ref}`Sediment rain time intervals<parameters:Mesh_20deformation/Fastscape/Sediment_20rain_20time_20intervals>`
+:name: parameters:Mesh_20deformation/Fastscape/Sediment_20rain_20time_20intervals
+**Default value:** 0
+
+**Pattern:** [List of <[Double 0...MAX_DOUBLE (inclusive)]> of length 0...4294967295 (inclusive)]
+
+**Documentation:** A list of times to change the sediment rain rate. Units: ${yrs}$
+::::
+
+::::{dropdown} __Parameter:__ {ref}`Surface refinement difference<parameters:Mesh_20deformation/Fastscape/Surface_20refinement_20difference>`
+:name: parameters:Mesh_20deformation/Fastscape/Surface_20refinement_20difference
+**Default value:** 0
+
+**Pattern:** [Integer range -2147483648...2147483647 (inclusive)]
+
+**Documentation:** The difference between the lowest and highest refinement level at the surface. E.g., if three resolution levels are expected, this would be set to two.
+::::
+
+::::{dropdown} __Parameter:__ {ref}`Uplift and advect with fastscape<parameters:Mesh_20deformation/Fastscape/Uplift_20and_20advect_20with_20fastscape>`
+:name: parameters:Mesh_20deformation/Fastscape/Uplift_20and_20advect_20with_20fastscape
+**Default value:** true
+
+**Pattern:** [Bool]
+
+**Documentation:** Flag to use FastScape advection and uplift.
+::::
+
+::::{dropdown} __Parameter:__ {ref}`Use ghost nodes<parameters:Mesh_20deformation/Fastscape/Use_20ghost_20nodes>`
+:name: parameters:Mesh_20deformation/Fastscape/Use_20ghost_20nodes
+**Default value:** true
+
+**Pattern:** [Bool]
+
+**Documentation:** Flag to use ghost nodes.
+::::
+
+::::{dropdown} __Parameter:__ {ref}`Use marine component<parameters:Mesh_20deformation/Fastscape/Use_20marine_20component>`
+:name: parameters:Mesh_20deformation/Fastscape/Use_20marine_20component
+**Default value:** false
+
+**Pattern:** [Bool]
+
+**Documentation:** Flag to use the marine component of FastScape.
+::::
+
+::::{dropdown} __Parameter:__ {ref}`Vertical exaggeration<parameters:Mesh_20deformation/Fastscape/Vertical_20exaggeration>`
+:name: parameters:Mesh_20deformation/Fastscape/Vertical_20exaggeration
+**Default value:** -1
+
+**Pattern:** [Double -MAX_DOUBLE...MAX_DOUBLE (inclusive)]
+
+**Documentation:** Vertical exaggeration for FastScape&rsquo;s VTK file. -1 outputs topography, basement, and sealevel.
+::::
+
+::::{dropdown} __Parameter:__ {ref}`Y extent in 2d<parameters:Mesh_20deformation/Fastscape/Y_20extent_20in_202d>`
+:name: parameters:Mesh_20deformation/Fastscape/Y_20extent_20in_202d
+**Default value:** 100000
+
+**Pattern:** [Double -MAX_DOUBLE...MAX_DOUBLE (inclusive)]
+
+**Documentation:** FastScape Y extent when using a 2D ASPECT model. Units: ${m}$
+::::
+
+(parameters:Mesh_20deformation/Fastscape/Boundary_20conditions)=
+## **Subsection:** Mesh deformation / Fastscape / Boundary conditions
+::::{dropdown} __Parameter:__ {ref}`Back<parameters:Mesh_20deformation/Fastscape/Boundary_20conditions/Back>`
+:name: parameters:Mesh_20deformation/Fastscape/Boundary_20conditions/Back
+**Default value:** 1
+
+**Pattern:** [Integer range 0...1 (inclusive)]
+
+**Documentation:** Back (top) boundary condition, where 1 is fixed and 0 is reflective.
+::::
+
+::::{dropdown} __Parameter:__ {ref}`Back front ghost nodes periodic<parameters:Mesh_20deformation/Fastscape/Boundary_20conditions/Back_20front_20ghost_20nodes_20periodic>`
+:name: parameters:Mesh_20deformation/Fastscape/Boundary_20conditions/Back_20front_20ghost_20nodes_20periodic
+**Default value:** false
+
+**Pattern:** [Bool]
+
+**Documentation:** Whether to set the ghost nodes at the FastScape back and front boundary to periodic even if &rsquo;Back&rsquo; and &rsquo;Front&rsquo; are set to fixed boundary.
+::::
+
+::::{dropdown} __Parameter:__ {ref}`Back mass flux<parameters:Mesh_20deformation/Fastscape/Boundary_20conditions/Back_20mass_20flux>`
+:name: parameters:Mesh_20deformation/Fastscape/Boundary_20conditions/Back_20mass_20flux
+**Default value:** 0
+
+**Pattern:** [Double -MAX_DOUBLE...MAX_DOUBLE (inclusive)]
+
+**Documentation:** Flux per unit length through the back boundary. Units: ${m^2/yr}$
+::::
+
+::::{dropdown} __Parameter:__ {ref}`Front<parameters:Mesh_20deformation/Fastscape/Boundary_20conditions/Front>`
+:name: parameters:Mesh_20deformation/Fastscape/Boundary_20conditions/Front
+**Default value:** 1
+
+**Pattern:** [Integer range 0...1 (inclusive)]
+
+**Documentation:** Front (bottom) boundary condition, where 1 is fixed and 0 is reflective.
+::::
+
+::::{dropdown} __Parameter:__ {ref}`Front mass flux<parameters:Mesh_20deformation/Fastscape/Boundary_20conditions/Front_20mass_20flux>`
+:name: parameters:Mesh_20deformation/Fastscape/Boundary_20conditions/Front_20mass_20flux
+**Default value:** 0
+
+**Pattern:** [Double -MAX_DOUBLE...MAX_DOUBLE (inclusive)]
+
+**Documentation:** Flux per unit length through the front boundary. Units: ${m^2/yr}$
+::::
+
+::::{dropdown} __Parameter:__ {ref}`Left<parameters:Mesh_20deformation/Fastscape/Boundary_20conditions/Left>`
+:name: parameters:Mesh_20deformation/Fastscape/Boundary_20conditions/Left
+**Default value:** 1
+
+**Pattern:** [Integer range 0...1 (inclusive)]
+
+**Documentation:** Left boundary condition, where 1 is fixed and 0 is reflective.
+::::
+
+::::{dropdown} __Parameter:__ {ref}`Left mass flux<parameters:Mesh_20deformation/Fastscape/Boundary_20conditions/Left_20mass_20flux>`
+:name: parameters:Mesh_20deformation/Fastscape/Boundary_20conditions/Left_20mass_20flux
+**Default value:** 0
+
+**Pattern:** [Double -MAX_DOUBLE...MAX_DOUBLE (inclusive)]
+
+**Documentation:** Flux per unit length through the left boundary. Units: ${m^2/yr}$
+::::
+
+::::{dropdown} __Parameter:__ {ref}`Left right ghost nodes periodic<parameters:Mesh_20deformation/Fastscape/Boundary_20conditions/Left_20right_20ghost_20nodes_20periodic>`
+:name: parameters:Mesh_20deformation/Fastscape/Boundary_20conditions/Left_20right_20ghost_20nodes_20periodic
+**Default value:** false
+
+**Pattern:** [Bool]
+
+**Documentation:** Whether to set the ghost nodes at the FastScape left and right boundary to periodic even if &rsquo;Left&rsquo; and &rsquo;Right&rsquo; are set to fixed boundary.
+::::
+
+::::{dropdown} __Parameter:__ {ref}`Right<parameters:Mesh_20deformation/Fastscape/Boundary_20conditions/Right>`
+:name: parameters:Mesh_20deformation/Fastscape/Boundary_20conditions/Right
+**Default value:** 1
+
+**Pattern:** [Integer range 0...1 (inclusive)]
+
+**Documentation:** Right boundary condition, where 1 is fixed and 0 is reflective.
+::::
+
+::::{dropdown} __Parameter:__ {ref}`Right mass flux<parameters:Mesh_20deformation/Fastscape/Boundary_20conditions/Right_20mass_20flux>`
+:name: parameters:Mesh_20deformation/Fastscape/Boundary_20conditions/Right_20mass_20flux
+**Default value:** 0
+
+**Pattern:** [Double -MAX_DOUBLE...MAX_DOUBLE (inclusive)]
+
+**Documentation:** Flux per unit length through the right boundary. Units: ${m^2/yr}$
+::::
+
+(parameters:Mesh_20deformation/Fastscape/Erosional_20parameters)=
+## **Subsection:** Mesh deformation / Fastscape / Erosional parameters
+::::{dropdown} __Parameter:__ {ref}`Bedrock deposition coefficient<parameters:Mesh_20deformation/Fastscape/Erosional_20parameters/Bedrock_20deposition_20coefficient>`
+:name: parameters:Mesh_20deformation/Fastscape/Erosional_20parameters/Bedrock_20deposition_20coefficient
+**Default value:** 1
+
+**Pattern:** [Double -MAX_DOUBLE...MAX_DOUBLE (inclusive)]
+
+**Documentation:** Deposition coefficient for bedrock.
+::::
+
+::::{dropdown} __Parameter:__ {ref}`Bedrock diffusivity<parameters:Mesh_20deformation/Fastscape/Erosional_20parameters/Bedrock_20diffusivity>`
+:name: parameters:Mesh_20deformation/Fastscape/Erosional_20parameters/Bedrock_20diffusivity
+**Default value:** 1e-2
+
+**Pattern:** [Double -MAX_DOUBLE...MAX_DOUBLE (inclusive)]
+
+**Documentation:** Transport coefficient (diffusivity) for bedrock. Units: ${m^2/yr}$ if &ldquo;Use years instead of seconds&rdquo; is true; otherwise, the units are ${m^2/s}$.
+::::
+
+::::{dropdown} __Parameter:__ {ref}`Bedrock river incision rate<parameters:Mesh_20deformation/Fastscape/Erosional_20parameters/Bedrock_20river_20incision_20rate>`
+:name: parameters:Mesh_20deformation/Fastscape/Erosional_20parameters/Bedrock_20river_20incision_20rate
+**Default value:** 1e-5
+
+**Pattern:** [Double -MAX_DOUBLE...MAX_DOUBLE (inclusive)]
+
+**Documentation:** River incision rate for bedrock in the Stream Power Law. Units: ${m^(1-2drainage_area_exponent)/yr}$ if &ldquo;Use years instead of seconds&rdquo; is true; otherwise, the units are ${m^(1-2drainage_area_exponent)/s}$.
+::::
+
+::::{dropdown} __Parameter:__ {ref}`Drainage area exponent<parameters:Mesh_20deformation/Fastscape/Erosional_20parameters/Drainage_20area_20exponent>`
+:name: parameters:Mesh_20deformation/Fastscape/Erosional_20parameters/Drainage_20area_20exponent
+**Default value:** 0.4
+
+**Pattern:** [Double -MAX_DOUBLE...MAX_DOUBLE (inclusive)]
+
+**Documentation:** The drainage area exponent for the Stream Power Law (m).
+::::
+
+::::{dropdown} __Parameter:__ {ref}`Elevation factor<parameters:Mesh_20deformation/Fastscape/Erosional_20parameters/Elevation_20factor>`
+:name: parameters:Mesh_20deformation/Fastscape/Erosional_20parameters/Elevation_20factor
+**Default value:** 1
+
+**Pattern:** [Double -MAX_DOUBLE...MAX_DOUBLE (inclusive)]
+
+**Documentation:** Amount to multiply the bedrock river incision rate and transport coefficient by past the given orographic elevation control.
+::::
+
+::::{dropdown} __Parameter:__ {ref}`Erosional base level<parameters:Mesh_20deformation/Fastscape/Erosional_20parameters/Erosional_20base_20level>`
+:name: parameters:Mesh_20deformation/Fastscape/Erosional_20parameters/Erosional_20base_20level
+**Default value:** 0
+
+**Pattern:** [Double -MAX_DOUBLE...MAX_DOUBLE (inclusive)]
+
+**Documentation:** When &rsquo;Use a fixed erosional base level&rsquo; is set to true, all ghost nodes of fixed FastScape boundaries where no mass flux is specified by the user (FastScape boundary condition set to 1 and &rsquo;Left/Right/Bottom/Top mass flux&rsquo; set to 0) will be fixed to this elevation. The reflecting boundaries (FastScape boundary condition set to 0) will not be affected, nor are the boundaries where a mass flux is specified.
+Units: m
+::::
+
+::::{dropdown} __Parameter:__ {ref}`Flag to use orographic controls<parameters:Mesh_20deformation/Fastscape/Erosional_20parameters/Flag_20to_20use_20orographic_20controls>`
+:name: parameters:Mesh_20deformation/Fastscape/Erosional_20parameters/Flag_20to_20use_20orographic_20controls
+**Default value:** false
+
+**Pattern:** [Bool]
+
+**Documentation:** Whether or not to apply orographic controls.
+::::
+
+::::{dropdown} __Parameter:__ {ref}`Multi-direction slope exponent<parameters:Mesh_20deformation/Fastscape/Erosional_20parameters/Multi_2ddirection_20slope_20exponent>`
+:name: parameters:Mesh_20deformation/Fastscape/Erosional_20parameters/Multi_2ddirection_20slope_20exponent
+**Default value:** 1
+
+**Pattern:** [Double -MAX_DOUBLE...MAX_DOUBLE (inclusive)]
+
+**Documentation:** Exponent to determine the distribution from the SPL to neighbor nodes, with 10 being steepest decent and 1 being more varied.
+::::
+
+::::{dropdown} __Parameter:__ {ref}`Orographic elevation control<parameters:Mesh_20deformation/Fastscape/Erosional_20parameters/Orographic_20elevation_20control>`
+:name: parameters:Mesh_20deformation/Fastscape/Erosional_20parameters/Orographic_20elevation_20control
+**Default value:** 2000
+
+**Pattern:** [Integer range -2147483648...2147483647 (inclusive)]
+
+**Documentation:** Above this height, the elevation factor is applied. Units: ${m}$
+::::
+
+::::{dropdown} __Parameter:__ {ref}`Orographic wind barrier height<parameters:Mesh_20deformation/Fastscape/Erosional_20parameters/Orographic_20wind_20barrier_20height>`
+:name: parameters:Mesh_20deformation/Fastscape/Erosional_20parameters/Orographic_20wind_20barrier_20height
+**Default value:** 500
+
+**Pattern:** [Integer range -2147483648...2147483647 (inclusive)]
+
+**Documentation:** When terrain reaches this height the wind barrier factor is applied. Units: ${m}$
+::::
+
+::::{dropdown} __Parameter:__ {ref}`Sediment deposition coefficient<parameters:Mesh_20deformation/Fastscape/Erosional_20parameters/Sediment_20deposition_20coefficient>`
+:name: parameters:Mesh_20deformation/Fastscape/Erosional_20parameters/Sediment_20deposition_20coefficient
+**Default value:** -1
+
+**Pattern:** [Double -MAX_DOUBLE...MAX_DOUBLE (inclusive)]
+
+**Documentation:** Deposition coefficient for sediment. A value smaller than 0 sets this to the same as the bedrock deposition coefficient.
+::::
+
+::::{dropdown} __Parameter:__ {ref}`Sediment diffusivity<parameters:Mesh_20deformation/Fastscape/Erosional_20parameters/Sediment_20diffusivity>`
+:name: parameters:Mesh_20deformation/Fastscape/Erosional_20parameters/Sediment_20diffusivity
+**Default value:** -1
+
+**Pattern:** [Double -MAX_DOUBLE...MAX_DOUBLE (inclusive)]
+
+**Documentation:** Transport coefficient (diffusivity) for sediment. -1 sets this to the bedrock diffusivity. Units: ${m^2/yr}$ if &ldquo;Use years instead of seconds&rdquo; is true; otherwise, the units are ${m^2/s}$.
+::::
+
+::::{dropdown} __Parameter:__ {ref}`Sediment river incision rate<parameters:Mesh_20deformation/Fastscape/Erosional_20parameters/Sediment_20river_20incision_20rate>`
+:name: parameters:Mesh_20deformation/Fastscape/Erosional_20parameters/Sediment_20river_20incision_20rate
+**Default value:** -1
+
+**Pattern:** [Double -MAX_DOUBLE...MAX_DOUBLE (inclusive)]
+
+**Documentation:** River incision rate for sediment in the Stream Power Law. A value smaller than 0 sets this to the bedrock river incision rate. Units: $m^(1-2drainage_area_exponent)/yr}$ if &ldquo;Use years instead of seconds&rdquo; is true; otherwise, the units are $m^(1-2drainage_area_exponent)/s}$.
+::::
+
+::::{dropdown} __Parameter:__ {ref}`Slope exponent<parameters:Mesh_20deformation/Fastscape/Erosional_20parameters/Slope_20exponent>`
+:name: parameters:Mesh_20deformation/Fastscape/Erosional_20parameters/Slope_20exponent
+**Default value:** 1
+
+**Pattern:** [Double -MAX_DOUBLE...MAX_DOUBLE (inclusive)]
+
+**Documentation:** The slope exponent for the Stream Power Law (n). Generally m/n should equal approximately 0.4
+::::
+
+::::{dropdown} __Parameter:__ {ref}`Stack orographic controls<parameters:Mesh_20deformation/Fastscape/Erosional_20parameters/Stack_20orographic_20controls>`
+:name: parameters:Mesh_20deformation/Fastscape/Erosional_20parameters/Stack_20orographic_20controls
+**Default value:** true
+
+**Pattern:** [Bool]
+
+**Documentation:** Whether or not to apply both controls to a point, or only a maximum of one set as the wind barrier.
+::::
+
+::::{dropdown} __Parameter:__ {ref}`Use a fixed erosional base level<parameters:Mesh_20deformation/Fastscape/Erosional_20parameters/Use_20a_20fixed_20erosional_20base_20level>`
+:name: parameters:Mesh_20deformation/Fastscape/Erosional_20parameters/Use_20a_20fixed_20erosional_20base_20level
+**Default value:** false
+
+**Pattern:** [Bool]
+
+**Documentation:** Whether or not to use an erosional base level that differs from sea level. Setting this parameter to true will set all ghost nodes of fixed FastScape boundaries to the height you specify in &rsquo;set Erosional base level&rsquo;.
+This can make sense for a continental model where the model surrounding topography is assumed above sea level, e.g. highlands. If the sea level would be used as an erosional base level in this case, all topography erodes away with lots of &rsquo;sediment volume&rsquo; lost through the sides of the model. This is mostly important, when there are mountains in the middle of the model, while it is less important when there is lower relief in the middle of the model.
+In the FastScape  visualization files, setting the extra base level may show up as a strong slope at the fixed boundaries of the model. However, in the ASPECT visualization files it will not show up, as the ghost nodes only exist in FastScape.
+::::
+
+::::{dropdown} __Parameter:__ {ref}`Use kd distribution function<parameters:Mesh_20deformation/Fastscape/Erosional_20parameters/Use_20kd_20distribution_20function>`
+:name: parameters:Mesh_20deformation/Fastscape/Erosional_20parameters/Use_20kd_20distribution_20function
+**Default value:** false
+
+**Pattern:** [Bool]
+
+**Documentation:** Whether to define Bedrock transport coefficient (diffusivity) using a distribution function. If false, a constant kd value will be used, which can be specified by setting the parameter &ldquo;Bedrock diffusivity&rdquo;. Units: ${m^2/yr}$ if &ldquo;Use years instead of seconds&rdquo; is true; otherwise, the units are ${m^2/s}$.
+::::
+
+::::{dropdown} __Parameter:__ {ref}`Use kf distribution function<parameters:Mesh_20deformation/Fastscape/Erosional_20parameters/Use_20kf_20distribution_20function>`
+:name: parameters:Mesh_20deformation/Fastscape/Erosional_20parameters/Use_20kf_20distribution_20function
+**Default value:** false
+
+**Pattern:** [Bool]
+
+**Documentation:** Whether to define bedrock river incision rate using a distribution function. If false, a constant kf value will be used, which can be specified by setting the parameter &ldquo;Bedrock river incision rate&rdquo;. Units: ${m^(1-2drainage_area_exponent)/yr}$ if &ldquo;Use years instead of seconds&rdquo; is true; otherwise, the units are ${m^(1-2drainage_area_exponent)/s}$.
+::::
+
+::::{dropdown} __Parameter:__ {ref}`Wind barrier factor<parameters:Mesh_20deformation/Fastscape/Erosional_20parameters/Wind_20barrier_20factor>`
+:name: parameters:Mesh_20deformation/Fastscape/Erosional_20parameters/Wind_20barrier_20factor
+**Default value:** 1
+
+**Pattern:** [Double -MAX_DOUBLE...MAX_DOUBLE (inclusive)]
+
+**Documentation:** Amount to multiply the bedrock river incision rate and transport coefficient by past given wind barrier height.
+::::
+
+::::{dropdown} __Parameter:__ {ref}`Wind direction<parameters:Mesh_20deformation/Fastscape/Erosional_20parameters/Wind_20direction>`
+:name: parameters:Mesh_20deformation/Fastscape/Erosional_20parameters/Wind_20direction
+**Default value:** west
+
+**Pattern:** [Selection east|west|south|north ]
+
+**Documentation:** This parameter assumes a wind direction, deciding which side is reduced from the wind barrier.
+::::
+
+(parameters:Mesh_20deformation/Fastscape/Erosional_20parameters/kd_20distribution_20function)=
+## **Subsection:** Mesh deformation / Fastscape / Erosional parameters / kd distribution function
+::::{dropdown} __Parameter:__ {ref}`Function constants<parameters:Mesh_20deformation/Fastscape/Erosional_20parameters/kd_20distribution_20function/Function_20constants>`
+:name: parameters:Mesh_20deformation/Fastscape/Erosional_20parameters/kd_20distribution_20function/Function_20constants
+**Default value:**
+
+**Pattern:** [Anything]
+
+**Documentation:** Sometimes it is convenient to use symbolic constants in the expression that describes the function, rather than having to use its numeric value everywhere the constant appears. These values can be defined using this parameter, in the form &lsquo;var1=value1, var2=value2, ...&rsquo;.
+
+A typical example would be to set this runtime parameter to &lsquo;pi=3.1415926536&rsquo; and then use &lsquo;pi&rsquo; in the expression of the actual formula. (That said, for convenience this class actually defines both &lsquo;pi&rsquo; and &lsquo;Pi&rsquo; by default, but you get the idea.)
+::::
+
+::::{dropdown} __Parameter:__ {ref}`Function expression<parameters:Mesh_20deformation/Fastscape/Erosional_20parameters/kd_20distribution_20function/Function_20expression>`
+:name: parameters:Mesh_20deformation/Fastscape/Erosional_20parameters/kd_20distribution_20function/Function_20expression
+**Default value:** 0; 0
+
+**Pattern:** [Anything]
+
+**Documentation:** The formula that denotes the function you want to evaluate for particular values of the independent variables. This expression may contain any of the usual operations such as addition or multiplication, as well as all of the common functions such as &lsquo;sin&rsquo; or &lsquo;cos&rsquo;. In addition, it may contain expressions like &lsquo;if(x>0, 1, -1)&rsquo; where the expression evaluates to the second argument if the first argument is true, and to the third argument otherwise. For a full overview of possible expressions accepted see the documentation of the muparser library at http://muparser.beltoforion.de/.
+
+If the function you are describing represents a vector-valued function with multiple components, then separate the expressions for individual components by a semicolon.
+::::
+
+::::{dropdown} __Parameter:__ {ref}`Variable names<parameters:Mesh_20deformation/Fastscape/Erosional_20parameters/kd_20distribution_20function/Variable_20names>`
+:name: parameters:Mesh_20deformation/Fastscape/Erosional_20parameters/kd_20distribution_20function/Variable_20names
+**Default value:** x,y,t
+
+**Pattern:** [Anything]
+
+**Documentation:** The names of the variables as they will be used in the function, separated by commas. By default, the names of variables at which the function will be evaluated are &lsquo;x&rsquo; (in 1d), &lsquo;x,y&rsquo; (in 2d) or &lsquo;x,y,z&rsquo; (in 3d) for spatial coordinates and &lsquo;t&rsquo; for time. You can then use these variable names in your function expression and they will be replaced by the values of these variables at which the function is currently evaluated. However, you can also choose a different set of names for the independent variables at which to evaluate your function expression. For example, if you work in spherical coordinates, you may wish to set this input parameter to &lsquo;r,phi,theta,t&rsquo; and then use these variable names in your function expression.
+::::
+
+(parameters:Mesh_20deformation/Fastscape/Erosional_20parameters/kf_20distribution_20function)=
+## **Subsection:** Mesh deformation / Fastscape / Erosional parameters / kf distribution function
+::::{dropdown} __Parameter:__ {ref}`Function constants<parameters:Mesh_20deformation/Fastscape/Erosional_20parameters/kf_20distribution_20function/Function_20constants>`
+:name: parameters:Mesh_20deformation/Fastscape/Erosional_20parameters/kf_20distribution_20function/Function_20constants
+**Default value:**
+
+**Pattern:** [Anything]
+
+**Documentation:** Sometimes it is convenient to use symbolic constants in the expression that describes the function, rather than having to use its numeric value everywhere the constant appears. These values can be defined using this parameter, in the form &lsquo;var1=value1, var2=value2, ...&rsquo;.
+
+A typical example would be to set this runtime parameter to &lsquo;pi=3.1415926536&rsquo; and then use &lsquo;pi&rsquo; in the expression of the actual formula. (That said, for convenience this class actually defines both &lsquo;pi&rsquo; and &lsquo;Pi&rsquo; by default, but you get the idea.)
+::::
+
+::::{dropdown} __Parameter:__ {ref}`Function expression<parameters:Mesh_20deformation/Fastscape/Erosional_20parameters/kf_20distribution_20function/Function_20expression>`
+:name: parameters:Mesh_20deformation/Fastscape/Erosional_20parameters/kf_20distribution_20function/Function_20expression
+**Default value:** 0; 0
+
+**Pattern:** [Anything]
+
+**Documentation:** The formula that denotes the function you want to evaluate for particular values of the independent variables. This expression may contain any of the usual operations such as addition or multiplication, as well as all of the common functions such as &lsquo;sin&rsquo; or &lsquo;cos&rsquo;. In addition, it may contain expressions like &lsquo;if(x>0, 1, -1)&rsquo; where the expression evaluates to the second argument if the first argument is true, and to the third argument otherwise. For a full overview of possible expressions accepted see the documentation of the muparser library at http://muparser.beltoforion.de/.
+
+If the function you are describing represents a vector-valued function with multiple components, then separate the expressions for individual components by a semicolon.
+::::
+
+::::{dropdown} __Parameter:__ {ref}`Variable names<parameters:Mesh_20deformation/Fastscape/Erosional_20parameters/kf_20distribution_20function/Variable_20names>`
+:name: parameters:Mesh_20deformation/Fastscape/Erosional_20parameters/kf_20distribution_20function/Variable_20names
+**Default value:** x,y,t
+
+**Pattern:** [Anything]
+
+**Documentation:** The names of the variables as they will be used in the function, separated by commas. By default, the names of variables at which the function will be evaluated are &lsquo;x&rsquo; (in 1d), &lsquo;x,y&rsquo; (in 2d) or &lsquo;x,y,z&rsquo; (in 3d) for spatial coordinates and &lsquo;t&rsquo; for time. You can then use these variable names in your function expression and they will be replaced by the values of these variables at which the function is currently evaluated. However, you can also choose a different set of names for the independent variables at which to evaluate your function expression. For example, if you work in spherical coordinates, you may wish to set this input parameter to &lsquo;r,phi,theta,t&rsquo; and then use these variable names in your function expression.
+::::
+
+(parameters:Mesh_20deformation/Fastscape/Marine_20parameters)=
+## **Subsection:** Mesh deformation / Fastscape / Marine parameters
+::::{dropdown} __Parameter:__ {ref}`Depth averaging thickness<parameters:Mesh_20deformation/Fastscape/Marine_20parameters/Depth_20averaging_20thickness>`
+:name: parameters:Mesh_20deformation/Fastscape/Marine_20parameters/Depth_20averaging_20thickness
+**Default value:** 1e2
+
+**Pattern:** [Double -MAX_DOUBLE...MAX_DOUBLE (inclusive)]
+
+**Documentation:** Depth averaging for the sand-silt equation. Units: ${m}$
+::::
+
+::::{dropdown} __Parameter:__ {ref}`Sand e-folding depth<parameters:Mesh_20deformation/Fastscape/Marine_20parameters/Sand_20e_2dfolding_20depth>`
+:name: parameters:Mesh_20deformation/Fastscape/Marine_20parameters/Sand_20e_2dfolding_20depth
+**Default value:** 1e3
+
+**Pattern:** [Double -MAX_DOUBLE...MAX_DOUBLE (inclusive)]
+
+**Documentation:** E-folding depth for the exponential of the sand porosity law. Units: ${m}$
+::::
+
+::::{dropdown} __Parameter:__ {ref}`Sand porosity<parameters:Mesh_20deformation/Fastscape/Marine_20parameters/Sand_20porosity>`
+:name: parameters:Mesh_20deformation/Fastscape/Marine_20parameters/Sand_20porosity
+**Default value:** 0.0
+
+**Pattern:** [Double -MAX_DOUBLE...MAX_DOUBLE (inclusive)]
+
+**Documentation:** Porosity of sand.
+::::
+
+::::{dropdown} __Parameter:__ {ref}`Sand transport coefficient<parameters:Mesh_20deformation/Fastscape/Marine_20parameters/Sand_20transport_20coefficient>`
+:name: parameters:Mesh_20deformation/Fastscape/Marine_20parameters/Sand_20transport_20coefficient
+**Default value:** 5e2
+
+**Pattern:** [Double -MAX_DOUBLE...MAX_DOUBLE (inclusive)]
+
+**Documentation:** Transport coefficient (diffusivity) for sand. Units: ${m^2/yr}$
+::::
+
+::::{dropdown} __Parameter:__ {ref}`Sea level<parameters:Mesh_20deformation/Fastscape/Marine_20parameters/Sea_20level>`
+:name: parameters:Mesh_20deformation/Fastscape/Marine_20parameters/Sea_20level
+**Default value:** 0.0
+
+**Pattern:** [Double -MAX_DOUBLE...MAX_DOUBLE (inclusive)]
+
+**Documentation:** Constant sea level relative to the ASPECT surface, where the maximum Z or Y extent in ASPECT is a sea level of zero. Units: ${m}$
+::::
+
+::::{dropdown} __Parameter:__ {ref}`Silt e-folding depth<parameters:Mesh_20deformation/Fastscape/Marine_20parameters/Silt_20e_2dfolding_20depth>`
+:name: parameters:Mesh_20deformation/Fastscape/Marine_20parameters/Silt_20e_2dfolding_20depth
+**Default value:** 1e3
+
+**Pattern:** [Double -MAX_DOUBLE...MAX_DOUBLE (inclusive)]
+
+**Documentation:** E-folding depth for the exponential of the silt porosity law. Units: ${m}$
+::::
+
+::::{dropdown} __Parameter:__ {ref}`Silt fraction<parameters:Mesh_20deformation/Fastscape/Marine_20parameters/Silt_20fraction>`
+:name: parameters:Mesh_20deformation/Fastscape/Marine_20parameters/Silt_20fraction
+**Default value:** 0.5
+
+**Pattern:** [Double -MAX_DOUBLE...MAX_DOUBLE (inclusive)]
+
+**Documentation:** Fraction of silt for material leaving continent. Formerly called Sand-silt ratio.
+::::
+
+::::{dropdown} __Parameter:__ {ref}`Silt porosity<parameters:Mesh_20deformation/Fastscape/Marine_20parameters/Silt_20porosity>`
+:name: parameters:Mesh_20deformation/Fastscape/Marine_20parameters/Silt_20porosity
+**Default value:** 0.0
+
+**Pattern:** [Double -MAX_DOUBLE...MAX_DOUBLE (inclusive)]
+
+**Documentation:** Porosity of silt.
+::::
+
+::::{dropdown} __Parameter:__ {ref}`Silt transport coefficient<parameters:Mesh_20deformation/Fastscape/Marine_20parameters/Silt_20transport_20coefficient>`
+:name: parameters:Mesh_20deformation/Fastscape/Marine_20parameters/Silt_20transport_20coefficient
+**Default value:** 2.5e2
+
+**Pattern:** [Double -MAX_DOUBLE...MAX_DOUBLE (inclusive)]
+
+**Documentation:** Transport coefficient (diffusivity) for silt. Units: ${m^2/yr}$
+::::
+
+::::{dropdown} __Parameter:__ {ref}`Use sea level function<parameters:Mesh_20deformation/Fastscape/Marine_20parameters/Use_20sea_20level_20function>`
+:name: parameters:Mesh_20deformation/Fastscape/Marine_20parameters/Use_20sea_20level_20function
+**Default value:** false
+
+**Pattern:** [Bool]
+
+**Documentation:** Whether to define sea level using a time-dependent function. If false, a constant value will be used.
+::::
+
+(parameters:Mesh_20deformation/Fastscape/Marine_20parameters/Sea_20level_20function)=
+## **Subsection:** Mesh deformation / Fastscape / Marine parameters / Sea level function
+::::{dropdown} __Parameter:__ {ref}`Function constants<parameters:Mesh_20deformation/Fastscape/Marine_20parameters/Sea_20level_20function/Function_20constants>`
+:name: parameters:Mesh_20deformation/Fastscape/Marine_20parameters/Sea_20level_20function/Function_20constants
+**Default value:**
+
+**Pattern:** [Anything]
+
+**Documentation:** Sometimes it is convenient to use symbolic constants in the expression that describes the function, rather than having to use its numeric value everywhere the constant appears. These values can be defined using this parameter, in the form &lsquo;var1=value1, var2=value2, ...&rsquo;.
+
+A typical example would be to set this runtime parameter to &lsquo;pi=3.1415926536&rsquo; and then use &lsquo;pi&rsquo; in the expression of the actual formula. (That said, for convenience this class actually defines both &lsquo;pi&rsquo; and &lsquo;Pi&rsquo; by default, but you get the idea.)
+::::
+
+::::{dropdown} __Parameter:__ {ref}`Function expression<parameters:Mesh_20deformation/Fastscape/Marine_20parameters/Sea_20level_20function/Function_20expression>`
+:name: parameters:Mesh_20deformation/Fastscape/Marine_20parameters/Sea_20level_20function/Function_20expression
+**Default value:** 0
+
+**Pattern:** [Anything]
+
+**Documentation:** The formula that denotes the function you want to evaluate for particular values of the independent variables. This expression may contain any of the usual operations such as addition or multiplication, as well as all of the common functions such as &lsquo;sin&rsquo; or &lsquo;cos&rsquo;. In addition, it may contain expressions like &lsquo;if(x>0, 1, -1)&rsquo; where the expression evaluates to the second argument if the first argument is true, and to the third argument otherwise. For a full overview of possible expressions accepted see the documentation of the muparser library at http://muparser.beltoforion.de/.
+
+If the function you are describing represents a vector-valued function with multiple components, then separate the expressions for individual components by a semicolon.
+::::
+
+::::{dropdown} __Parameter:__ {ref}`Variable names<parameters:Mesh_20deformation/Fastscape/Marine_20parameters/Sea_20level_20function/Variable_20names>`
+:name: parameters:Mesh_20deformation/Fastscape/Marine_20parameters/Sea_20level_20function/Variable_20names
+**Default value:** x,t
+
+**Pattern:** [Anything]
+
+**Documentation:** The names of the variables as they will be used in the function, separated by commas. By default, the names of variables at which the function will be evaluated are &lsquo;x&rsquo; (in 1d), &lsquo;x,y&rsquo; (in 2d) or &lsquo;x,y,z&rsquo; (in 3d) for spatial coordinates and &lsquo;t&rsquo; for time. You can then use these variable names in your function expression and they will be replaced by the values of these variables at which the function is currently evaluated. However, you can also choose a different set of names for the independent variables at which to evaluate your function expression. For example, if you work in spherical coordinates, you may wish to set this input parameter to &lsquo;r,phi,theta,t&rsquo; and then use these variable names in your function expression.
 ::::
 
 (parameters:Mesh_20deformation/Free_20surface)=

--- a/doc/sphinx/parameters/Mesh_20deformation.md
+++ b/doc/sphinx/parameters/Mesh_20deformation.md
@@ -36,6 +36,12 @@ Using this definition, the plugin then solves for one time step, i.e., using as 
 
 This surface velocity is used to deform the surface and as a boundary condition for solving the Laplace equation to determine the mesh velocity in the domain interior. Diffusion can be applied every timestep, mimicking surface processes of erosion and deposition, or at a user-defined timestep interval to purely smooth the surface topography to avoid too great a distortion of mesh elements when a free surface is also used.
 
+&lsquo;fastscape&rsquo;: A plugin that uses the program FastScape to compute the deformation of the mesh surface. FastScape is a surface processes code that computes the erosion, transport and deposition of sediments both on land and in the marine domain. These surface processes include river incision (through the stream power law), hillslope diffusion and marine diffusion, as described in Braun and Willett 2013; Yuan et al. 2019; Yuan et al. 2019b.
+Upon initialization, FastScape requires the initial topography of the surface boundary of ASPECT&rsquo;s model domain and several user-specified erosional and depositional parameters. In each ASPECT timestep, FastScape is then fed ASPECT&rsquo;s material velocity at the surface boundary. The z-component of this velocity is used to uplift the FastScape surface, while the horizontal components are used to advect the topography in the x-y plane.
+After solving its governing equations (this can be done in several timesteps that are smaller than the ASPECT timestep), FastScape returns a new topography of the surface. The difference in topography before and after the call to FastScape divided by the ASPECT timestep provides the mesh velocity at the domain&rsquo;s surface that is used to displace the surface and internal mesh nodes.
+FastScape can be used in both 2D and 3D ASPECT simulations. In 2D, one can think of the coupled model as a T-model.The ASPECT domain spans the x - z plane, while FastScape acts on the horizontal x-y plane. This means that to communicate ASPECT&rsquo;s material velocities to FastScape, FastScape mesh nodes with the same x-coordinate (so lying along the y-direction) get the same velocities. In turn, the FastScape topography is collapsed back onto the line of the ASPECT surface boundary by averaging the topography over the y-direction. In 3D no such actions are necessary.
+The FastScape manual (https://fastscape.org/fastscapelib-fortran/) provides more information on the input parameters.
+
 &lsquo;free surface&rsquo;: A plugin that computes the deformation of surface vertices according to the solution of the flow problem. In particular this means if the surface of the domain is left open to flow, this flow will carry the mesh with it. The implementation was described in {cite}`rose_freesurface`, with the stabilization of the free surface originally described in {cite}`kaus:etal:2010`.
 ::::
 
@@ -137,6 +143,629 @@ If the function you are describing represents a vector-valued function with mult
 **Pattern:** [Integer range 0...2147483647 (inclusive)]
 
 **Documentation:** The number of time steps between each application of diffusion.
+::::
+
+(parameters:Mesh_20deformation/Fastscape)=
+## **Subsection:** Mesh deformation / Fastscape
+::::{dropdown} __Parameter:__ {ref}`Additional fastscape refinement<parameters:Mesh_20deformation/Fastscape/Additional_20fastscape_20refinement>`
+:name: parameters:Mesh_20deformation/Fastscape/Additional_20fastscape_20refinement
+**Default value:** 0
+
+**Pattern:** [Integer range -2147483648...2147483647 (inclusive)]
+
+**Documentation:** How many levels above the ASPECT mesh the FastScape mesh should be refined.
+::::
+
+::::{dropdown} __Parameter:__ {ref}`Additional output variables<parameters:Mesh_20deformation/Fastscape/Additional_20output_20variables>`
+:name: parameters:Mesh_20deformation/Fastscape/Additional_20output_20variables
+**Default value:** river incision rate
+
+**Pattern:** [Selection river incision rate|transport coefficient|uplift rate ]
+
+**Documentation:** Select one additional Fastscape variable to output in the Fastcape vtk. Output are in units of per year.
+::::
+
+::::{dropdown} __Parameter:__ {ref}`Average out of plane surface topography in 2d<parameters:Mesh_20deformation/Fastscape/Average_20out_20of_20plane_20surface_20topography_20in_202d>`
+:name: parameters:Mesh_20deformation/Fastscape/Average_20out_20of_20plane_20surface_20topography_20in_202d
+**Default value:** true
+
+**Pattern:** [Bool]
+
+**Documentation:** If this is set to false, then a 2D model will only consider the center slice FastScape gives. If set to true, then ASPECT will average the mesh along Y excluding the ghost nodes.
+::::
+
+::::{dropdown} __Parameter:__ {ref}`Fastscape seed<parameters:Mesh_20deformation/Fastscape/Fastscape_20seed>`
+:name: parameters:Mesh_20deformation/Fastscape/Fastscape_20seed
+**Default value:** 1000
+
+**Pattern:** [Integer range -2147483648...2147483647 (inclusive)]
+
+**Documentation:** Seed used for adding an initial noise to FastScape topography based on the initial noise magnitude.
+::::
+
+::::{dropdown} __Parameter:__ {ref}`Initial noise magnitude<parameters:Mesh_20deformation/Fastscape/Initial_20noise_20magnitude>`
+:name: parameters:Mesh_20deformation/Fastscape/Initial_20noise_20magnitude
+**Default value:** 5
+
+**Pattern:** [Double -MAX_DOUBLE...MAX_DOUBLE (inclusive)]
+
+**Documentation:** Maximum topography change from the initial noise. Units: ${m}$
+::::
+
+::::{dropdown} __Parameter:__ {ref}`Maximum surface refinement level<parameters:Mesh_20deformation/Fastscape/Maximum_20surface_20refinement_20level>`
+:name: parameters:Mesh_20deformation/Fastscape/Maximum_20surface_20refinement_20level
+**Default value:** 1
+
+**Pattern:** [Integer range -2147483648...2147483647 (inclusive)]
+
+**Documentation:** This should be set to the highest ASPECT refinement level expected at the surface.
+::::
+
+::::{dropdown} __Parameter:__ {ref}`Maximum timestep length<parameters:Mesh_20deformation/Fastscape/Maximum_20timestep_20length>`
+:name: parameters:Mesh_20deformation/Fastscape/Maximum_20timestep_20length
+**Default value:** 10e3
+
+**Pattern:** [Double 0...MAX_DOUBLE (inclusive)]
+
+**Documentation:** Maximum timestep for FastScape. Units: ${yrs}$
+::::
+
+::::{dropdown} __Parameter:__ {ref}`Node tolerance<parameters:Mesh_20deformation/Fastscape/Node_20tolerance>`
+:name: parameters:Mesh_20deformation/Fastscape/Node_20tolerance
+**Default value:** 0.001
+
+**Pattern:** [Double -MAX_DOUBLE...MAX_DOUBLE (inclusive)]
+
+**Documentation:** Node tolerance for how close an ASPECT node must be to a FastScape node for the value to be transferred.
+::::
+
+::::{dropdown} __Parameter:__ {ref}`Number of fastscape timesteps per aspect timestep<parameters:Mesh_20deformation/Fastscape/Number_20of_20fastscape_20timesteps_20per_20aspect_20timestep>`
+:name: parameters:Mesh_20deformation/Fastscape/Number_20of_20fastscape_20timesteps_20per_20aspect_20timestep
+**Default value:** 5
+
+**Pattern:** [Integer range -2147483648...2147483647 (inclusive)]
+
+**Documentation:** Initial number of fastscape time steps per ASPECT timestep, this value will double if the FastScape timestep is above the maximum FastScape timestep.
+::::
+
+::::{dropdown} __Parameter:__ {ref}`Sediment rain rates<parameters:Mesh_20deformation/Fastscape/Sediment_20rain_20rates>`
+:name: parameters:Mesh_20deformation/Fastscape/Sediment_20rain_20rates
+**Default value:** 0,0
+
+**Pattern:** [List of <[Double 0...MAX_DOUBLE (inclusive)]> of length 0...4294967295 (inclusive)]
+
+**Documentation:** Sediment rain rates given as a list 1 greater than the number of sediment rain time intervals. E.g, If the time interval is given at 5 Myr, there will be one value for 0-5 Myr model time and a second value for 5+ Myr. Units: ${m/yr}$
+::::
+
+::::{dropdown} __Parameter:__ {ref}`Sediment rain time intervals<parameters:Mesh_20deformation/Fastscape/Sediment_20rain_20time_20intervals>`
+:name: parameters:Mesh_20deformation/Fastscape/Sediment_20rain_20time_20intervals
+**Default value:** 0
+
+**Pattern:** [List of <[Double 0...MAX_DOUBLE (inclusive)]> of length 0...4294967295 (inclusive)]
+
+**Documentation:** A list of times to change the sediment rain rate. Units: ${yrs}$
+::::
+
+::::{dropdown} __Parameter:__ {ref}`Surface refinement difference<parameters:Mesh_20deformation/Fastscape/Surface_20refinement_20difference>`
+:name: parameters:Mesh_20deformation/Fastscape/Surface_20refinement_20difference
+**Default value:** 0
+
+**Pattern:** [Integer range -2147483648...2147483647 (inclusive)]
+
+**Documentation:** The difference between the lowest and highest refinement level at the surface. E.g., if three resolution levels are expected, this would be set to two.
+::::
+
+::::{dropdown} __Parameter:__ {ref}`Uplift and advect with fastscape<parameters:Mesh_20deformation/Fastscape/Uplift_20and_20advect_20with_20fastscape>`
+:name: parameters:Mesh_20deformation/Fastscape/Uplift_20and_20advect_20with_20fastscape
+**Default value:** true
+
+**Pattern:** [Bool]
+
+**Documentation:** Flag to use FastScape advection and uplift.
+::::
+
+::::{dropdown} __Parameter:__ {ref}`Use ghost nodes<parameters:Mesh_20deformation/Fastscape/Use_20ghost_20nodes>`
+:name: parameters:Mesh_20deformation/Fastscape/Use_20ghost_20nodes
+**Default value:** true
+
+**Pattern:** [Bool]
+
+**Documentation:** Flag to use ghost nodes.
+::::
+
+::::{dropdown} __Parameter:__ {ref}`Use marine component<parameters:Mesh_20deformation/Fastscape/Use_20marine_20component>`
+:name: parameters:Mesh_20deformation/Fastscape/Use_20marine_20component
+**Default value:** false
+
+**Pattern:** [Bool]
+
+**Documentation:** Flag to use the marine component of FastScape.
+::::
+
+::::{dropdown} __Parameter:__ {ref}`Vertical exaggeration<parameters:Mesh_20deformation/Fastscape/Vertical_20exaggeration>`
+:name: parameters:Mesh_20deformation/Fastscape/Vertical_20exaggeration
+**Default value:** -1
+
+**Pattern:** [Double -MAX_DOUBLE...MAX_DOUBLE (inclusive)]
+
+**Documentation:** Vertical exaggeration for FastScape&rsquo;s VTK file. -1 outputs topography, basement, and sealevel.
+::::
+
+::::{dropdown} __Parameter:__ {ref}`Y extent in 2d<parameters:Mesh_20deformation/Fastscape/Y_20extent_20in_202d>`
+:name: parameters:Mesh_20deformation/Fastscape/Y_20extent_20in_202d
+**Default value:** 100000
+
+**Pattern:** [Double -MAX_DOUBLE...MAX_DOUBLE (inclusive)]
+
+**Documentation:** FastScape Y extent when using a 2D ASPECT model. Units: ${m}$
+::::
+
+(parameters:Mesh_20deformation/Fastscape/Boundary_20conditions)=
+## **Subsection:** Mesh deformation / Fastscape / Boundary conditions
+::::{dropdown} __Parameter:__ {ref}`Back<parameters:Mesh_20deformation/Fastscape/Boundary_20conditions/Back>`
+:name: parameters:Mesh_20deformation/Fastscape/Boundary_20conditions/Back
+**Default value:** 1
+
+**Pattern:** [Integer range 0...1 (inclusive)]
+
+**Documentation:** Back (top) boundary condition, where 1 is fixed and 0 is reflective.
+::::
+
+::::{dropdown} __Parameter:__ {ref}`Back front ghost nodes periodic<parameters:Mesh_20deformation/Fastscape/Boundary_20conditions/Back_20front_20ghost_20nodes_20periodic>`
+:name: parameters:Mesh_20deformation/Fastscape/Boundary_20conditions/Back_20front_20ghost_20nodes_20periodic
+**Default value:** false
+
+**Pattern:** [Bool]
+
+**Documentation:** Whether to set the ghost nodes at the FastScape back and front boundary to periodic even if &rsquo;Back&rsquo; and &rsquo;Front&rsquo; are set to fixed boundary.
+::::
+
+::::{dropdown} __Parameter:__ {ref}`Back mass flux<parameters:Mesh_20deformation/Fastscape/Boundary_20conditions/Back_20mass_20flux>`
+:name: parameters:Mesh_20deformation/Fastscape/Boundary_20conditions/Back_20mass_20flux
+**Default value:** 0
+
+**Pattern:** [Double -MAX_DOUBLE...MAX_DOUBLE (inclusive)]
+
+**Documentation:** Flux per unit length through the back boundary. Units: ${m^2/yr}$
+::::
+
+::::{dropdown} __Parameter:__ {ref}`Front<parameters:Mesh_20deformation/Fastscape/Boundary_20conditions/Front>`
+:name: parameters:Mesh_20deformation/Fastscape/Boundary_20conditions/Front
+**Default value:** 1
+
+**Pattern:** [Integer range 0...1 (inclusive)]
+
+**Documentation:** Front (bottom) boundary condition, where 1 is fixed and 0 is reflective.
+::::
+
+::::{dropdown} __Parameter:__ {ref}`Front mass flux<parameters:Mesh_20deformation/Fastscape/Boundary_20conditions/Front_20mass_20flux>`
+:name: parameters:Mesh_20deformation/Fastscape/Boundary_20conditions/Front_20mass_20flux
+**Default value:** 0
+
+**Pattern:** [Double -MAX_DOUBLE...MAX_DOUBLE (inclusive)]
+
+**Documentation:** Flux per unit length through the front boundary. Units: ${m^2/yr}$
+::::
+
+::::{dropdown} __Parameter:__ {ref}`Left<parameters:Mesh_20deformation/Fastscape/Boundary_20conditions/Left>`
+:name: parameters:Mesh_20deformation/Fastscape/Boundary_20conditions/Left
+**Default value:** 1
+
+**Pattern:** [Integer range 0...1 (inclusive)]
+
+**Documentation:** Left boundary condition, where 1 is fixed and 0 is reflective.
+::::
+
+::::{dropdown} __Parameter:__ {ref}`Left mass flux<parameters:Mesh_20deformation/Fastscape/Boundary_20conditions/Left_20mass_20flux>`
+:name: parameters:Mesh_20deformation/Fastscape/Boundary_20conditions/Left_20mass_20flux
+**Default value:** 0
+
+**Pattern:** [Double -MAX_DOUBLE...MAX_DOUBLE (inclusive)]
+
+**Documentation:** Flux per unit length through the left boundary. Units: ${m^2/yr}$
+::::
+
+::::{dropdown} __Parameter:__ {ref}`Left right ghost nodes periodic<parameters:Mesh_20deformation/Fastscape/Boundary_20conditions/Left_20right_20ghost_20nodes_20periodic>`
+:name: parameters:Mesh_20deformation/Fastscape/Boundary_20conditions/Left_20right_20ghost_20nodes_20periodic
+**Default value:** false
+
+**Pattern:** [Bool]
+
+**Documentation:** Whether to set the ghost nodes at the FastScape left and right boundary to periodic even if &rsquo;Left&rsquo; and &rsquo;Right&rsquo; are set to fixed boundary.
+::::
+
+::::{dropdown} __Parameter:__ {ref}`Right<parameters:Mesh_20deformation/Fastscape/Boundary_20conditions/Right>`
+:name: parameters:Mesh_20deformation/Fastscape/Boundary_20conditions/Right
+**Default value:** 1
+
+**Pattern:** [Integer range 0...1 (inclusive)]
+
+**Documentation:** Right boundary condition, where 1 is fixed and 0 is reflective.
+::::
+
+::::{dropdown} __Parameter:__ {ref}`Right mass flux<parameters:Mesh_20deformation/Fastscape/Boundary_20conditions/Right_20mass_20flux>`
+:name: parameters:Mesh_20deformation/Fastscape/Boundary_20conditions/Right_20mass_20flux
+**Default value:** 0
+
+**Pattern:** [Double -MAX_DOUBLE...MAX_DOUBLE (inclusive)]
+
+**Documentation:** Flux per unit length through the right boundary. Units: ${m^2/yr}$
+::::
+
+(parameters:Mesh_20deformation/Fastscape/Erosional_20parameters)=
+## **Subsection:** Mesh deformation / Fastscape / Erosional parameters
+::::{dropdown} __Parameter:__ {ref}`Bedrock deposition coefficient<parameters:Mesh_20deformation/Fastscape/Erosional_20parameters/Bedrock_20deposition_20coefficient>`
+:name: parameters:Mesh_20deformation/Fastscape/Erosional_20parameters/Bedrock_20deposition_20coefficient
+**Default value:** 1
+
+**Pattern:** [Double -MAX_DOUBLE...MAX_DOUBLE (inclusive)]
+
+**Documentation:** Deposition coefficient for bedrock.
+::::
+
+::::{dropdown} __Parameter:__ {ref}`Bedrock diffusivity<parameters:Mesh_20deformation/Fastscape/Erosional_20parameters/Bedrock_20diffusivity>`
+:name: parameters:Mesh_20deformation/Fastscape/Erosional_20parameters/Bedrock_20diffusivity
+**Default value:** 1e-2
+
+**Pattern:** [Double -MAX_DOUBLE...MAX_DOUBLE (inclusive)]
+
+**Documentation:** Transport coefficient (diffusivity) for bedrock. Units: ${m^2/yr}$ if &ldquo;Use years instead of seconds&rdquo; is true; otherwise, the units are ${m^2/s}$.
+::::
+
+::::{dropdown} __Parameter:__ {ref}`Bedrock river incision rate<parameters:Mesh_20deformation/Fastscape/Erosional_20parameters/Bedrock_20river_20incision_20rate>`
+:name: parameters:Mesh_20deformation/Fastscape/Erosional_20parameters/Bedrock_20river_20incision_20rate
+**Default value:** 1e-5
+
+**Pattern:** [Double -MAX_DOUBLE...MAX_DOUBLE (inclusive)]
+
+**Documentation:** River incision rate for bedrock in the Stream Power Law. Units: ${m^(1-2drainage_area_exponent)/yr}$ if &ldquo;Use years instead of seconds&rdquo; is true; otherwise, the units are ${m^(1-2drainage_area_exponent)/s}$.
+::::
+
+::::{dropdown} __Parameter:__ {ref}`Drainage area exponent<parameters:Mesh_20deformation/Fastscape/Erosional_20parameters/Drainage_20area_20exponent>`
+:name: parameters:Mesh_20deformation/Fastscape/Erosional_20parameters/Drainage_20area_20exponent
+**Default value:** 0.4
+
+**Pattern:** [Double -MAX_DOUBLE...MAX_DOUBLE (inclusive)]
+
+**Documentation:** The drainage area exponent for the Stream Power Law (m).
+::::
+
+::::{dropdown} __Parameter:__ {ref}`Elevation factor<parameters:Mesh_20deformation/Fastscape/Erosional_20parameters/Elevation_20factor>`
+:name: parameters:Mesh_20deformation/Fastscape/Erosional_20parameters/Elevation_20factor
+**Default value:** 1
+
+**Pattern:** [Double -MAX_DOUBLE...MAX_DOUBLE (inclusive)]
+
+**Documentation:** Amount to multiply the bedrock river incision rate and transport coefficient by past the given orographic elevation control.
+::::
+
+::::{dropdown} __Parameter:__ {ref}`Erosional base level<parameters:Mesh_20deformation/Fastscape/Erosional_20parameters/Erosional_20base_20level>`
+:name: parameters:Mesh_20deformation/Fastscape/Erosional_20parameters/Erosional_20base_20level
+**Default value:** 0
+
+**Pattern:** [Double -MAX_DOUBLE...MAX_DOUBLE (inclusive)]
+
+**Documentation:** When &rsquo;Use a fixed erosional base level&rsquo; is set to true, all ghost nodes of fixed FastScape boundaries where no mass flux is specified by the user (FastScape boundary condition set to 1 and &rsquo;Left/Right/Bottom/Top mass flux&rsquo; set to 0) will be fixed to this elevation. The reflecting boundaries (FastScape boundary condition set to 0) will not be affected, nor are the boundaries where a mass flux is specified.
+Units: m
+::::
+
+::::{dropdown} __Parameter:__ {ref}`Flag to use orographic controls<parameters:Mesh_20deformation/Fastscape/Erosional_20parameters/Flag_20to_20use_20orographic_20controls>`
+:name: parameters:Mesh_20deformation/Fastscape/Erosional_20parameters/Flag_20to_20use_20orographic_20controls
+**Default value:** false
+
+**Pattern:** [Bool]
+
+**Documentation:** Whether or not to apply orographic controls.
+::::
+
+::::{dropdown} __Parameter:__ {ref}`Multi-direction slope exponent<parameters:Mesh_20deformation/Fastscape/Erosional_20parameters/Multi_2ddirection_20slope_20exponent>`
+:name: parameters:Mesh_20deformation/Fastscape/Erosional_20parameters/Multi_2ddirection_20slope_20exponent
+**Default value:** 1
+
+**Pattern:** [Double -MAX_DOUBLE...MAX_DOUBLE (inclusive)]
+
+**Documentation:** Exponent to determine the distribution from the SPL to neighbor nodes, with 10 being steepest decent and 1 being more varied.
+::::
+
+::::{dropdown} __Parameter:__ {ref}`Orographic elevation control<parameters:Mesh_20deformation/Fastscape/Erosional_20parameters/Orographic_20elevation_20control>`
+:name: parameters:Mesh_20deformation/Fastscape/Erosional_20parameters/Orographic_20elevation_20control
+**Default value:** 2000
+
+**Pattern:** [Integer range -2147483648...2147483647 (inclusive)]
+
+**Documentation:** Above this height, the elevation factor is applied. Units: ${m}$
+::::
+
+::::{dropdown} __Parameter:__ {ref}`Orographic wind barrier height<parameters:Mesh_20deformation/Fastscape/Erosional_20parameters/Orographic_20wind_20barrier_20height>`
+:name: parameters:Mesh_20deformation/Fastscape/Erosional_20parameters/Orographic_20wind_20barrier_20height
+**Default value:** 500
+
+**Pattern:** [Integer range -2147483648...2147483647 (inclusive)]
+
+**Documentation:** When terrain reaches this height the wind barrier factor is applied. Units: ${m}$
+::::
+
+::::{dropdown} __Parameter:__ {ref}`Sediment deposition coefficient<parameters:Mesh_20deformation/Fastscape/Erosional_20parameters/Sediment_20deposition_20coefficient>`
+:name: parameters:Mesh_20deformation/Fastscape/Erosional_20parameters/Sediment_20deposition_20coefficient
+**Default value:** -1
+
+**Pattern:** [Double -MAX_DOUBLE...MAX_DOUBLE (inclusive)]
+
+**Documentation:** Deposition coefficient for sediment. A value smaller than 0 sets this to the same as the bedrock deposition coefficient.
+::::
+
+::::{dropdown} __Parameter:__ {ref}`Sediment diffusivity<parameters:Mesh_20deformation/Fastscape/Erosional_20parameters/Sediment_20diffusivity>`
+:name: parameters:Mesh_20deformation/Fastscape/Erosional_20parameters/Sediment_20diffusivity
+**Default value:** -1
+
+**Pattern:** [Double -MAX_DOUBLE...MAX_DOUBLE (inclusive)]
+
+**Documentation:** Transport coefficient (diffusivity) for sediment. -1 sets this to the bedrock diffusivity. Units: ${m^2/yr}$ if &ldquo;Use years instead of seconds&rdquo; is true; otherwise, the units are ${m^2/s}$.
+::::
+
+::::{dropdown} __Parameter:__ {ref}`Sediment river incision rate<parameters:Mesh_20deformation/Fastscape/Erosional_20parameters/Sediment_20river_20incision_20rate>`
+:name: parameters:Mesh_20deformation/Fastscape/Erosional_20parameters/Sediment_20river_20incision_20rate
+**Default value:** -1
+
+**Pattern:** [Double -MAX_DOUBLE...MAX_DOUBLE (inclusive)]
+
+**Documentation:** River incision rate for sediment in the Stream Power Law. A value smaller than 0 sets this to the bedrock river incision rate. Units: $m^(1-2drainage_area_exponent)/yr}$ if &ldquo;Use years instead of seconds&rdquo; is true; otherwise, the units are $m^(1-2drainage_area_exponent)/s}$.
+::::
+
+::::{dropdown} __Parameter:__ {ref}`Slope exponent<parameters:Mesh_20deformation/Fastscape/Erosional_20parameters/Slope_20exponent>`
+:name: parameters:Mesh_20deformation/Fastscape/Erosional_20parameters/Slope_20exponent
+**Default value:** 1
+
+**Pattern:** [Double -MAX_DOUBLE...MAX_DOUBLE (inclusive)]
+
+**Documentation:** The slope exponent for the Stream Power Law (n). Generally m/n should equal approximately 0.4
+::::
+
+::::{dropdown} __Parameter:__ {ref}`Stack orographic controls<parameters:Mesh_20deformation/Fastscape/Erosional_20parameters/Stack_20orographic_20controls>`
+:name: parameters:Mesh_20deformation/Fastscape/Erosional_20parameters/Stack_20orographic_20controls
+**Default value:** true
+
+**Pattern:** [Bool]
+
+**Documentation:** Whether or not to apply both controls to a point, or only a maximum of one set as the wind barrier.
+::::
+
+::::{dropdown} __Parameter:__ {ref}`Use a fixed erosional base level<parameters:Mesh_20deformation/Fastscape/Erosional_20parameters/Use_20a_20fixed_20erosional_20base_20level>`
+:name: parameters:Mesh_20deformation/Fastscape/Erosional_20parameters/Use_20a_20fixed_20erosional_20base_20level
+**Default value:** false
+
+**Pattern:** [Bool]
+
+**Documentation:** Whether or not to use an erosional base level that differs from sea level. Setting this parameter to true will set all ghost nodes of fixed FastScape boundaries to the height you specify in &rsquo;set Erosional base level&rsquo;.
+This can make sense for a continental model where the model surrounding topography is assumed above sea level, e.g. highlands. If the sea level would be used as an erosional base level in this case, all topography erodes away with lots of &rsquo;sediment volume&rsquo; lost through the sides of the model. This is mostly important, when there are mountains in the middle of the model, while it is less important when there is lower relief in the middle of the model.
+In the FastScape  visualization files, setting the extra base level may show up as a strong slope at the fixed boundaries of the model. However, in the ASPECT visualization files it will not show up, as the ghost nodes only exist in FastScape.
+::::
+
+::::{dropdown} __Parameter:__ {ref}`Use kd distribution function<parameters:Mesh_20deformation/Fastscape/Erosional_20parameters/Use_20kd_20distribution_20function>`
+:name: parameters:Mesh_20deformation/Fastscape/Erosional_20parameters/Use_20kd_20distribution_20function
+**Default value:** false
+
+**Pattern:** [Bool]
+
+**Documentation:** Whether to define Bedrock transport coefficient (diffusivity) using a distribution function. If false, a constant kd value will be used, which can be specified by setting the parameter &ldquo;Bedrock diffusivity&rdquo;. Units: ${m^2/yr}$ if &ldquo;Use years instead of seconds&rdquo; is true; otherwise, the units are ${m^2/s}$.
+::::
+
+::::{dropdown} __Parameter:__ {ref}`Use kf distribution function<parameters:Mesh_20deformation/Fastscape/Erosional_20parameters/Use_20kf_20distribution_20function>`
+:name: parameters:Mesh_20deformation/Fastscape/Erosional_20parameters/Use_20kf_20distribution_20function
+**Default value:** false
+
+**Pattern:** [Bool]
+
+**Documentation:** Whether to define bedrock river incision rate using a distribution function. If false, a constant kf value will be used, which can be specified by setting the parameter &ldquo;Bedrock river incision rate&rdquo;. Units: ${m^(1-2drainage_area_exponent)/yr}$ if &ldquo;Use years instead of seconds&rdquo; is true; otherwise, the units are ${m^(1-2drainage_area_exponent)/s}$.
+::::
+
+::::{dropdown} __Parameter:__ {ref}`Wind barrier factor<parameters:Mesh_20deformation/Fastscape/Erosional_20parameters/Wind_20barrier_20factor>`
+:name: parameters:Mesh_20deformation/Fastscape/Erosional_20parameters/Wind_20barrier_20factor
+**Default value:** 1
+
+**Pattern:** [Double -MAX_DOUBLE...MAX_DOUBLE (inclusive)]
+
+**Documentation:** Amount to multiply the bedrock river incision rate and transport coefficient by past given wind barrier height.
+::::
+
+::::{dropdown} __Parameter:__ {ref}`Wind direction<parameters:Mesh_20deformation/Fastscape/Erosional_20parameters/Wind_20direction>`
+:name: parameters:Mesh_20deformation/Fastscape/Erosional_20parameters/Wind_20direction
+**Default value:** west
+
+**Pattern:** [Selection east|west|south|north ]
+
+**Documentation:** This parameter assumes a wind direction, deciding which side is reduced from the wind barrier.
+::::
+
+(parameters:Mesh_20deformation/Fastscape/Erosional_20parameters/kd_20distribution_20function)=
+## **Subsection:** Mesh deformation / Fastscape / Erosional parameters / kd distribution function
+::::{dropdown} __Parameter:__ {ref}`Function constants<parameters:Mesh_20deformation/Fastscape/Erosional_20parameters/kd_20distribution_20function/Function_20constants>`
+:name: parameters:Mesh_20deformation/Fastscape/Erosional_20parameters/kd_20distribution_20function/Function_20constants
+**Default value:**
+
+**Pattern:** [Anything]
+
+**Documentation:** Sometimes it is convenient to use symbolic constants in the expression that describes the function, rather than having to use its numeric value everywhere the constant appears. These values can be defined using this parameter, in the form &lsquo;var1=value1, var2=value2, ...&rsquo;.
+
+A typical example would be to set this runtime parameter to &lsquo;pi=3.1415926536&rsquo; and then use &lsquo;pi&rsquo; in the expression of the actual formula. (That said, for convenience this class actually defines both &lsquo;pi&rsquo; and &lsquo;Pi&rsquo; by default, but you get the idea.)
+::::
+
+::::{dropdown} __Parameter:__ {ref}`Function expression<parameters:Mesh_20deformation/Fastscape/Erosional_20parameters/kd_20distribution_20function/Function_20expression>`
+:name: parameters:Mesh_20deformation/Fastscape/Erosional_20parameters/kd_20distribution_20function/Function_20expression
+**Default value:** 0; 0
+
+**Pattern:** [Anything]
+
+**Documentation:** The formula that denotes the function you want to evaluate for particular values of the independent variables. This expression may contain any of the usual operations such as addition or multiplication, as well as all of the common functions such as &lsquo;sin&rsquo; or &lsquo;cos&rsquo;. In addition, it may contain expressions like &lsquo;if(x>0, 1, -1)&rsquo; where the expression evaluates to the second argument if the first argument is true, and to the third argument otherwise. For a full overview of possible expressions accepted see the documentation of the muparser library at http://muparser.beltoforion.de/.
+
+If the function you are describing represents a vector-valued function with multiple components, then separate the expressions for individual components by a semicolon.
+::::
+
+::::{dropdown} __Parameter:__ {ref}`Variable names<parameters:Mesh_20deformation/Fastscape/Erosional_20parameters/kd_20distribution_20function/Variable_20names>`
+:name: parameters:Mesh_20deformation/Fastscape/Erosional_20parameters/kd_20distribution_20function/Variable_20names
+**Default value:** x,y,t
+
+**Pattern:** [Anything]
+
+**Documentation:** The names of the variables as they will be used in the function, separated by commas. By default, the names of variables at which the function will be evaluated are &lsquo;x&rsquo; (in 1d), &lsquo;x,y&rsquo; (in 2d) or &lsquo;x,y,z&rsquo; (in 3d) for spatial coordinates and &lsquo;t&rsquo; for time. You can then use these variable names in your function expression and they will be replaced by the values of these variables at which the function is currently evaluated. However, you can also choose a different set of names for the independent variables at which to evaluate your function expression. For example, if you work in spherical coordinates, you may wish to set this input parameter to &lsquo;r,phi,theta,t&rsquo; and then use these variable names in your function expression.
+::::
+
+(parameters:Mesh_20deformation/Fastscape/Erosional_20parameters/kf_20distribution_20function)=
+## **Subsection:** Mesh deformation / Fastscape / Erosional parameters / kf distribution function
+::::{dropdown} __Parameter:__ {ref}`Function constants<parameters:Mesh_20deformation/Fastscape/Erosional_20parameters/kf_20distribution_20function/Function_20constants>`
+:name: parameters:Mesh_20deformation/Fastscape/Erosional_20parameters/kf_20distribution_20function/Function_20constants
+**Default value:**
+
+**Pattern:** [Anything]
+
+**Documentation:** Sometimes it is convenient to use symbolic constants in the expression that describes the function, rather than having to use its numeric value everywhere the constant appears. These values can be defined using this parameter, in the form &lsquo;var1=value1, var2=value2, ...&rsquo;.
+
+A typical example would be to set this runtime parameter to &lsquo;pi=3.1415926536&rsquo; and then use &lsquo;pi&rsquo; in the expression of the actual formula. (That said, for convenience this class actually defines both &lsquo;pi&rsquo; and &lsquo;Pi&rsquo; by default, but you get the idea.)
+::::
+
+::::{dropdown} __Parameter:__ {ref}`Function expression<parameters:Mesh_20deformation/Fastscape/Erosional_20parameters/kf_20distribution_20function/Function_20expression>`
+:name: parameters:Mesh_20deformation/Fastscape/Erosional_20parameters/kf_20distribution_20function/Function_20expression
+**Default value:** 0; 0
+
+**Pattern:** [Anything]
+
+**Documentation:** The formula that denotes the function you want to evaluate for particular values of the independent variables. This expression may contain any of the usual operations such as addition or multiplication, as well as all of the common functions such as &lsquo;sin&rsquo; or &lsquo;cos&rsquo;. In addition, it may contain expressions like &lsquo;if(x>0, 1, -1)&rsquo; where the expression evaluates to the second argument if the first argument is true, and to the third argument otherwise. For a full overview of possible expressions accepted see the documentation of the muparser library at http://muparser.beltoforion.de/.
+
+If the function you are describing represents a vector-valued function with multiple components, then separate the expressions for individual components by a semicolon.
+::::
+
+::::{dropdown} __Parameter:__ {ref}`Variable names<parameters:Mesh_20deformation/Fastscape/Erosional_20parameters/kf_20distribution_20function/Variable_20names>`
+:name: parameters:Mesh_20deformation/Fastscape/Erosional_20parameters/kf_20distribution_20function/Variable_20names
+**Default value:** x,y,t
+
+**Pattern:** [Anything]
+
+**Documentation:** The names of the variables as they will be used in the function, separated by commas. By default, the names of variables at which the function will be evaluated are &lsquo;x&rsquo; (in 1d), &lsquo;x,y&rsquo; (in 2d) or &lsquo;x,y,z&rsquo; (in 3d) for spatial coordinates and &lsquo;t&rsquo; for time. You can then use these variable names in your function expression and they will be replaced by the values of these variables at which the function is currently evaluated. However, you can also choose a different set of names for the independent variables at which to evaluate your function expression. For example, if you work in spherical coordinates, you may wish to set this input parameter to &lsquo;r,phi,theta,t&rsquo; and then use these variable names in your function expression.
+::::
+
+(parameters:Mesh_20deformation/Fastscape/Marine_20parameters)=
+## **Subsection:** Mesh deformation / Fastscape / Marine parameters
+::::{dropdown} __Parameter:__ {ref}`Depth averaging thickness<parameters:Mesh_20deformation/Fastscape/Marine_20parameters/Depth_20averaging_20thickness>`
+:name: parameters:Mesh_20deformation/Fastscape/Marine_20parameters/Depth_20averaging_20thickness
+**Default value:** 1e2
+
+**Pattern:** [Double -MAX_DOUBLE...MAX_DOUBLE (inclusive)]
+
+**Documentation:** Depth averaging for the sand-silt equation. Units: ${m}$
+::::
+
+::::{dropdown} __Parameter:__ {ref}`Sand e-folding depth<parameters:Mesh_20deformation/Fastscape/Marine_20parameters/Sand_20e_2dfolding_20depth>`
+:name: parameters:Mesh_20deformation/Fastscape/Marine_20parameters/Sand_20e_2dfolding_20depth
+**Default value:** 1e3
+
+**Pattern:** [Double -MAX_DOUBLE...MAX_DOUBLE (inclusive)]
+
+**Documentation:** E-folding depth for the exponential of the sand porosity law. Units: ${m}$
+::::
+
+::::{dropdown} __Parameter:__ {ref}`Sand porosity<parameters:Mesh_20deformation/Fastscape/Marine_20parameters/Sand_20porosity>`
+:name: parameters:Mesh_20deformation/Fastscape/Marine_20parameters/Sand_20porosity
+**Default value:** 0.0
+
+**Pattern:** [Double -MAX_DOUBLE...MAX_DOUBLE (inclusive)]
+
+**Documentation:** Porosity of sand.
+::::
+
+::::{dropdown} __Parameter:__ {ref}`Sand transport coefficient<parameters:Mesh_20deformation/Fastscape/Marine_20parameters/Sand_20transport_20coefficient>`
+:name: parameters:Mesh_20deformation/Fastscape/Marine_20parameters/Sand_20transport_20coefficient
+**Default value:** 5e2
+
+**Pattern:** [Double -MAX_DOUBLE...MAX_DOUBLE (inclusive)]
+
+**Documentation:** Transport coefficient (diffusivity) for sand. Units: ${m^2/yr}$
+::::
+
+::::{dropdown} __Parameter:__ {ref}`Sea level<parameters:Mesh_20deformation/Fastscape/Marine_20parameters/Sea_20level>`
+:name: parameters:Mesh_20deformation/Fastscape/Marine_20parameters/Sea_20level
+**Default value:** 0.0
+
+**Pattern:** [Double -MAX_DOUBLE...MAX_DOUBLE (inclusive)]
+
+**Documentation:** Constant sea level relative to the ASPECT surface, where the maximum Z or Y extent in ASPECT is a sea level of zero. Units: ${m}$
+::::
+
+::::{dropdown} __Parameter:__ {ref}`Silt e-folding depth<parameters:Mesh_20deformation/Fastscape/Marine_20parameters/Silt_20e_2dfolding_20depth>`
+:name: parameters:Mesh_20deformation/Fastscape/Marine_20parameters/Silt_20e_2dfolding_20depth
+**Default value:** 1e3
+
+**Pattern:** [Double -MAX_DOUBLE...MAX_DOUBLE (inclusive)]
+
+**Documentation:** E-folding depth for the exponential of the silt porosity law. Units: ${m}$
+::::
+
+::::{dropdown} __Parameter:__ {ref}`Silt fraction<parameters:Mesh_20deformation/Fastscape/Marine_20parameters/Silt_20fraction>`
+:name: parameters:Mesh_20deformation/Fastscape/Marine_20parameters/Silt_20fraction
+**Default value:** 0.5
+
+**Pattern:** [Double -MAX_DOUBLE...MAX_DOUBLE (inclusive)]
+
+**Documentation:** Fraction of silt for material leaving continent. Formerly called Sand-silt ratio.
+::::
+
+::::{dropdown} __Parameter:__ {ref}`Silt porosity<parameters:Mesh_20deformation/Fastscape/Marine_20parameters/Silt_20porosity>`
+:name: parameters:Mesh_20deformation/Fastscape/Marine_20parameters/Silt_20porosity
+**Default value:** 0.0
+
+**Pattern:** [Double -MAX_DOUBLE...MAX_DOUBLE (inclusive)]
+
+**Documentation:** Porosity of silt.
+::::
+
+::::{dropdown} __Parameter:__ {ref}`Silt transport coefficient<parameters:Mesh_20deformation/Fastscape/Marine_20parameters/Silt_20transport_20coefficient>`
+:name: parameters:Mesh_20deformation/Fastscape/Marine_20parameters/Silt_20transport_20coefficient
+**Default value:** 2.5e2
+
+**Pattern:** [Double -MAX_DOUBLE...MAX_DOUBLE (inclusive)]
+
+**Documentation:** Transport coefficient (diffusivity) for silt. Units: ${m^2/yr}$
+::::
+
+::::{dropdown} __Parameter:__ {ref}`Use sea level function<parameters:Mesh_20deformation/Fastscape/Marine_20parameters/Use_20sea_20level_20function>`
+:name: parameters:Mesh_20deformation/Fastscape/Marine_20parameters/Use_20sea_20level_20function
+**Default value:** false
+
+**Pattern:** [Bool]
+
+**Documentation:** Whether to define sea level using a time-dependent function. If false, a constant value will be used.
+::::
+
+(parameters:Mesh_20deformation/Fastscape/Marine_20parameters/Sea_20level_20function)=
+## **Subsection:** Mesh deformation / Fastscape / Marine parameters / Sea level function
+::::{dropdown} __Parameter:__ {ref}`Function constants<parameters:Mesh_20deformation/Fastscape/Marine_20parameters/Sea_20level_20function/Function_20constants>`
+:name: parameters:Mesh_20deformation/Fastscape/Marine_20parameters/Sea_20level_20function/Function_20constants
+**Default value:**
+
+**Pattern:** [Anything]
+
+**Documentation:** Sometimes it is convenient to use symbolic constants in the expression that describes the function, rather than having to use its numeric value everywhere the constant appears. These values can be defined using this parameter, in the form &lsquo;var1=value1, var2=value2, ...&rsquo;.
+
+A typical example would be to set this runtime parameter to &lsquo;pi=3.1415926536&rsquo; and then use &lsquo;pi&rsquo; in the expression of the actual formula. (That said, for convenience this class actually defines both &lsquo;pi&rsquo; and &lsquo;Pi&rsquo; by default, but you get the idea.)
+::::
+
+::::{dropdown} __Parameter:__ {ref}`Function expression<parameters:Mesh_20deformation/Fastscape/Marine_20parameters/Sea_20level_20function/Function_20expression>`
+:name: parameters:Mesh_20deformation/Fastscape/Marine_20parameters/Sea_20level_20function/Function_20expression
+**Default value:** 0
+
+**Pattern:** [Anything]
+
+**Documentation:** The formula that denotes the function you want to evaluate for particular values of the independent variables. This expression may contain any of the usual operations such as addition or multiplication, as well as all of the common functions such as &lsquo;sin&rsquo; or &lsquo;cos&rsquo;. In addition, it may contain expressions like &lsquo;if(x>0, 1, -1)&rsquo; where the expression evaluates to the second argument if the first argument is true, and to the third argument otherwise. For a full overview of possible expressions accepted see the documentation of the muparser library at http://muparser.beltoforion.de/.
+
+If the function you are describing represents a vector-valued function with multiple components, then separate the expressions for individual components by a semicolon.
+::::
+
+::::{dropdown} __Parameter:__ {ref}`Variable names<parameters:Mesh_20deformation/Fastscape/Marine_20parameters/Sea_20level_20function/Variable_20names>`
+:name: parameters:Mesh_20deformation/Fastscape/Marine_20parameters/Sea_20level_20function/Variable_20names
+**Default value:** x,t
+
+**Pattern:** [Anything]
+
+**Documentation:** The names of the variables as they will be used in the function, separated by commas. By default, the names of variables at which the function will be evaluated are &lsquo;x&rsquo; (in 1d), &lsquo;x,y&rsquo; (in 2d) or &lsquo;x,y,z&rsquo; (in 3d) for spatial coordinates and &lsquo;t&rsquo; for time. You can then use these variable names in your function expression and they will be replaced by the values of these variables at which the function is currently evaluated. However, you can also choose a different set of names for the independent variables at which to evaluate your function expression. For example, if you work in spherical coordinates, you may wish to set this input parameter to &lsquo;r,phi,theta,t&rsquo; and then use these variable names in your function expression.
 ::::
 
 (parameters:Mesh_20deformation/Free_20surface)=

--- a/include/aspect/mesh_deformation/fastscape.h
+++ b/include/aspect/mesh_deformation/fastscape.h
@@ -23,8 +23,6 @@
 
 #include <aspect/global.h>
 
-#ifdef ASPECT_WITH_FASTSCAPE
-
 #include <aspect/mesh_deformation/interface.h>
 #include <deal.II/base/parsed_function.h>
 
@@ -743,5 +741,4 @@ namespace aspect
   }
 }
 
-#endif
 #endif

--- a/source/mesh_deformation/fastscape.cc
+++ b/source/mesh_deformation/fastscape.cc
@@ -30,7 +30,6 @@
 namespace aspect
 {
 
-#ifdef ASPECT_WITH_FASTSCAPE
 
   namespace MeshDeformation
   {
@@ -185,16 +184,20 @@ namespace aspect
     template <int dim>
     FastScape<dim>::~FastScape ()
     {
+#ifdef ASPECT_WITH_FASTSCAPE
       // It doesn't seem to matter if this is done on all processors or only on the one that runs
       // FastScape as the destroy function checks if the memory is allocated.
       if (Utilities::MPI::this_mpi_process(this->get_mpi_communicator()) == 0)
         fastscape_destroy_();
+#endif
     }
 
     template <int dim>
     void
     FastScape<dim>::initialize ()
     {
+#ifdef ASPECT_WITH_FASTSCAPE
+
       CitationInfo::add("fastscape");
 
       const GeometryModel::Box<dim> *box_geometry
@@ -315,6 +318,9 @@ namespace aspect
                                    true /*do not print message in log file*/);
 
       last_output_time = 0;
+#else
+      AssertThrow(false, ExcMessage("The FastScape plugin was requested, but ASPECT was not compiled with FastScape support."));
+#endif
     }
 
 
@@ -324,6 +330,7 @@ namespace aspect
                                                              AffineConstraints<double> &mesh_velocity_constraints,
                                                              const std::set<types::boundary_id> &boundary_ids) const
     {
+#ifdef ASPECT_WITH_FASTSCAPE
 
       // Because there is no increase in time during timestep 0, we return and only
       // initialize and run FastScape from timestep 1 and on.
@@ -691,6 +698,11 @@ namespace aspect
                                                   mesh_velocity_constraints);
 
       this->get_computing_timer().leave_subsection("FastScape plugin");
+#else
+      (void) mesh_deformation_dof_handler;
+      (void) mesh_velocity_constraints;
+      (void) boundary_ids;
+#endif
     }
 
 
@@ -698,6 +710,7 @@ namespace aspect
     std::vector<std::vector<double>>
     FastScape<dim>::get_aspect_values() const
     {
+#ifdef ASPECT_WITH_FASTSCAPE
 
       const types::boundary_id relevant_boundary = this->get_geometry_model().translate_symbolic_boundary_name_to_id ("top");
       std::vector<std::vector<double>> local_aspect_values(dim+2, std::vector<double>());
@@ -795,6 +808,9 @@ namespace aspect
               }
 
       return local_aspect_values;
+#else
+      return std::vector<std::vector<double>>();
+#endif
     }
 
 
@@ -807,6 +823,7 @@ namespace aspect
                                                std::vector<double> &velocity_z,
                                                std::vector<std::vector<double>> &local_aspect_values) const
     {
+#ifdef ASPECT_WITH_FASTSCAPE
       for (unsigned int i=0; i<local_aspect_values[1].size(); ++i)
         {
           // In get_aspect_values(), we store an integer value as a double in local_aspect_values[1][...].
@@ -910,6 +927,15 @@ namespace aspect
       AssertThrow (fastscape_mesh_filled == true,
                    ExcMessage("The FastScape mesh is missing data. A likely cause for this is that the "
                               "maximum surface refinement or surface refinement difference are improperly set."));
+#else
+      (void) elevation;
+      (void) bedrock_transport_coefficient_array;
+      (void) bedrock_river_incision_rate_array;
+      (void) velocity_x;
+      (void) velocity_y;
+      (void) velocity_z;
+      (void) local_aspect_values;
+#endif
     }
 
 
@@ -919,6 +945,7 @@ namespace aspect
                                               std::vector<double> &silt_fraction,
                                               bool restart) const
     {
+#ifdef ASPECT_WITH_FASTSCAPE
       Assert (Utilities::MPI::this_mpi_process(this->get_mpi_communicator()) == 0, ExcInternalError());
 
       // Initialize FastScape with grid and extent.
@@ -942,6 +969,12 @@ namespace aspect
           if (use_marine_component)
             fastscape_init_f_(silt_fraction.data());
         }
+#else
+      (void) elevation;
+      (void) basement;
+      (void) silt_fraction;
+      (void) restart;
+#endif
     }
 
 
@@ -955,6 +988,7 @@ namespace aspect
                                            const double &fastscape_timestep_in_years,
                                            const unsigned int &fastscape_iterations) const
     {
+#ifdef ASPECT_WITH_FASTSCAPE
       // This function can only be called on the root process where we run
       // Fastscape:
       Assert (Utilities::MPI::this_mpi_process(this->get_mpi_communicator()) == 0,
@@ -1082,6 +1116,16 @@ namespace aspect
       }
 
       this->get_computing_timer().leave_subsection("Execute FastScape");
+#else
+      (void) elevation;
+      (void) extra_vtk_field;
+      (void) velocity_x;
+      (void) velocity_y;
+      (void) velocity_z;
+      (void) bedrock_transport_coefficient_array;
+      (void) fastscape_timestep_in_years;
+      (void) fastscape_iterations;
+#endif
     }
 
 
@@ -1090,6 +1134,7 @@ namespace aspect
                                                    std::vector<double> &bedrock_transport_coefficient_array,
                                                    std::vector<double> &bedrock_river_incision_rate_array) const
     {
+#ifdef ASPECT_WITH_FASTSCAPE
       // First for the wind barrier, we find the maximum height and index
       // along each line in the x and y direction.
       // If wind is east or west, we find maximum point for each ny row along x.
@@ -1215,6 +1260,11 @@ namespace aspect
                 }
             }
         }
+#else
+      (void) elevation;
+      (void) bedrock_transport_coefficient_array;
+      (void) bedrock_river_incision_rate_array;
+#endif
     }
 
 
@@ -1227,6 +1277,7 @@ namespace aspect
                                          const double &fastscape_timestep_in_years,
                                          const bool init) const
     {
+#ifdef ASPECT_WITH_FASTSCAPE
       // Copy the slopes at each point, this will be used to set an H
       // at the ghost nodes if a boundary mass flux is given.
       const unsigned int fastscape_array_size = fastscape_nx*fastscape_ny;
@@ -1509,12 +1560,22 @@ namespace aspect
               velocity_z[op_side-jj] = velocity_z[side+jj];
             }
         }
+#else
+      (void) elevation;
+      (void) velocity_x;
+      (void) velocity_y;
+      (void) velocity_z;
+      (void) bedrock_transport_coefficient_array;
+      (void) fastscape_timestep_in_years;
+      (void) init;
+#endif
     }
 
     template <int dim>
     bool FastScape<dim>::is_ghost_node(const unsigned int &index,
                                        const bool &exclude_boundaries) const
     {
+#ifdef ASPECT_WITH_FASTSCAPE
       if (use_ghost_nodes == false && exclude_boundaries == false)
         return false;
 
@@ -1527,6 +1588,11 @@ namespace aspect
         return true;
       else
         return false;
+#else
+      (void) index;
+      (void) exclude_boundaries;
+      return false;
+#endif
     }
 
 
@@ -1537,6 +1603,7 @@ namespace aspect
                                     const unsigned int &fastscape_nx,
                                     const unsigned int &fastscape_ny) const
     {
+#ifdef ASPECT_WITH_FASTSCAPE
       // Create data table based off of the given size.
       Table<dim,double> data_table;
       data_table.TableBase<dim,double>::reinit(size_idx);
@@ -1587,6 +1654,13 @@ namespace aspect
         }
 
       return data_table;
+#else
+      (void) values;
+      (void) size_idx;
+      (void) fastscape_nx;
+      (void) fastscape_ny;
+      return Table<dim,double>();
+#endif
     }
 
 
@@ -1598,6 +1672,7 @@ namespace aspect
                           const Point<dim> &position,
                           const unsigned int compositional_field) const
     {
+#ifdef ASPECT_WITH_FASTSCAPE
       // FastScape is only applied to the top boundary of the model domain.
       // If a composition value is requested for any other boundary,
       // return zero.
@@ -1637,6 +1712,12 @@ namespace aspect
         }
       else
         return 0.0;
+#else
+      (void) boundary_indicator;
+      (void) position;
+      (void) compositional_field;
+      return 0.0;
+#endif
     }
 
 
@@ -1645,7 +1726,11 @@ namespace aspect
     template <class Archive>
     void FastScape<dim>::serialize (Archive &ar, const unsigned int)
     {
+#ifdef ASPECT_WITH_FASTSCAPE
       ar &last_output_time;
+#else
+      (void) ar;
+#endif
     }
 
 
@@ -1654,6 +1739,7 @@ namespace aspect
     void
     FastScape<dim>::save (std::map<std::string, std::string> &status_strings) const
     {
+#ifdef ASPECT_WITH_FASTSCAPE
       // FastScape elevation values for restart.
       std::vector<double> elevation;
 
@@ -1711,6 +1797,9 @@ namespace aspect
       }
 
       status_strings["FastScape"] = os.str();
+#else
+      (void) status_strings;
+#endif
     }
 
 
@@ -1719,6 +1808,7 @@ namespace aspect
     void
     FastScape<dim>::load (const std::map<std::string, std::string> &status_strings)
     {
+#ifdef ASPECT_WITH_FASTSCAPE
       // FastScape elevation values for restart.
       std::vector<double> elevation;
 
@@ -1750,12 +1840,16 @@ namespace aspect
                              basement,
                              silt_fraction,
                              true);
+#else
+      (void) status_strings;
+#endif
     }
 
     template <int dim>
     void
     FastScape<dim>::update()
     {
+#ifdef ASPECT_WITH_FASTSCAPE
       // Set the time in seconds or years in each
       // of the used functions.
       const double time = this->get_time();
@@ -1775,6 +1869,7 @@ namespace aspect
         {
           sea_level_function.set_time(scaled_time);
         }
+#endif
     }
 
 
@@ -1783,7 +1878,11 @@ namespace aspect
     FastScape<dim>::
     needs_surface_stabilization () const
     {
+#ifdef ASPECT_WITH_FASTSCAPE
       return true;
+#else
+      return false;
+#endif
     }
 
 
@@ -2309,5 +2408,4 @@ namespace aspect
 
   }
 
-#endif
 }


### PR DESCRIPTION
Since FastScape is now included in the tester images, I think it is also time to include the coupling to FastScape in the documentation. This PR updates the .md file with the documentation and includes FS in the tester that checks the documentation. 

I need to check if the test workflow is correct, so WIP.

### For all pull requests:

* [x] I have followed the [instructions for indenting my code](../blob/main/CONTRIBUTING.md#making-aspect-better).
* I followed the [AI Policy](../blob/main/CONTRIBUTING.md#policy-on-usage-of-ai):
  - [ ] Significant parts of this PR were written by AI (please add a sentence below).
  - [ ] AI has not been used in significant ways.

*If yes, please describe your usage of AI models in the creation of this pull request*

### For new features/models or changes of existing features:

* [x] I have tested my new feature locally to ensure it is correct.
* [ ] I have [created a testcase](https://aspect-documentation.readthedocs.io/en/latest/user/extending/testing/writing-tests.html) for the new feature/benchmark in the [tests/](../blob/main/tests/) directory.
* [ ] I have added a changelog entry in the [doc/modules/changes](../blob/main/doc/modules/changes) directory that will inform other users of my change.
