### PR TITLE
Use std clamp instead of std::min(std::max(val, low), high)

### DIFF
--- a/cookbooks/tomography_based_plate_motions/plugins/tomography_based_plate_motions.cc
+++ b/cookbooks/tomography_based_plate_motions/plugins/tomography_based_plate_motions.cc
@@ -431,7 +431,7 @@ namespace aspect
                   if (disl_viscosities_out != nullptr)
                     {
                       disl_viscosities_out->diffusion_viscosities[i] = diff_viscosity;
-                      disl_viscosities_out->dislocation_viscosities[i] = std::min(std::max(min_eta,disl_viscosity),1e30);
+                      disl_viscosities_out->dislocation_viscosities[i] = std::clamp(disl_viscosity, min_eta, 1e30);
                     }
 
                   out.viscosities[i] = diff_viscosity * disl_viscosity / (disl_viscosity + diff_viscosity);
@@ -494,7 +494,7 @@ namespace aspect
             }
 
           // Ensure we respect viscosity bounds
-          out.viscosities[i] = std::min(std::max(min_eta, out.viscosities[i]),max_eta);
+          out.viscosities[i] = std::clamp(out.viscosities[i], min_eta, max_eta);
 
           // This represents the viscosity with respect to which we want to define cratons/faults.
           const double background_viscosity_log = std::log10(out.viscosities[i]);

--- a/cookbooks/vankeken_subduction/plugin/van_Keken_mesh.cc
+++ b/cookbooks/vankeken_subduction/plugin/van_Keken_mesh.cc
@@ -18,7 +18,7 @@
   <http://www.gnu.org/licenses/>.
 */
 
-
+#include <algorithm>
 #include <aspect/geometry_model/initial_topography_model/zero_topography.h>
 
 #include <aspect/geometry_model/interface.h>
@@ -282,7 +282,7 @@ namespace aspect
       Assert(dim==2, ExcNotImplemented());
       const double y_extent = 600e3;
       const double d = y_extent - (position(dim-1));
-      return std::min (std::max (d, 0.), maximal_depth());
+      return std::clamp(d, 0., maximal_depth());
     }
 
 

--- a/doc/modules/changes/20260730_buchanankerswell
+++ b/doc/modules/changes/20260730_buchanankerswell
@@ -1,0 +1,3 @@
+Added: Swapped std::min(std::max(val, low), high) for std::clamp(val, low, high)
+<br>
+(Buchanan Kerswell, 2026/07/30)

--- a/source/geometry_model/box.cc
+++ b/source/geometry_model/box.cc
@@ -18,7 +18,7 @@
   <http://www.gnu.org/licenses/>.
 */
 
-
+#include <algorithm>
 #include <aspect/geometry_model/box.h>
 #include <aspect/geometry_model/initial_topography_model/zero_topography.h>
 #include <aspect/mesh_deformation/interface.h>
@@ -269,7 +269,7 @@ namespace aspect
       const double topo = this->get_initial_topography_model().value(surface_point);
 
       const double d = extents[dim-1] + topo - (position(dim-1)-box_origin[dim-1]);
-      return std::min (std::max (d, 0.), maximal_depth());
+      return std::clamp(d, 0., maximal_depth());
     }
 
 

--- a/source/geometry_model/chunk.cc
+++ b/source/geometry_model/chunk.cc
@@ -18,7 +18,7 @@
   <http://www.gnu.org/licenses/>.
 */
 
-
+#include <algorithm>
 #include <aspect/geometry_model/chunk.h>
 #include <aspect/geometry_model/initial_topography_model/zero_topography.h>
 #include <aspect/geometry_model/initial_topography_model/ascii_data.h>
@@ -603,9 +603,9 @@ namespace aspect
       // plus initial topography. Negative depth is not allowed.
       if (this->simulator_is_past_initialization() &&
           !Plugins::plugin_type_matches<const InitialTopographyModel::ZeroTopography<dim>>(this->get_initial_topography_model()))
-        return std::min(std::max(point2[0]+ manifold->topography_for_point(position) - position.norm(), 0.), maximal_depth());
+        return std::clamp(point2[0] + manifold->topography_for_point(position) - position.norm(), 0., maximal_depth());
       else
-        return std::min(std::max(point2[0]-position.norm(), 0.), maximal_depth());
+        return std::clamp(point2[0] - position.norm(), 0., maximal_depth());
     }
 
 

--- a/source/geometry_model/sphere.cc
+++ b/source/geometry_model/sphere.cc
@@ -18,7 +18,7 @@
   <http://www.gnu.org/licenses/>.
 */
 
-
+#include <algorithm>
 #include <aspect/geometry_model/sphere.h>
 #include <aspect/geometry_model/initial_topography_model/zero_topography.h>
 
@@ -82,7 +82,7 @@ namespace aspect
     double
     Sphere<dim>::depth(const Point<dim> &position) const
     {
-      return std::min (std::max (R-position.norm(), 0.), maximal_depth());
+      return std::clamp(R - position.norm(), 0., maximal_depth());
     }
 
     template <int dim>
@@ -98,7 +98,7 @@ namespace aspect
     Sphere<dim>::representative_point(const double depth) const
     {
       Point<dim> p;
-      p(dim-1) = std::min (std::max(R - depth, 0.), maximal_depth());
+      p(dim-1) = std::clamp(R - depth, 0., maximal_depth());
       return p;
     }
 

--- a/source/geometry_model/spherical_shell.cc
+++ b/source/geometry_model/spherical_shell.cc
@@ -18,7 +18,7 @@
   <http://www.gnu.org/licenses/>.
 */
 
-
+#include <algorithm>
 #include <aspect/geometry_model/spherical_shell.h>
 #include <aspect/geometry_model/initial_topography_model/zero_topography.h>
 
@@ -742,9 +742,9 @@ namespace aspect
     {
       if (this->simulator_is_past_initialization() &&
           !Plugins::plugin_type_matches<const InitialTopographyModel::ZeroTopography<dim>>(this->get_initial_topography_model()))
-        return std::min(std::max (R1 + manifold->topography_for_point(position) - position.norm(), 0.), maximal_depth());
+        return std::clamp(R1 + manifold->topography_for_point(position) - position.norm(), 0., maximal_depth());
       else
-        return std::min (std::max (R1-position.norm(), 0.), maximal_depth());
+        return std::clamp(R1 - position.norm(), 0., maximal_depth());
     }
 
 
@@ -771,7 +771,7 @@ namespace aspect
       // requested depth.
       Point<dim> p;
 
-      p[dim-1] = std::min (std::max(R1 + manifold->topography_for_point(p) - depth, R0), R1);
+      p[dim-1] = std::clamp(R1 + manifold->topography_for_point(p) - depth, R0, R1);
 
       return p;
     }

--- a/source/geometry_model/two_merged_boxes.cc
+++ b/source/geometry_model/two_merged_boxes.cc
@@ -18,7 +18,7 @@
   <http://www.gnu.org/licenses/>.
 */
 
-
+#include <algorithm>
 #include <aspect/geometry_model/two_merged_boxes.h>
 #include <aspect/geometry_model/initial_topography_model/zero_topography.h>
 
@@ -368,7 +368,7 @@ namespace aspect
 
       const double topo = get_topography_at_point(position);
       const double d = extents[dim-1] + topo - (position(dim-1)-lower_box_origin[dim-1]);
-      return std::min (std::max (d, 0.), maximal_depth());
+      return std::clamp(d, 0., maximal_depth());
     }
 
 

--- a/source/geometry_model/two_merged_chunks.cc
+++ b/source/geometry_model/two_merged_chunks.cc
@@ -18,7 +18,7 @@
   <http://www.gnu.org/licenses/>.
 */
 
-
+#include <algorithm>
 #include <aspect/geometry_model/two_merged_chunks.h>
 #include <aspect/geometry_model/initial_topography_model/zero_topography.h>
 #include <aspect/geometry_model/initial_topography_model/ascii_data.h>
@@ -266,9 +266,9 @@ namespace aspect
       // plus initial topography. Negative depth is not allowed.
       if (this->simulator_is_past_initialization() &&
           !Plugins::plugin_type_matches<const InitialTopographyModel::ZeroTopography<dim>>(this->get_initial_topography_model()))
-        return std::min(std::max(point2[0]+ manifold->topography_for_point(position) - position.norm(), 0.), maximal_depth());
+        return std::clamp(point2[0] + manifold->topography_for_point(position) - position.norm(), 0., maximal_depth());
       else
-        return std::min(std::max(point2[0]-position.norm(), 0.), maximal_depth());
+        return std::clamp(point2[0] - position.norm(), 0., maximal_depth());
     }
 
 

--- a/source/material_model/grain_size.cc
+++ b/source/material_model/grain_size.cc
@@ -618,14 +618,14 @@ namespace aspect
                     }
                 }
 
-              out.viscosities[i] = std::min(std::max(min_eta,effective_viscosity),max_eta);
+              out.viscosities[i] = std::clamp(effective_viscosity, min_eta, max_eta);
 
               if (const std::shared_ptr<DislocationViscosityOutputs<dim>> disl_viscosities_out
                   = out.template get_additional_output_object<DislocationViscosityOutputs<dim>>())
                 if (in.requests_property(MaterialProperties::additional_outputs))
                   {
-                    disl_viscosities_out->dislocation_viscosities[i] = std::min(std::max(min_eta,disl_viscosity),1e300);
-                    disl_viscosities_out->diffusion_viscosities[i] = std::min(std::max(min_eta,diff_viscosity),1e300);
+                    disl_viscosities_out->dislocation_viscosities[i] = std::clamp(disl_viscosity, min_eta, 1e300);
+                    disl_viscosities_out->diffusion_viscosities[i] = std::clamp(diff_viscosity, min_eta, 1e300);
                   }
 
             }

--- a/source/material_model/melt_boukare.cc
+++ b/source/material_model/melt_boukare.cc
@@ -472,10 +472,10 @@ namespace aspect
             const double molar_composition_of_solid = molar_composition_of_melt * c_Fe_endmember;
 
             new_molar_composition_of_solid = std::clamp(molar_composition_of_solid, 0.0, molar_composition_of_bulk);
-            new_molar_composition_of_melt = std::min(std::max(molar_composition_of_melt, molar_composition_of_bulk), 1.0);
+            new_molar_composition_of_melt = std::clamp(molar_composition_of_melt, molar_composition_of_bulk, 1.0);
 
             if (std::abs(molar_composition_of_melt - molar_composition_of_solid) > std::numeric_limits<double>::min())
-              melt_molar_fraction = std::min(std::max((molar_composition_of_bulk - molar_composition_of_solid) / (molar_composition_of_melt - molar_composition_of_solid), 0.0), 1.0);
+              melt_molar_fraction = std::clamp((molar_composition_of_bulk - molar_composition_of_solid) / (molar_composition_of_melt - molar_composition_of_solid), 0.0, 1.0);
             // If solid and melt composition are the same, there is no two-phase region.
             // If we are not above the liquidus, we are below the solidus.
             else

--- a/source/material_model/reaction_model/grain_size_evolution.cc
+++ b/source/material_model/reaction_model/grain_size_evolution.cc
@@ -241,14 +241,14 @@ namespace aspect
               if (grain_size_evolution_formulation == Formulation::paleowattmeter)
                 {
                   // paleowattmeter: Austin and Evans (2007): Paleowattmeters: A scaling relation for dynamically recrystallized grain size. Geology 35, 343-346
-                  const double stress = 2.0 * second_strain_rate_invariant * std::min(std::max(min_eta,current_viscosity),max_eta);
+                  const double stress = 2.0 * second_strain_rate_invariant * std::clamp(current_viscosity, min_eta, max_eta);
                   grain_size_reduction_rate = 2.0 * stress * boundary_area_change_work_fraction[phase_indices[i]] * dislocation_strain_rate * grain_size * grain_size
                                               / (geometric_constant[phase_indices[i]] * grain_boundary_energy[phase_indices[i]]);
                 }
               else if (grain_size_evolution_formulation == Formulation::pinned_grain_damage)
                 {
                   // pinned_grain_damage: Mulyukova and Bercovici (2018) Collapse of passive margins by lithospheric damage and plunging grain size. Earth and Planetary Science Letters, 484, 341-352.
-                  const double stress = 2.0 * second_strain_rate_invariant * std::min(std::max(min_eta,current_viscosity),max_eta);
+                  const double stress = 2.0 * second_strain_rate_invariant * std::clamp(current_viscosity, min_eta, max_eta);
                   grain_size_reduction_rate = 2.0 * stress * partitioning_fraction * second_strain_rate_invariant * grain_size * grain_size
                                               * roughness_to_grain_size
                                               / (geometric_constant[phase_indices[i]] * grain_boundary_energy[phase_indices[i]] * phase_distribution);

--- a/source/material_model/reaction_model/tian2019_solubility.cc
+++ b/source/material_model/reaction_model/tian2019_solubility.cc
@@ -18,7 +18,7 @@
   <http://www.gnu.org/licenses/>.
 */
 
-
+#include <algorithm>
 #include <aspect/material_model/reaction_model/tian2019_solubility.h>
 #include <deal.II/base/parameter_handler.h>
 
@@ -99,7 +99,7 @@ namespace aspect
             // cap the pressure just before this break down. Additionally, the inverse pressure is used for
             // parameterized enthalpy change, so introduce a minimum pressure to avoid a division by 0.
             const double minimum_pressure = 1e-12;
-            pressure_for_reaction_in_GPa = std::min(std::max(minimum_pressure, pressure_for_reaction_in_GPa), pressure_cutoffs[i]);
+            pressure_for_reaction_in_GPa = std::clamp(pressure_for_reaction_in_GPa, minimum_pressure, pressure_cutoffs[i]);
             const double inverse_pressure_for_reaction = 1.0/pressure_for_reaction_in_GPa;
 
             for (unsigned int j = 0; j<devolatilization_enthalpy_changes[i].size(); ++j)

--- a/source/material_model/rheology/diffusion_dislocation.cc
+++ b/source/material_model/rheology/diffusion_dislocation.cc
@@ -18,7 +18,7 @@
   <http://www.gnu.org/licenses/>.
 */
 
-
+#include <algorithm>
 #include <aspect/material_model/rheology/diffusion_dislocation.h>
 #include <aspect/material_model/utilities.h>
 #include <aspect/utilities.h>
@@ -141,18 +141,18 @@ namespace aspect
                         const double diffusion_T_and_P_dependence = std::exp(std::max(diffusion_creep_parameters.activation_energy + pressure*diffusion_creep_parameters.activation_volume,0.0)/
                                                                              (constants::gas_constant*temperature));
 
-                        const double diffusion_viscosity = std::min(std::max(diffusion_prefactor * diffusion_grain_size_dependence
-                                                                             * diffusion_strain_rate_dependence * diffusion_T_and_P_dependence,
-                                                                             minimum_viscosity), maximum_viscosity);
+                        const double diffusion_viscosity = std::clamp(diffusion_prefactor * diffusion_grain_size_dependence
+                                                                      * diffusion_strain_rate_dependence * diffusion_T_and_P_dependence,
+                                                                      minimum_viscosity, maximum_viscosity);
 
                         const double dislocation_prefactor = 0.5 * std::pow(dislocation_creep_parameters.prefactor,-1.0/dislocation_creep_parameters.stress_exponent);
                         const double dislocation_strain_rate_dependence = std::pow(dislocation_strain_rate, (1.-dislocation_creep_parameters.stress_exponent)/dislocation_creep_parameters.stress_exponent);
                         const double dislocation_T_and_P_dependence = std::exp(std::max(dislocation_creep_parameters.activation_energy + pressure*dislocation_creep_parameters.activation_volume,0.0)/
                                                                                (dislocation_creep_parameters.stress_exponent*constants::gas_constant*temperature));
 
-                        const double dislocation_viscosity = std::min(std::max(dislocation_prefactor * dislocation_strain_rate_dependence
-                                                                               * dislocation_T_and_P_dependence,
-                                                                               minimum_viscosity), maximum_viscosity);
+                        const double dislocation_viscosity = std::clamp(dislocation_prefactor * dislocation_strain_rate_dependence
+                                                                        * dislocation_T_and_P_dependence,
+                                                                        minimum_viscosity, maximum_viscosity);
 
                         diffusion_strain_rate = dislocation_viscosity / (diffusion_viscosity + dislocation_viscosity) * edot_ii;
                         dislocation_strain_rate = diffusion_viscosity / (diffusion_viscosity + dislocation_viscosity) * edot_ii;
@@ -176,7 +176,7 @@ namespace aspect
               }
 
             // The effective viscosity, with minimum and maximum bounds
-            composition_viscosities[j] = std::min(std::max(stress_ii/edot_ii/2, minimum_viscosity), maximum_viscosity);
+            composition_viscosities[j] = std::clamp(stress_ii / edot_ii / 2, minimum_viscosity, maximum_viscosity);
           }
         return composition_viscosities;
       }

--- a/source/material_model/rheology/visco_plastic.cc
+++ b/source/material_model/rheology/visco_plastic.cc
@@ -18,6 +18,7 @@
   <http://www.gnu.org/licenses/>.
 */
 
+#include <algorithm>
 #include <aspect/material_model/rheology/visco_plastic.h>
 #include <aspect/material_model/utilities.h>
 #include <aspect/utilities.h>
@@ -495,7 +496,7 @@ namespace aspect
                                                                j,
                                                                MaterialModel::MaterialUtilities::PhaseUtilities::logarithmic
                                                              );
-            output_parameters.composition_viscosities[j] = std::min(std::max(effective_viscosity, minimum_viscosity_for_composition), maximum_viscosity_for_composition);
+            output_parameters.composition_viscosities[j] = std::clamp(effective_viscosity, minimum_viscosity_for_composition, maximum_viscosity_for_composition);
 
             // Compute the dilation terms if necessary.
             if (this->get_parameters().enable_prescribed_dilation == true)

--- a/source/material_model/utilities.cc
+++ b/source/material_model/utilities.cc
@@ -18,7 +18,7 @@
   <http://www.gnu.org/licenses/>.
 */
 
-
+#include <algorithm>
 #include <aspect/global.h>
 #include <aspect/simulator_access.h>
 #include <aspect/structured_data.h>
@@ -892,7 +892,7 @@ namespace aspect
 
         for (unsigned int i=0; i < x_comp.size(); ++i)
           {
-            x_comp[i] = std::min(std::max(compositional_fields[indices_to_use[i]], 0.0), 1.0);
+            x_comp[i] = std::clamp(compositional_fields[indices_to_use[i]], 0.0, 1.0);
 
             if (x_comp[i] < minimum_fraction)
               x_comp[i] = 0.0;
@@ -937,7 +937,7 @@ namespace aspect
         for (unsigned int i=0; i < x_comp.size(); ++i)
           if (field_mask[i] == true)
             {
-              x_comp[i] = std::min(std::max(x_comp[i], 0.0), 1.0);
+              x_comp[i] = std::clamp(x_comp[i], 0.0, 1.0);
 
               if (x_comp[i] < minimum_fraction)
                 x_comp[i] = 0.0;

--- a/source/mesh_refinement/isosurfaces.cc
+++ b/source/mesh_refinement/isosurfaces.cc
@@ -18,8 +18,6 @@
   <http://www.gnu.org/licenses/>.
 */
 
-
-
 #include <algorithm>
 #include <aspect/geometry_model/interface.h>
 #include <aspect/mesh_refinement/isosurfaces.h>
@@ -117,7 +115,7 @@ namespace aspect
                 std::vector<std::string> tmpNumber = Utilities::split_string_list(string,'+');
                 AssertThrow(tmpNumber.size() == 2,
                             ExcMessage("Could not convert value '" + string + "' to an int because it contains more than one '+' sign."));
-                return std::min(std::max(minimum_refinement_level+Utilities::string_to_int(tmpNumber[1]),minimum_refinement_level),maximum_refinement_level);
+                return std::clamp(minimum_refinement_level + Utilities::string_to_int(tmpNumber[1]), minimum_refinement_level, maximum_refinement_level);
               }
             else
               {
@@ -133,7 +131,7 @@ namespace aspect
                 std::vector<std::string> tmpNumber = Utilities::split_string_list(string,'-');
                 AssertThrow(tmpNumber.size() == 2,
                             ExcMessage("Could not convert value '" + string + "' to an int because it contains more than one '-' sign."));
-                return std::min(std::max(static_cast<int>(maximum_refinement_level)-Utilities::string_to_int(tmpNumber[1]),static_cast<int>(minimum_refinement_level)),static_cast<int>(maximum_refinement_level));
+                return std::clamp(static_cast<int>(maximum_refinement_level) - Utilities::string_to_int(tmpNumber[1]), static_cast<int>(minimum_refinement_level), static_cast<int>(maximum_refinement_level));
               }
             else
               {
@@ -144,7 +142,7 @@ namespace aspect
           }
         else
           {
-            return std::min(std::max(static_cast<unsigned int>(Utilities::string_to_int(string)),minimum_refinement_level),maximum_refinement_level);
+            return std::clamp(static_cast<unsigned int>(Utilities::string_to_int(string)), minimum_refinement_level, maximum_refinement_level);
           }
 
       }

--- a/source/simulator/solver/matrix_free_operators.cc
+++ b/source/simulator/solver/matrix_free_operators.cc
@@ -18,7 +18,7 @@
   <http://www.gnu.org/licenses/>.
  */
 
-
+#include <algorithm>
 #include <aspect/simulator/solver/stokes_matrix_free.h>
 #include <aspect/simulator/solver/matrix_free_operators.h>
 #include <aspect/mesh_deformation/interface.h>
@@ -322,7 +322,7 @@ namespace aspect
                     // of the evaluated viscosity on the active level.
                     for (unsigned int q=0; q<n_q_points; ++q)
                       active_cell_data.viscosity(cell, q)[i]
-                        = std::min(std::max(values_on_quad[q], minimum_viscosity), maximum_viscosity);
+                        = std::clamp(values_on_quad[q], minimum_viscosity, maximum_viscosity);
                   }
               }
           }

--- a/source/simulator/solver/stokes_matrix_free_global_coarsening.cc
+++ b/source/simulator/solver/stokes_matrix_free_global_coarsening.cc
@@ -18,6 +18,7 @@
   <http://www.gnu.org/licenses/>.
 */
 
+#include <algorithm>
 #include <aspect/simulator/solver/matrix_free_operators.h>
 #include <aspect/simulator/solver/stokes_matrix_free.h>
 #include <aspect/simulator/solver/stokes_matrix_free_global_coarsening.h>
@@ -311,8 +312,7 @@ namespace aspect
                     // of the evaluated viscosity on the active level.
                     for (unsigned int q=0; q<n_q_points; ++q)
                       level_cell_data[level].viscosity(cell,q)[i]
-                        = std::min(std::max(values_on_quad[q], static_cast<GMGNumberType>(minimum_viscosity)),
-                                   static_cast<GMGNumberType>(maximum_viscosity));
+                        = std::clamp(values_on_quad[q], static_cast<GMGNumberType>(minimum_viscosity), static_cast<GMGNumberType>(maximum_viscosity));
                   }
 
               }

--- a/source/simulator/solver/stokes_matrix_free_local_smoothing.cc
+++ b/source/simulator/solver/stokes_matrix_free_local_smoothing.cc
@@ -18,6 +18,7 @@
   <http://www.gnu.org/licenses/>.
 */
 
+#include <algorithm>
 #include <aspect/simulator/solver/matrix_free_operators.h>
 #include <aspect/simulator/solver/stokes_matrix_free.h>
 #include <aspect/simulator/solver/stokes_matrix_free_local_smoothing.h>
@@ -282,8 +283,7 @@ namespace aspect
                     // of the evaluated viscosity on the active level.
                     for (unsigned int q=0; q<n_q_points; ++q)
                       level_cell_data[level].viscosity(cell,q)[i]
-                        = std::min(std::max(values_on_quad[q], static_cast<GMGNumberType>(minimum_viscosity)),
-                                   static_cast<GMGNumberType>(maximum_viscosity));
+                        = std::clamp(values_on_quad[q], static_cast<GMGNumberType>(minimum_viscosity), static_cast<GMGNumberType>(maximum_viscosity));
                   }
               }
           }

--- a/tests/melt_visco_plastic.cc
+++ b/tests/melt_visco_plastic.cc
@@ -580,7 +580,7 @@ namespace aspect
                 }
 
               // Limit the viscosity with specified minimum and maximum bounds
-              out.viscosities[i] = std::min(std::max(out.viscosities[i], min_viscosity), max_viscosity);
+              out.viscosities[i] = std::clamp(out.viscosities[i], min_viscosity, max_viscosity);
 
               // Compute the volumetric yield strength (Keller et al. eq (38))
               volumetric_yield_strength[i] = viscous_stress - tensile_strength;
@@ -631,7 +631,7 @@ namespace aspect
                 }
 
               // Limit the viscosity with specified minimum and maximum bounds
-              melt_out->compaction_viscosities[i] = std::min(std::max(melt_out->compaction_viscosities[i], min_viscosity), max_viscosity);
+              melt_out->compaction_viscosities[i] = std::clamp(melt_out->compaction_viscosities[i], min_viscosity, max_viscosity);
             }
         }
 


### PR DESCRIPTION
Pull Request Checklist. Please read and check each box with an X. Delete any part not applicable. Ask on the [forum](https://community.geodynamics.org/c/aspect) if you need help with any step.

*Describe what you did in this PR and why you did it.*

### Before your first pull request:

* [X] I have read the guidelines in our [CONTRIBUTING.md](../blob/main/CONTRIBUTING.md) document.

### For all pull requests:

* [X] I have followed the [instructions for indenting my code](../blob/main/CONTRIBUTING.md#making-aspect-better).
* I followed the [AI Policy](../blob/main/CONTRIBUTING.md#policy-on-usage-of-ai):
  - [ ] Significant parts of this PR were written by AI (please add a sentence below).
  - [X] AI has not been used in significant ways.

*If yes, please describe your usage of AI models in the creation of this pull request*

### For new features/models or changes of existing features:

* [X] I have tested my new feature locally to ensure it is correct.
* [X] I have [created a testcase](https://aspect-documentation.readthedocs.io/en/latest/user/extending/testing/writing-tests.html) for the new feature/benchmark in the [tests/](../blob/main/tests/) directory.
* [X] I have added a changelog entry in the [doc/modules/changes](../blob/main/doc/modules/changes) directory that will inform other users of my change.


## Summary

I manually replaced instances of the pattern `std::min(std::max(val, low), high)` with `std::clamp(val, low, high)`. Most of patterns were obvious which variables were `val`, `low`, and `high`, but there were some that were less obvious. This could use a careful check.

Passes all `./aspect --test` on my local machine.

This handles one half of issue #6349. I will work on the reverse pattern `std::max(std::min(val, high), low)` in a separate PR.