### PR TITLE
Use std clamp instead of std::max(std::min(val, high), low)

### DIFF
--- a/benchmarks/newton_solver_benchmark_set/nonlinear_channel_flow/simple_nonlinear.cc
+++ b/benchmarks/newton_solver_benchmark_set/nonlinear_channel_flow/simple_nonlinear.cc
@@ -17,6 +17,8 @@
   along with ASPECT; see the file LICENSE.  If not see
   <http://www.gnu.org/licenses/>.
 */
+
+#include <algorithm>
 #include <aspect/simulator.h>
 #include <deal.II/grid/tria.h>
 #include <aspect/material_model/interface.h>
@@ -180,7 +182,7 @@ namespace aspect
                   const double edot_ii = std::max(edot_ii_strict, min_strain_rate[c]);
 
                   const double stress_exponent_inv = 1/stress_exponent[c];
-                  composition_viscosities[c] = std::max(std::min(std::pow(viscosity_prefactor[c],-stress_exponent_inv) * std::pow(edot_ii,stress_exponent_inv-1), max_viscosity[c]), min_viscosity[c]);
+                  composition_viscosities[c] = std::clamp(std::pow(viscosity_prefactor[c],-stress_exponent_inv) * std::pow(edot_ii,stress_exponent_inv-1), min_viscosity[c], max_viscosity[c]);
                   Assert(dealii::numbers::is_finite(composition_viscosities[c]), ExcMessage ("Error: Viscosity is not finite."));
                   if (derivatives != nullptr)
                     {

--- a/benchmarks/newton_solver_benchmark_set/spiegelman_et_al_2016/drucker_prager_compositions.cc
+++ b/benchmarks/newton_solver_benchmark_set/spiegelman_et_al_2016/drucker_prager_compositions.cc
@@ -29,6 +29,7 @@
 #ifndef _aspect_model_drucker_prager_compositions_h
 #define _aspect_model_drucker_prager_compositions_h
 
+#include <algorithm>
 #include <aspect/material_model/interface.h>
 #include <aspect/simulator_access.h>
 #include <aspect/newton.h>
@@ -231,7 +232,7 @@ namespace aspect
           viscosity = prefactor;
         }
 
-      return std::max(std::min(viscosity,max_visc),min_visc);
+      return std::clamp(viscosity, min_visc, max_visc);
     }
 
     template <int dim>

--- a/benchmarks/tosi_et_al_2015_gcubed/tosi.cc
+++ b/benchmarks/tosi_et_al_2015_gcubed/tosi.cc
@@ -18,6 +18,7 @@
   <http://www.gnu.org/licenses/>.
  */
 
+#include <algorithm>
 #include <aspect/geometry_model/interface.h>
 #include <aspect/global.h>
 #include <aspect/geometry_model/box.h>
@@ -352,7 +353,7 @@ namespace aspect
         }
 
       // Cut-off the viscosity by user-defined values to avoid possible very large viscosity ratios
-      viscosity = std::max(std::min(viscosity,eta_maximum),eta_minimum);
+      viscosity = std::clamp(viscosity, eta_minimum, eta_maximum);
 
       return viscosity;
     }

--- a/cookbooks/tomography_based_plate_motions/plugins/tomography_based_plate_motions.cc
+++ b/cookbooks/tomography_based_plate_motions/plugins/tomography_based_plate_motions.cc
@@ -18,7 +18,7 @@
   <http://www.gnu.org/licenses/>.
 */
 
-
+#include <algorithm>
 #include "tomography_based_plate_motions.h"
 #include <aspect/adiabatic_conditions/interface.h>
 #include <aspect/gravity_model/interface.h>
@@ -942,7 +942,7 @@ namespace aspect
             alpha += compositional_fields[i] * material_lookup[i]->thermal_expansivity(temperature,pressure);
         }
 
-      alpha = std::max(std::min(alpha,max_thermal_expansivity),min_thermal_expansivity);
+      alpha = std::clamp(alpha, min_thermal_expansivity, max_thermal_expansivity);
       return alpha;
     }
 
@@ -966,7 +966,7 @@ namespace aspect
             cp += compositional_fields[i] * material_lookup[i]->specific_heat(temperature,pressure);
         }
 
-      cp = std::max(std::min(cp,max_specific_heat),min_specific_heat);
+      cp = std::clamp(cp, min_specific_heat, max_specific_heat);
       return cp;
     }
 

--- a/source/geometry_model/ellipsoidal_chunk.cc
+++ b/source/geometry_model/ellipsoidal_chunk.cc
@@ -18,7 +18,7 @@
   <http://www.gnu.org/licenses/>.
 */
 
-
+#include <algorithm>
 #include <aspect/geometry_model/ellipsoidal_chunk.h>
 #include <aspect/utilities.h>
 #include <aspect/geometry_model/initial_topography_model/prm_polygon.h>
@@ -615,7 +615,7 @@ namespace aspect
     double
     EllipsoidalChunk<dim>::depth(const Point<dim> &position) const
     {
-      return std::max(std::min(-manifold->pull_back(position)[dim-1], maximal_depth()), 0.0);
+      return std::clamp(-manifold->pull_back(position)[dim-1], 0.0, maximal_depth());
     }
 
     template <int dim>

--- a/source/material_model/ascii_reference_profile.cc
+++ b/source/material_model/ascii_reference_profile.cc
@@ -18,7 +18,7 @@
   <http://www.gnu.org/licenses/>.
 */
 
-
+#include <algorithm>
 #include <aspect/material_model/ascii_reference_profile.h>
 #include <aspect/adiabatic_conditions/interface.h>
 
@@ -75,7 +75,7 @@ namespace aspect
           const double depth = this->get_geometry_model().depth(position);
           const Point<1> profile_position(depth);
 
-          double visc_temperature_dependence = std::max(std::min(std::exp(-thermal_viscosity_exponent*temperature_deviation/this->get_adiabatic_conditions().temperature(position)),1e3),1e-3);
+          double visc_temperature_dependence = std::clamp(std::exp(-thermal_viscosity_exponent*temperature_deviation/this->get_adiabatic_conditions().temperature(position)), 1e-3, 1e3);
           if (std::isnan(visc_temperature_dependence))
             visc_temperature_dependence = 1.0;
 

--- a/source/material_model/composition_reaction.cc
+++ b/source/material_model/composition_reaction.cc
@@ -18,7 +18,7 @@
   <http://www.gnu.org/licenses/>.
 */
 
-
+#include <algorithm>
 #include <aspect/material_model/composition_reaction.h>
 #include <aspect/geometry_model/interface.h>
 #include <aspect/material_model/equation_of_state/interface.h>
@@ -48,7 +48,7 @@ namespace aspect
           const double temperature = in.temperature[i];
           const std::vector<double> &composition = in.composition[i];
           const double delta_temp = temperature-reference_T;
-          double temperature_dependence = std::max(std::min(std::exp(-thermal_viscosity_exponent*delta_temp/reference_T),1e2),1e-2);
+          double temperature_dependence = std::clamp(std::exp(-thermal_viscosity_exponent*delta_temp/reference_T), 1e-2, 1e2);
 
           if (std::isnan(temperature_dependence))
             temperature_dependence = 1.0;

--- a/source/material_model/entropy_model.cc
+++ b/source/material_model/entropy_model.cc
@@ -18,7 +18,7 @@
   <http://www.gnu.org/licenses/>.
 */
 
-
+#include <algorithm>
 #include <aspect/material_model/entropy_model.h>
 #include <aspect/material_model/thermal_conductivity/constant.h>
 #include <aspect/material_model/thermal_conductivity/tosi_stackhouse.h>
@@ -390,7 +390,7 @@ namespace aspect
                 {
                   double vis_lateral = std::exp(-lateral_viscosity_prefactor_lookup->lateral_viscosity(depth)*delta_temperature/(adjusted_inputs.temperature[i]*reference_temperature));
                   // lateral vis variation
-                  vis_lateral = std::max(std::min((vis_lateral),max_lateral_eta_variation),1/max_lateral_eta_variation);
+                  vis_lateral = std::clamp(vis_lateral, 1/max_lateral_eta_variation, max_lateral_eta_variation);
 
                   if (std::isnan(vis_lateral))
                     vis_lateral = 1.0;
@@ -430,7 +430,7 @@ namespace aspect
                         plastic_out->yielding[i] = eta_plastic < (vis_lateral * viscosity_profile) ? 1 : 0;
                     }
 
-                  out.viscosities[i] = std::max(std::min(effective_viscosity,max_eta),min_eta);
+                  out.viscosities[i] = std::clamp(effective_viscosity, min_eta, max_eta);
                 }
             }
 

--- a/source/material_model/grain_size.cc
+++ b/source/material_model/grain_size.cc
@@ -18,7 +18,7 @@
   <http://www.gnu.org/licenses/>.
 */
 
-
+#include <algorithm>
 #include <aspect/material_model/grain_size.h>
 #include <aspect/adiabatic_conditions/interface.h>
 #include <aspect/gravity_model/interface.h>
@@ -399,7 +399,7 @@ namespace aspect
                 alpha += compositional_fields[i] * material_lookup[i]->thermal_expansivity(temperature,pressure);
             }
         }
-      alpha = std::max(std::min(alpha,max_thermal_expansivity),min_thermal_expansivity);
+      alpha = std::clamp(alpha, min_thermal_expansivity, max_thermal_expansivity);
       return alpha;
     }
 
@@ -426,7 +426,7 @@ namespace aspect
                 cp += compositional_fields[i] * material_lookup[i]->specific_heat(temperature,pressure);
             }
         }
-      cp = std::max(std::min(cp,max_specific_heat),min_specific_heat);
+      cp = std::clamp(cp, min_specific_heat, max_specific_heat);
       return cp;
     }
 
@@ -736,8 +736,8 @@ namespace aspect
               out.specific_heat[i] = specific_heat(in.temperature[i], adiabatic_pressures[i], in.composition[i], in.position[i]);
             }
 
-          out.thermal_expansion_coefficients[i] = std::max(std::min(out.thermal_expansion_coefficients[i],max_thermal_expansivity),min_thermal_expansivity);
-          out.specific_heat[i] = std::max(std::min(out.specific_heat[i],max_specific_heat),min_specific_heat);
+          out.thermal_expansion_coefficients[i] = std::clamp(out.thermal_expansion_coefficients[i], min_thermal_expansivity, max_thermal_expansivity);
+          out.specific_heat[i] = std::clamp(out.specific_heat[i], min_specific_heat, max_specific_heat);
         }
     }
 

--- a/source/material_model/latent_heat.cc
+++ b/source/material_model/latent_heat.cc
@@ -18,7 +18,7 @@
   <http://www.gnu.org/licenses/>.
 */
 
-
+#include <algorithm>
 #include <aspect/material_model/latent_heat.h>
 #include <aspect/adiabatic_conditions/interface.h>
 #include <aspect/gravity_model/interface.h>
@@ -64,7 +64,7 @@ namespace aspect
                                           :
                                           thermal_viscosity_exponent * delta_temp / reference_temperature );
 
-            double visc_temperature_dependence = std::max(std::min(std::exp(-T_dependence),1e2),1e-2);
+            double visc_temperature_dependence = std::clamp(std::exp(-T_dependence), 1e-2, 1e2);
 
             if (std::isnan(visc_temperature_dependence))
               visc_temperature_dependence = 1.0;

--- a/source/material_model/latent_heat_melt.cc
+++ b/source/material_model/latent_heat_melt.cc
@@ -18,7 +18,7 @@
   <http://www.gnu.org/licenses/>.
 */
 
-
+#include <algorithm>
 #include <aspect/material_model/latent_heat_melt.h>
 #include <aspect/adiabatic_conditions/interface.h>
 
@@ -61,7 +61,7 @@ namespace aspect
                                         thermal_viscosity_exponent * delta_temp / reference_temperature );
 
 
-          double temperature_dependence = std::max (std::min ( std::exp( - T_dependence ), 1e2 ), 1e-2 );
+          double temperature_dependence = std::clamp(std::exp(-T_dependence), 1e-2, 1e2);
 
           if (std::isnan(temperature_dependence))
             temperature_dependence = 1.0;

--- a/source/material_model/melt_boukare.cc
+++ b/source/material_model/melt_boukare.cc
@@ -18,7 +18,7 @@
   <http://www.gnu.org/licenses/>.
 */
 
-
+#include <algorithm>
 #include <aspect/adiabatic_conditions/interface.h>
 #include <aspect/material_model/melt_boukare.h>
 #include <aspect/gravity_model/interface.h>
@@ -471,7 +471,7 @@ namespace aspect
             // Equations (B.9) in Appendix B of Dannberg et al., 2021.
             const double molar_composition_of_solid = molar_composition_of_melt * c_Fe_endmember;
 
-            new_molar_composition_of_solid = std::max(std::min(molar_composition_of_solid, molar_composition_of_bulk), 0.0);
+            new_molar_composition_of_solid = std::clamp(molar_composition_of_solid, 0.0, molar_composition_of_bulk);
             new_molar_composition_of_melt = std::min(std::max(molar_composition_of_melt, molar_composition_of_bulk), 1.0);
 
             if (std::abs(molar_composition_of_melt - molar_composition_of_solid) > std::numeric_limits<double>::min())
@@ -878,7 +878,7 @@ namespace aspect
 
           const double delta_temp = in.temperature[q]-this->get_adiabatic_conditions().temperature(in.position[q]);
           const double viscosity_bound = 1.e8;
-          const double visc_temperature_dependence = std::max(std::min(std::exp(-thermal_viscosity_exponent*delta_temp/this->get_adiabatic_conditions().temperature(in.position[q])),viscosity_bound),1./viscosity_bound);
+          const double visc_temperature_dependence = std::clamp(std::exp(-thermal_viscosity_exponent*delta_temp/this->get_adiabatic_conditions().temperature(in.position[q])), 1./viscosity_bound, viscosity_bound);
           out.viscosities[q] *= visc_temperature_dependence;
         }
 
@@ -901,7 +901,7 @@ namespace aspect
 
               const double delta_temp = in.temperature[q]-this->get_adiabatic_conditions().temperature(in.position[q]);
               const double compaction_viscosity_bound = 1.e4;
-              const double visc_temperature_dependence = std::max(std::min(std::exp(-thermal_bulk_viscosity_exponent*delta_temp/this->get_adiabatic_conditions().temperature(in.position[q])),compaction_viscosity_bound),1./compaction_viscosity_bound);
+              const double visc_temperature_dependence = std::clamp(std::exp(-thermal_bulk_viscosity_exponent*delta_temp/this->get_adiabatic_conditions().temperature(in.position[q])), 1./compaction_viscosity_bound, compaction_viscosity_bound);
 
               melt_out->compaction_viscosities[q] *= visc_temperature_dependence;
             }

--- a/source/material_model/melt_global.cc
+++ b/source/material_model/melt_global.cc
@@ -18,7 +18,7 @@
   <http://www.gnu.org/licenses/>.
 */
 
-
+#include <algorithm>
 #include <aspect/material_model/melt_global.h>
 #include <aspect/adiabatic_conditions/interface.h>
 
@@ -244,12 +244,12 @@ namespace aspect
           if (this->include_adiabatic_heating ())
             {
               const double delta_temp = in.temperature[i]-this->get_adiabatic_conditions().temperature(in.position[i]);
-              visc_temperature_dependence = std::max(std::min(std::exp(-thermal_viscosity_exponent*delta_temp/this->get_adiabatic_conditions().temperature(in.position[i])),1e4),1e-4);
+              visc_temperature_dependence = std::clamp(std::exp(-thermal_viscosity_exponent*delta_temp/this->get_adiabatic_conditions().temperature(in.position[i])), 1e-4, 1e4);
             }
           else if (thermal_viscosity_exponent != 0.0)
             {
               const double delta_temp = in.temperature[i]-reference_T;
-              visc_temperature_dependence = std::max(std::min(std::exp(-thermal_viscosity_exponent*delta_temp/reference_T),1e4),1e-4);
+              visc_temperature_dependence = std::clamp(std::exp(-thermal_viscosity_exponent*delta_temp/reference_T), 1e-4, 1e4);
             }
           out.viscosities[i] *= visc_temperature_dependence;
         }
@@ -287,12 +287,12 @@ namespace aspect
               if (this->include_adiabatic_heating ())
                 {
                   const double delta_temp = in.temperature[i]-this->get_adiabatic_conditions().temperature(in.position[i]);
-                  visc_temperature_dependence = std::max(std::min(std::exp(-thermal_bulk_viscosity_exponent*delta_temp/this->get_adiabatic_conditions().temperature(in.position[i])),1e4),1e-4);
+                  visc_temperature_dependence = std::clamp(std::exp(-thermal_bulk_viscosity_exponent*delta_temp/this->get_adiabatic_conditions().temperature(in.position[i])), 1e-4, 1e4);
                 }
               else if (thermal_viscosity_exponent != 0.0)
                 {
                   const double delta_temp = in.temperature[i]-reference_T;
-                  visc_temperature_dependence = std::max(std::min(std::exp(-thermal_bulk_viscosity_exponent*delta_temp/reference_T),1e4),1e-4);
+                  visc_temperature_dependence = std::clamp(std::exp(-thermal_bulk_viscosity_exponent*delta_temp/reference_T), 1e-4, 1e4);
                 }
               melt_out->compaction_viscosities[i] *= visc_temperature_dependence;
             }

--- a/source/material_model/melt_simple.cc
+++ b/source/material_model/melt_simple.cc
@@ -18,7 +18,7 @@
   <http://www.gnu.org/licenses/>.
 */
 
-
+#include <algorithm>
 #include <aspect/adiabatic_conditions/interface.h>
 #include <aspect/material_model/melt_simple.h>
 #include <aspect/material_model/reaction_model/katz2003_mantle_melting.h>
@@ -117,7 +117,7 @@ namespace aspect
           if (this->include_adiabatic_heating ())
             {
               const double delta_temp = in.temperature[i]-this->get_adiabatic_conditions().temperature(in.position[i]);
-              visc_temperature_dependence = std::max(std::min(std::exp(-thermal_viscosity_exponent*delta_temp/this->get_adiabatic_conditions().temperature(in.position[i])),1e4),1e-4);
+              visc_temperature_dependence = std::clamp(std::exp(-thermal_viscosity_exponent*delta_temp/this->get_adiabatic_conditions().temperature(in.position[i])), 1e-4, 1e4);
             }
           else
             {
@@ -127,7 +127,7 @@ namespace aspect
                                            0.0
                                            :
                                            thermal_viscosity_exponent*delta_temp/reference_T);
-              visc_temperature_dependence = std::max(std::min(std::exp(-T_dependence),1e4),1e-4);
+              visc_temperature_dependence = std::clamp(std::exp(-T_dependence), 1e-4, 1e4);
             }
           out.viscosities[i] *= visc_temperature_dependence;
 

--- a/source/material_model/reaction_model/grain_size_evolution.cc
+++ b/source/material_model/reaction_model/grain_size_evolution.cc
@@ -18,7 +18,7 @@
   <http://www.gnu.org/licenses/>.
 */
 
-
+#include <algorithm>
 #include <aspect/material_model/reaction_model/grain_size_evolution.h>
 #include <aspect/utilities.h>
 #include <aspect/gravity_model/interface.h>
@@ -108,7 +108,7 @@ namespace aspect
 
         // We have to ensure the power term exponent is between 0 and 1, otherwise the partitioning fraction
         // will be outside the set bounds for the work fraction.
-        const double power_term_exponent = std::max(std::min(power_term_numerator / power_term_denominator, 1.0), 0.0);
+        const double power_term_exponent = std::clamp(power_term_numerator / power_term_denominator, 0.0, 1.0);
 
         const double power_term = std::pow(power_term_base,
                                            power_term_exponent);

--- a/source/material_model/reaction_model/katz2003_mantle_melting.cc
+++ b/source/material_model/reaction_model/katz2003_mantle_melting.cc
@@ -18,7 +18,7 @@
   <http://www.gnu.org/licenses/>.
 */
 
-
+#include <algorithm>
 #include <aspect/material_model/reaction_model/katz2003_mantle_melting.h>
 #include <aspect/utilities.h>
 #include <aspect/gravity_model/interface.h>
@@ -322,14 +322,14 @@ namespace aspect
                                                        * this->get_gravity_model().gravity_vector(in.position[i]);
 
                 const double phi_0 = 0.05;
-                porosity = std::max(std::min(porosity,0.995),1e-4);
+                porosity = std::clamp(porosity, 1e-4, 0.995);
                 melt_out->compaction_viscosities[i] = xi_0 * phi_0 / porosity;
 
                 double visc_temperature_dependence = 1.0;
                 if (this->include_adiabatic_heating ())
                   {
                     const double delta_temp = in.temperature[i]-this->get_adiabatic_conditions().temperature(in.position[i]);
-                    visc_temperature_dependence = std::max(std::min(std::exp(-thermal_bulk_viscosity_exponent*delta_temp/this->get_adiabatic_conditions().temperature(in.position[i])),1e4),1e-4);
+                    visc_temperature_dependence = std::clamp(std::exp(-thermal_bulk_viscosity_exponent*delta_temp/this->get_adiabatic_conditions().temperature(in.position[i])), 1e-4, 1e4);
                   }
                 else
                   {
@@ -339,7 +339,7 @@ namespace aspect
                                                  0.0
                                                  :
                                                  thermal_bulk_viscosity_exponent*delta_temp/reference_T);
-                    visc_temperature_dependence = std::max(std::min(std::exp(-T_dependence),1e4),1e-4);
+                    visc_temperature_dependence = std::clamp(std::exp(-T_dependence), 1e-4, 1e4);
                   }
                 melt_out->compaction_viscosities[i] *= visc_temperature_dependence;
               }

--- a/source/material_model/reactive_fluid_transport.cc
+++ b/source/material_model/reactive_fluid_transport.cc
@@ -18,6 +18,7 @@
   <http://www.gnu.org/licenses/>.
 */
 
+#include <algorithm>
 #include <aspect/material_model/reactive_fluid_transport.h>
 #include <aspect/adiabatic_conditions/interface.h>
 #include <deal.II/base/parameter_handler.h>
@@ -219,7 +220,7 @@ namespace aspect
                       // Limit the porosity to be no smaller than 1e-8 when
                       // calculating fluid effects on viscosities.
                       porosity = std::max(porosity,1e-8);
-                      fluid_out->compaction_viscosities[q] = std::max(std::min(out.viscosities[q] * shear_to_bulk_viscosity_ratio * phi_0/porosity, max_compaction_viscosity), min_compaction_viscosity);
+                      fluid_out->compaction_viscosities[q] = std::clamp(out.viscosities[q] * shear_to_bulk_viscosity_ratio * phi_0/porosity, min_compaction_viscosity, max_compaction_viscosity);
                     }
                 }
             }

--- a/source/material_model/rheology/strain_dependent.cc
+++ b/source/material_model/rheology/strain_dependent.cc
@@ -18,7 +18,7 @@
   <http://www.gnu.org/licenses/>.
 */
 
-
+#include <algorithm>
 #include <aspect/material_model/rheology/strain_dependent.h>
 
 #include <deal.II/base/signaling_nan.h>
@@ -600,7 +600,7 @@ namespace aspect
                                   const unsigned int j) const
       {
         // Constrain the second strain invariant of the previous timestep by the strain interval
-        const double cut_off_strain_ii = std::max(std::min(strain_ii,end_plastic_strain_weakening_intervals[j]),start_plastic_strain_weakening_intervals[j]);
+        const double cut_off_strain_ii = std::clamp(strain_ii, start_plastic_strain_weakening_intervals[j], end_plastic_strain_weakening_intervals[j]);
 
         // Linear strain weakening of cohesion and internal friction angle between specified strain values
         const double strain_fraction = (cut_off_strain_ii - start_plastic_strain_weakening_intervals[j]) /
@@ -620,7 +620,7 @@ namespace aspect
                                   const unsigned int j) const
       {
         // Constrain the second strain invariant of the previous timestep by the strain interval
-        const double cut_off_strain_ii = std::max(std::min(strain_ii,end_viscous_strain_weakening_intervals[j]),start_viscous_strain_weakening_intervals[j]);
+        const double cut_off_strain_ii = std::clamp(strain_ii, start_viscous_strain_weakening_intervals[j], end_viscous_strain_weakening_intervals[j]);
 
         // Linear strain weakening of the viscous flow law prefactors between specified strain values
         const double strain_fraction = (cut_off_strain_ii - start_viscous_strain_weakening_intervals[j]) /

--- a/source/material_model/simple.cc
+++ b/source/material_model/simple.cc
@@ -18,7 +18,7 @@
   <http://www.gnu.org/licenses/>.
 */
 
-
+#include <algorithm>
 #include <aspect/material_model/simple.h>
 #include <aspect/material_model/equation_of_state/interface.h>
 
@@ -44,10 +44,10 @@ namespace aspect
           const double temperature_dependence
             = (reference_T > 0
                ?
-               std::max(std::min(std::exp(-thermal_viscosity_exponent *
-                                          delta_temp/reference_T),
-                                 maximum_thermal_prefactor),
-                        minimum_thermal_prefactor)
+               std::clamp(std::exp(-thermal_viscosity_exponent *
+                                   delta_temp/reference_T),
+                          minimum_thermal_prefactor,
+                          maximum_thermal_prefactor)
                :
                1.0);
 

--- a/source/material_model/steinberger.cc
+++ b/source/material_model/steinberger.cc
@@ -18,6 +18,7 @@
   <http://www.gnu.org/licenses/>.
 */
 
+#include <algorithm>
 
 #include <aspect/material_model/steinberger.h>
 #include <aspect/material_model/rheology/visco_plastic.h>
@@ -195,7 +196,7 @@ namespace aspect
       const double log_thermal_prefactor = -1.0 * lateral_viscosity_lookup->lateral_viscosity(depth) * delta_temperature / (in.temperature[q] * adiabatic_temperature);
 
       // Limit the lateral viscosity variation to a reasonable interval
-      const double thermal_prefactor = std::max(std::min(std::exp(log_thermal_prefactor), max_lateral_eta_variation), 1/max_lateral_eta_variation);
+      const double thermal_prefactor = std::clamp(std::exp(log_thermal_prefactor), 1/max_lateral_eta_variation, max_lateral_eta_variation);
 
       const double compositional_prefactor = MaterialUtilities::average_value (volume_fractions, viscosity_prefactors, viscosity_averaging_scheme);
 
@@ -310,7 +311,7 @@ namespace aspect
           if (in.requests_property(MaterialProperties::viscosity) || in.requests_property(MaterialProperties::additional_outputs))
             {
               out.viscosities[i] = viscosity(i, volume_fractions[i], in, out);
-              out.viscosities[i] = std::max(std::min(out.viscosities[i], max_eta), min_eta);
+              out.viscosities[i] = std::clamp(out.viscosities[i], min_eta, max_eta);
             }
 
           MaterialUtilities::fill_averaged_equation_of_state_outputs(eos_outputs[i], mass_fractions, volume_fractions[i], i, out);

--- a/source/particle/interpolator/quadratic_least_squares.cc
+++ b/source/particle/interpolator/quadratic_least_squares.cc
@@ -18,6 +18,7 @@
  <http://www.gnu.org/licenses/>.
  */
 
+#include <algorithm>
 #include <aspect/particle/interpolator/quadratic_least_squares.h>
 #include <aspect/particle/manager.h>
 #include <aspect/utilities.h>
@@ -466,8 +467,8 @@ namespace aspect
                     if ((interpolation_max - cell_average_values[property_index]) > std::numeric_limits<double>::epsilon() &&
                         (cell_average_values[property_index] - interpolation_min) > std::numeric_limits<double>::epsilon())
                       {
-                        const double alpha = std::max(std::min((cell_average_values[property_index] - property_minimums[property_index])/(cell_average_values[property_index] - interpolation_min),
-                                                               (property_maximums[property_index]-cell_average_values[property_index])/(interpolation_max - cell_average_values[property_index])), 0.0);
+                        const double alpha = std::clamp((cell_average_values[property_index] - property_minimums[property_index])/(cell_average_values[property_index] - interpolation_min),
+                                                        0.0, (property_maximums[property_index]-cell_average_values[property_index])/(interpolation_max - cell_average_values[property_index]));
                         // If alpha > 1, then using it would make the function grow to meet the bounds.
                         if (alpha < 1.0)
                           {

--- a/tests/free_surface_blob_melt.cc
+++ b/tests/free_surface_blob_melt.cc
@@ -18,6 +18,7 @@
   <http://www.gnu.org/licenses/>.
 */
 
+#include <algorithm>
 #include <aspect/global.h>
 #include <aspect/melt.h>
 
@@ -101,9 +102,9 @@ namespace aspect
           const double delta_temp = in.temperature[i]-reference_T;
           const double temperature_dependence = (reference_T > 0
                                                  ?
-                                                 std::max(std::min(std::exp(-thermal_viscosity_exponent*delta_temp/reference_T),
-                                                                   maximum_thermal_prefactor),
-                                                          minimum_thermal_prefactor)
+                                                 std::clamp(std::exp(-thermal_viscosity_exponent*delta_temp/reference_T),
+                                                            minimum_thermal_prefactor,
+                                                            maximum_thermal_prefactor)
                                                  :
                                                  1.0);
 

--- a/tests/melt_visco_plastic.cc
+++ b/tests/melt_visco_plastic.cc
@@ -21,6 +21,7 @@
 #ifndef _aspect_material_model_melt_visco_plastic_h
 #define _aspect_material_model_melt_visco_plastic_h
 
+#include <algorithm>
 #include <aspect/material_model/interface.h>
 #include <aspect/simulator.h>
 #include <aspect/simulator_access.h>
@@ -605,7 +606,7 @@ namespace aspect
               const double compaction_pressure = (1.0 - porosity) * (in.pressure[i] - fluid_pressures[i]);
 
               const double phi_0 = 0.05;
-              porosity = std::max(std::min(porosity,0.995),1.e-8);
+              porosity = std::clamp(porosity, 1.e-8, 0.995);
               // compaction viscosities (Keller et al. eq (51)
               melt_out->compaction_viscosities[i] = intrinsic_viscosities[i] * phi_0 / porosity;
 

--- a/tests/spiegelman_fail_test.cc
+++ b/tests/spiegelman_fail_test.cc
@@ -18,6 +18,7 @@
   <http://www.gnu.org/licenses/>.
 */
 
+#include <algorithm>
 #include <aspect/simulator.h>
 #include <deal.II/grid/tria.h>
 #include <aspect/simulator_access.h>
@@ -248,7 +249,7 @@ namespace aspect
         }
 
       if (compute_full_viscosity == true)
-        return std::max(std::min(viscosity, max_visc), min_visc);
+        return std::clamp(viscosity, min_visc, max_visc);
       else
         return viscosity;
     }


### PR DESCRIPTION
Pull Request Checklist. Please read and check each box with an X. Delete any part not applicable. Ask on the [forum](https://community.geodynamics.org/c/aspect) if you need help with any step.

*Describe what you did in this PR and why you did it.*

### Before your first pull request:

* [X] I have read the guidelines in our [CONTRIBUTING.md](../blob/main/CONTRIBUTING.md) document.

### For all pull requests:

* [X] I have followed the [instructions for indenting my code](../blob/main/CONTRIBUTING.md#making-aspect-better).
* I followed the [AI Policy](../blob/main/CONTRIBUTING.md#policy-on-usage-of-ai):
  - [ ] Significant parts of this PR were written by AI (please add a sentence below).
  - [X] AI has not been used in significant ways.

*If yes, please describe your usage of AI models in the creation of this pull request*

### For new features/models or changes of existing features:

* [X] I have tested my new feature locally to ensure it is correct.
* [X] I have [created a testcase](https://aspect-documentation.readthedocs.io/en/latest/user/extending/testing/writing-tests.html) for the new feature/benchmark in the [tests/](../blob/main/tests/) directory.
* [X] I have added a changelog entry in the [doc/modules/changes](../blob/main/doc/modules/changes) directory that will inform other users of my change.


## Summary

I manually replaced instances of the pattern `std::max(std::min(val, high), low)` with `std::clamp(val, low, high)`. Most of patterns were obvious which variables were `val`, `low`, and `high`, but there were some that were less obvious. In this 'reverse' case, I also had to manually swap the `high` and `low` values. ***This could use a careful check***.

Compiles and passes all `./aspect --test` on my local machine.

This handles the 'reverse' half of issue #6349. The forward pattern `std::min(std::max(val, low), high)` is in a separate PR (#7221).