### PR TITLE
Allow particle elastic stress for compositing material model

### DIFF
--- a/source/particle/property/elastic_stress.cc
+++ b/source/particle/property/elastic_stress.cc
@@ -21,6 +21,7 @@
 #include <aspect/particle/property/elastic_stress.h>
 #include <aspect/material_model/visco_plastic.h>
 #include <aspect/material_model/viscoelastic.h>
+#include <aspect/material_model/compositing.h>
 #include <aspect/initial_composition/interface.h>
 #include <aspect/particle/world.h>
 
@@ -45,10 +46,12 @@ namespace aspect
       void
       ElasticStress<dim>::initialize ()
       {
-        AssertThrow((Plugins::plugin_type_matches<const MaterialModel::ViscoPlastic<dim>>(this->get_material_model())
-                     ||
-                     Plugins::plugin_type_matches<const MaterialModel::Viscoelastic<dim>>(this->get_material_model())),
-                    ExcMessage("This particle property only makes sense in combination with the viscoelastic or visco_plastic material model."));
+        AssertThrow(Plugins::plugin_type_matches<const MaterialModel::ViscoPlastic<dim>>(this->get_material_model())
+                    ||
+                    Plugins::plugin_type_matches<const MaterialModel::Viscoelastic<dim>>(this->get_material_model())
+                    ||
+                    Plugins::plugin_type_matches<const MaterialModel::Compositing<dim>>(this->get_material_model()),
+                    ExcMessage("This particle property only makes sense in combination with the viscoelastic, visco_plastic, or compositing material model."));
 
         AssertThrow(this->get_parameters().enable_elasticity == true,
                     ExcMessage ("This particle property should only be used if 'Enable elasticity' is set to true"));

--- a/tests/compositing_elastic_particles.prm
+++ b/tests/compositing_elastic_particles.prm
@@ -1,0 +1,89 @@
+# This test checks whether particles with elasticity enabled can run with the compositing material model.
+
+include $ASPECT_SOURCE_DIR/benchmarks/viscoelastic_bending_beam/viscoelastic_bending_beam.prm
+
+# For particles, the stress update is done by the particle property elastic stress,
+# so we do not use the operator splitting.
+set Use operator splitting                 = false
+
+set End time         = 2e3
+set Output directory = compositing_elastic_particles
+set Max nonlinear iterations               = 5
+
+# Significantly reduce resolution
+subsection Geometry model
+  set Model name = box
+
+  subsection Box
+    set X repetitions = 15
+    set Y repetitions = 10
+  end
+end
+
+# Compositional field names and methods
+subsection Compositional fields
+  set Number of fields = 7
+  set Compositional field methods =           particles,           particles,           particles,         particles,           particles,           particles,         particles
+  set Names of fields             =           ve_stress_xx,        ve_stress_yy,        ve_stress_xy,      ve_stress_xx_old,    ve_stress_yy_old,    ve_stress_xy_old,  beam
+  set Types of fields             =           stress,              stress,              stress,            stress,              stress,              stress,            chemical composition
+  set Mapped particle properties  = ve_stress_xx:ve_stress_xx, ve_stress_yy:ve_stress_yy, ve_stress_xy:ve_stress_xy, ve_stress_xx_old:ve_stress_xx_old, ve_stress_yy_old:ve_stress_yy_old, ve_stress_xy_old:ve_stress_xy_old, beam:initial beam
+end
+
+# Post processing
+subsection Postprocess
+  set List of postprocessors = basic statistics, composition statistics, particles
+
+  subsection Particles
+    set Time between data output    = 1e9
+    set Data output format          = vtu
+  end
+end
+
+subsection Material model
+  set Model name = compositing
+
+  subsection Multicomponent compressible
+    set Reference temperatures                       = 293
+    set Viscosities                                  = 1e20
+    set Reference densities                          = 2700
+    set Reference isothermal compressibilities       = 6e-11
+    set Isothermal bulk modulus pressure derivatives = 4
+    set Reference thermal expansivities              = 4e-11
+    set Isochoric specific heats                     = 1250
+    set Thermal conductivities                       = 2.5
+  end
+
+  subsection Viscoelastic
+    set Elastic shear moduli        = 1e11
+    set Use fixed elastic time step = false
+    set Viscosities                 = 1e21
+  end
+
+  subsection Compositing
+    set Viscosity                      = viscoelastic
+    set Density                        = multicomponent compressible
+    set Thermal expansion coefficient  = multicomponent compressible
+    set Specific heat                  = multicomponent compressible
+    set Thermal conductivity           = multicomponent compressible
+    set Compressibility                = multicomponent compressible
+    set Entropy derivative pressure    = multicomponent compressible
+    set Entropy derivative temperature = multicomponent compressible
+    set Reaction terms                 = viscoelastic
+  end
+
+end
+
+subsection Particles
+  set Minimum particles per cell  = 25
+  set Maximum particles per cell  = 35
+  set Load balancing strategy     = remove and add particles
+  set List of particle properties = initial composition, elastic stress
+  set Interpolation scheme        = linear least squares
+  set Particle generator name     = random uniform
+
+  subsection Generator
+    subsection Random uniform
+      set Number of particles = 4.5e3
+    end
+  end
+end

--- a/tests/compositing_elastic_particles/screen-output
+++ b/tests/compositing_elastic_particles/screen-output
@@ -1,0 +1,44 @@
+
+Number of active cells: 150 (on 1 levels)
+Number of degrees of freedom: 11,104 (1,302+176+176+1,350+1,350+1,350+1,350+1,350+1,350+1,350)
+
+*** Timestep 0:  t=0 years, dt=0 years
+   Solving temperature system... 0 iterations.
+   Advecting particles...  done.
+   Solving Stokes system (GMG)... 55+0 iterations.
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 1.2959e-16, 0, 0, 0, 0, 0, 0, 0, 4.12153e-06
+      Relative nonlinear residual (total system) after nonlinear iteration 1: 4.12153e-06
+
+
+   Postprocessing:
+     Compositions min/max/mass: 0/0/0 // 0/0/0 // 0/0/0 // 0/0/0 // 0/0/0 // 0/0/0 // 0/1/2.25e+06
+     Writing particle output:   output-compositing_elastic_particles/particles/particles-00000
+
+*** Timestep 1:  t=1000 years, dt=1000 years
+   Solving temperature system... 0 iterations.
+   Advecting particles...  done.
+   Solving Stokes system (GMG)... 53+0 iterations.
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 1.3578e-16, 0, 0, 0, 0, 0, 0, 0, 3.12164e-08
+      Relative nonlinear residual (total system) after nonlinear iteration 1: 3.12164e-08
+
+
+   Postprocessing:
+     Compositions min/max/mass:    -0.2828/0.2939/-209.6 // -0.5878/0.5656/-71.56 // -0.08238/0.0656/8704 // -0.2828/0.2939/-209.6 // -0.5878/0.5656/-71.56 // -0.08238/0.0656/8704 // 0/1/2.25e+06
+     Number of advected particles: 4474
+
+*** Timestep 2:  t=2000 years, dt=1000 years
+   Solving temperature system... 0 iterations.
+   Advecting particles...  done.
+   Solving Stokes system (GMG)... 53+0 iterations.
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 1.36172e-16, 0, 0, 0, 0, 0, 0, 0, 3.08023e-08
+      Relative nonlinear residual (total system) after nonlinear iteration 1: 3.08023e-08
+
+
+   Postprocessing:
+     Compositions min/max/mass:    -0.2843/0.2951/-511.2 // -0.5914/0.5706/404.3 // -0.08212/0.05689/5962 // -0.2843/0.2951/-511.2 // -0.5914/0.5706/404.3 // -0.08212/0.05689/5962 // 0/1/2.25e+06
+     Number of advected particles: 4474
+
+Termination requested by criterion: end time
+
+
+

--- a/tests/compositing_elastic_particles/statistics
+++ b/tests/compositing_elastic_particles/statistics
@@ -1,0 +1,38 @@
+# 1: Time step number
+# 2: Time (years)
+# 3: Time step size (years)
+# 4: Number of mesh cells
+# 5: Number of Stokes degrees of freedom
+# 6: Number of temperature degrees of freedom
+# 7: Number of degrees of freedom for all compositions
+# 8: Number of nonlinear iterations
+# 9: Iterations for temperature solver
+# 10: Iterations for Stokes solver
+# 11: Velocity iterations in Stokes preconditioner
+# 12: Schur complement iterations in Stokes preconditioner
+# 13: Minimal value for composition ve_stress_xx
+# 14: Maximal value for composition ve_stress_xx
+# 15: Global mass for composition ve_stress_xx
+# 16: Minimal value for composition ve_stress_yy
+# 17: Maximal value for composition ve_stress_yy
+# 18: Global mass for composition ve_stress_yy
+# 19: Minimal value for composition ve_stress_xy
+# 20: Maximal value for composition ve_stress_xy
+# 21: Global mass for composition ve_stress_xy
+# 22: Minimal value for composition ve_stress_xx_old
+# 23: Maximal value for composition ve_stress_xx_old
+# 24: Global mass for composition ve_stress_xx_old
+# 25: Minimal value for composition ve_stress_yy_old
+# 26: Maximal value for composition ve_stress_yy_old
+# 27: Global mass for composition ve_stress_yy_old
+# 28: Minimal value for composition ve_stress_xy_old
+# 29: Maximal value for composition ve_stress_xy_old
+# 30: Global mass for composition ve_stress_xy_old
+# 31: Minimal value for composition beam
+# 32: Maximal value for composition beam
+# 33: Global mass for composition beam
+# 34: Number of advected particles
+# 35: Particle file name
+0 0.000000000000e+00 0.000000000000e+00 150 1478 176 9450 1 0 55 56 56  0.00000000e+00 0.00000000e+00  0.00000000e+00  0.00000000e+00 0.00000000e+00  0.00000000e+00  0.00000000e+00 0.00000000e+00 0.00000000e+00  0.00000000e+00 0.00000000e+00  0.00000000e+00  0.00000000e+00 0.00000000e+00  0.00000000e+00  0.00000000e+00 0.00000000e+00 0.00000000e+00 0.00000000e+00 1.00000000e+00 2.25000000e+06 4474 output-compositing_elastic_particles/particles/particles-00000 
+1 1.000000000000e+03 1.000000000000e+03 150 1478 176 9450 1 0 53 54 54 -2.82772509e-01 2.93876188e-01 -2.09585191e+02 -5.87839046e-01 5.65648980e-01 -7.15649773e+01 -8.23751360e-02 6.55998303e-02 8.70354759e+03 -2.82772509e-01 2.93876188e-01 -2.09585191e+02 -5.87839046e-01 5.65648980e-01 -7.15649775e+01 -8.23751360e-02 6.55998303e-02 8.70354759e+03 0.00000000e+00 1.00000000e+00 2.25000000e+06 4474                                                             "" 
+2 2.000000000000e+03 1.000000000000e+03 150 1478 176 9450 1 0 53 54 54 -2.84296954e-01 2.95133613e-01 -5.11192385e+02 -5.91393502e-01 5.70607002e-01  4.04268679e+02 -8.21218509e-02 5.68850350e-02 5.96203946e+03 -2.84296954e-01 2.95133613e-01 -5.11192385e+02 -5.91393502e-01 5.70607002e-01  4.04268679e+02 -8.21218509e-02 5.68850350e-02 5.96203946e+03 0.00000000e+00 1.00000000e+00 2.25000000e+06 4474                                                             "" 


### PR DESCRIPTION
Currently, we cannot use the compositing material model with elastic particles. This material model is useful for modeling compressible elastic material, so it should be able to use that feature. I added compositing to the AssertThrow statement in source/particle/property/elastic_stress.cc so that an error no longer occurs.

@bangerth @cedrict 

### Before your first pull request:

* [x] I have read the guidelines in our [CONTRIBUTING.md](../blob/main/CONTRIBUTING.md) document.

### For all pull requests:

* [x] I have followed the [instructions for indenting my code](../blob/main/CONTRIBUTING.md#making-aspect-better).
* I followed the [AI Policy](../blob/main/CONTRIBUTING.md#policy-on-usage-of-ai):
  - [ ] Significant parts of this PR were written by AI (please add a sentence below).
  - [ ] AI has not been used in significant ways.

I used AI for debugging.

### For new features/models or changes of existing features:

* [x] I have tested my new feature locally to ensure it is correct.
* [x] I have [created a testcase](https://aspect-documentation.readthedocs.io/en/latest/user/extending/testing/writing-tests.html) for the new feature/benchmark in the [tests/](../blob/main/tests/) directory.
* [ ] I have added a changelog entry in the [doc/modules/changes](../blob/main/doc/modules/changes) directory that will inform other users of my change.
