### PR TITLE
Unify the update of postprocessors with other plugin systems

### DIFF
--- a/doc/modules/changes/20260807_gassmoeller
+++ b/doc/modules/changes/20260807_gassmoeller
@@ -1,0 +1,6 @@
+Changed: The function 'update' of all postprocessors is now called at the
+beginning of each time step, not right before the postprocessors are
+executed. This is to make their behavior consistent with all other
+plugin systems, which call 'update' at the beginning of each time step.
+<br>
+(Rene Gassmoeller, 2026/08/07)

--- a/include/aspect/postprocess/visualization/heat_flux_map.h
+++ b/include/aspect/postprocess/visualization/heat_flux_map.h
@@ -56,14 +56,6 @@ namespace aspect
           initialize() override;
 
           /**
-           * Fill the temporary storage variables with the
-           * heat flux for the current time step.
-           *
-           * @copydoc Interface<dim>::update()
-           */
-          void update() override;
-
-          /**
            * Compute the heat flux for the given input cell.
            *
            * @copydoc dealii::DataPostprocessor<dim>::evaluate_vector_field()
@@ -86,6 +78,15 @@ namespace aspect
           parse_parameters (ParameterHandler &prm) override;
 
         private:
+          /**
+           * Fill the temporary storage variables with the
+           * heat flux for the current time step. We do
+           * not use the regular update() function, because
+           * we need the solution after the nonlinear
+           * solver loop, not at the beginning of the time step.
+           */
+          void update_heat_flux();
+
           /**
            * A flag that determines whether to use the point-wise
            * heat flux calculation or the cell-wise averaged calculation.

--- a/source/postprocess/interface.cc
+++ b/source/postprocess/interface.cc
@@ -54,9 +54,6 @@ namespace aspect
         {
           try
             {
-              // first call the update() function.
-              p->update();
-
               // call the execute() function. if it produces any output
               // then add it to the list
               std::pair<std::string,std::string> output

--- a/source/postprocess/visualization/heat_flux_map.cc
+++ b/source/postprocess/visualization/heat_flux_map.cc
@@ -23,6 +23,7 @@
 #include <aspect/postprocess/heat_flux_map.h>
 #include <aspect/geometry_model/interface.h>
 #include <aspect/boundary_velocity/interface.h>
+#include <aspect/simulator_signals.h>
 
 #include <deal.II/base/quadrature_lib.h>
 #include <deal.II/fe/fe_values.h>
@@ -49,13 +50,21 @@ namespace aspect
       HeatFluxMap<dim>::initialize ()
       {
         CitationInfo::add("cbfheatflux");
+
+        // Connect the function update_heat_flux() to the signal
+        // pre_data_out_build_patches, to recompute the heat flux map
+        // before evaluating it for each cell.
+        this->get_signals().pre_data_out_build_patches.connect([&](DataOut<dim> &)
+        {
+          update_heat_flux();
+        });
       }
 
 
 
       template <int dim>
       void
-      HeatFluxMap<dim>::update ()
+      HeatFluxMap<dim>::update_heat_flux ()
       {
         if (output_point_wise_heat_flux)
           heat_flux_density_solution = Postprocess::internal::compute_dirichlet_boundary_heat_flux_solution_vector(*this);

--- a/source/simulator/core.cc
+++ b/source/simulator/core.cc
@@ -711,6 +711,8 @@ namespace aspect
     // the constraints object when calling compute_current_constraints()
     // above
     boundary_traction_manager.update();
+
+    postprocess_manager.update();
   }
 
 


### PR DESCRIPTION
I noticed that while the documentation of the `update` function says it is run at the beginning of a time step, the postprocessors actually run their `update` function just before they are called, i.e. at the end of a time step. This PR proposes to unify the update of all plugin systems and in particular resolve this wrong documentation.

This may break some postprocessors, and I know @bangerth that you did not particularly like this arrrangement anyway. I am ok discussing alternatives, but at the moment at least the documentation is wrong.

Also seen while reviewing #7226.