### PR TITLE
Serialize the random number generator of particles::Manager.

### DIFF
--- a/include/aspect/particle/manager.h
+++ b/include/aspect/particle/manager.h
@@ -47,6 +47,7 @@
 #include <boost/serialization/unique_ptr.hpp>
 
 #include <random>
+#include <sstream>
 #include <vector>
 
 namespace aspect
@@ -398,7 +399,11 @@ namespace aspect
         std::unique_ptr<Integrator::Interface<dim>> integrator;
 
         /**
-         * Random number generator used for creating and deleting particles
+         * A random number generator that is used for creating and deleting particles
+         * in a random manner.
+         *
+         * This variable is part of the state of the object, and so it is
+         * serialized along with all of the other stateful variables here.
          */
         std::mt19937 random_number_generator;
 
@@ -575,6 +580,22 @@ namespace aspect
     void Manager<dim>::serialize (Archive &ar, const unsigned int)
     {
       ar &particle_manager_index;
+
+      if constexpr (Archive::is_saving::value)
+        {
+          std::ostringstream os;
+          os << random_number_generator << std::flush;
+          ar &os.str();
+        }
+      else
+        {
+          std::string random_number_generator_state;
+          ar &random_number_generator_state;
+          std::istringstream is(random_number_generator_state);
+          is >> random_number_generator;
+          AssertThrow(!is.fail(),
+                      ExcMessage("Could not restore the particle manager random number generator."));
+        }
 
       // Note that although Boost claims to handle serialization of pointers
       // correctly, at least for the case of unique_ptr it seems to not work.


### PR DESCRIPTION
Part of #6744. Replaces a part of #7099. The particle manager has a member variable (the random number generator) that is not serialized. That's an oversight. The only tricky part is that boost::serialization doesn't know how to serialize RNG objects, so one has to go through some hoops -- the specifics of the hoop I used AI for.

* [x] I have read the guidelines in our [CONTRIBUTING.md](../blob/main/CONTRIBUTING.md) document.

### For all pull requests:

* [x] I have followed the [instructions for indenting my code](../blob/main/CONTRIBUTING.md#making-aspect-better).
* I followed the [AI Policy](../blob/main/CONTRIBUTING.md#policy-on-usage-of-ai):
  - [ ] Significant parts of this PR were written by AI (please add a sentence below).
  - [x] AI has not been used in significant ways.

*If yes, please describe your usage of AI models in the creation of this pull request*

### For new features/models or changes of existing features:

* [ ] I have tested my new feature locally to ensure it is correct.
* [ ] I have [created a testcase](https://aspect-documentation.readthedocs.io/en/latest/user/extending/testing/writing-tests.html) for the new feature/benchmark in the [tests/](../blob/main/tests/) directory.
* [ ] I have added a changelog entry in the [doc/modules/changes](../blob/main/doc/modules/changes) directory that will inform other users of my change.
