### PR TITLE
2D implementation of latitudinally varying tidal heating

### DIFF
--- a/doc/modules/changes/20260730_hyunseong96
+++ b/doc/modules/changes/20260730_hyunseong96
@@ -1,0 +1,4 @@
+The heating model 'Tidal Heating' with the option 'latitudinal variation' now works for 2-dimensional spherical geometries.
+The model assumes that the 2D geometry represents the simplified latitudinal variation from Nimmo et al. (2007).
+<br>
+(Hyunseong Kim 2026/07/30)

--- a/doc/sphinx/parameters/Heating_20model.md
+++ b/doc/sphinx/parameters/Heating_20model.md
@@ -47,7 +47,7 @@ The formula is interpreted as having units W/kg.
 
 &lsquo;shear heating with melt&rsquo;: Implementation of a standard model for shear heating of migrating melt, including bulk (compression) heating $\xi \left( \nabla \cdot \mathbf u_s \right)^2 $ and heating due to melt segregation $\frac{\eta_f \phi^2}{k} \left( \mathbf u_f - \mathbf u_s \right)^2 $. For full shear heating, this has to be used in combination with the heating model shear heating to also include shear heating for the solid part.
 
-&lsquo;tidal heating&rsquo;: A tidal heating implementation related to diurnal tides. The default equation ignores regional (radial/lateral) changes. This equation is the Eq.12 from Tobie et al. (2003) (https://doi.org/10.1029/2003JE002099). Selecting &rsquo;latitudinal variation&rsquo; from &rsquo;Custom distribution of tidal strain rate&rsquo; allows simplified latitudinal variation with cosine function, &rsquo;Maximum tidal strain rate&rsquo; and &rsquo;Minimum tidal strain rate. Latitudinal variation of tidal strain rate is shown in Fig.3 from Nimmo et al. (2007) (https://doi.org/10.1016/j.icarus.2007.04.021). Unit: \si{\watt\per\meter\cubed}.
+&lsquo;tidal heating&rsquo;: A tidal heating implementation related to diurnal tides. The default equation ignores regional (radial/lateral) changes. This equation is the Eq.12 from Tobie et al. (2003) (https://doi.org/10.1029/2003JE002099). Selecting &rsquo;latitudinal variation&rsquo; from &rsquo;Custom distribution of tidal strain rate&rsquo; allows simplified latitudinal variation with cosine function, &rsquo;Maximum tidal strain rate&rsquo; and &rsquo;Minimum tidal strain rate. Latitudinal variation of tidal strain rate is shown in Fig.3 from Nimmo et al. (2007) (https://doi.org/10.1016/j.icarus.2007.04.021). On 2D geometry, y axis works as polar axis for latitudinal variation. Unit: \si{\watt\per\meter\cubed}.
 ::::
 
 (parameters:Heating_20model/Adiabatic_20heating)=
@@ -285,7 +285,7 @@ If the function you are describing represents a vector-valued function with mult
 
 **Pattern:** [Selection constant|latitudinal variation ]
 
-**Documentation:** Choose how the time-averaged tidal strain rate is distributed. If &rsquo;constant&rsquo;, the tidal strain rate is fixed to &rsquo;Constant tidal strain rate&rsquo;. If &rsquo;latitudinal variation&rsquo;, &rsquo;Maximum tidal strain rate&rsquo; and &rsquo;Minimum tidal strain rate&rsquo; are used.
+**Documentation:** Choose how the time-averaged tidal strain rate is distributed. If &rsquo;constant&rsquo;, the tidal strain rate is fixed to &rsquo;Constant tidal strain rate&rsquo;. If &rsquo;latitudinal variation&rsquo;, &rsquo;Maximum tidal strain rate&rsquo; and &rsquo;Minimum tidal strain rate&rsquo; are used. On 2D geometry, y axis works as polar axis for latitudinal variation.
 ::::
 
 ::::{dropdown} __Parameter:__ {ref}`Elastic shear modulus<parameters:Heating_20model/Tidal_20heating/Elastic_20shear_20modulus>`

--- a/source/heating_model/tidal_heating.cc
+++ b/source/heating_model/tidal_heating.cc
@@ -28,6 +28,7 @@
 #include <aspect/geometry_model/ellipsoidal_chunk.h>
 #include <aspect/geometry_model/sphere.h>
 #include <aspect/geometry_model/spherical_shell.h>
+#include <aspect/gravity_model/radial_with_tidal_potential.h>
 
 namespace aspect
 {
@@ -44,9 +45,8 @@ namespace aspect
                        Plugins::plugin_type_matches<GeometryModel::TwoMergedChunks<dim>>(this->get_geometry_model()) ||
                        Plugins::plugin_type_matches<GeometryModel::EllipsoidalChunk<dim>>(this->get_geometry_model()) ||
                        Plugins::plugin_type_matches<GeometryModel::Sphere<dim>>(this->get_geometry_model()) ||
-                       Plugins::plugin_type_matches<GeometryModel::SphericalShell<dim>>(this->get_geometry_model())) &&
-                      dim==3,
-                      ExcMessage("Latitudinal variation of strain rate can only be used with 3-dimensional geometry models that "
+                       Plugins::plugin_type_matches<GeometryModel::SphericalShell<dim>>(this->get_geometry_model())),
+                      ExcMessage("Latitudinal variation of strain rate can only be used with models that "
                                  "have either a spherical or ellipsoidal natural coordinate system."));
         }
     }
@@ -79,8 +79,13 @@ namespace aspect
           if (strain_rate_distribution == latitudinal_variation)
             {
               const Point<dim> position = material_model_inputs.position[q];
-              const double theta = Utilities::Coordinates::cartesian_to_spherical_coordinates(position)[dim-1];
-              local_tidal_strain_rate = ( maximum_tidal_strain_rate - minimum_tidal_strain_rate ) / 2. * std::cos( theta * 2. ) + ( maximum_tidal_strain_rate + minimum_tidal_strain_rate ) / 2.;
+              double colatitude = Utilities::Coordinates::cartesian_to_spherical_coordinates(position)[dim-1];
+              if constexpr (dim == 2)
+                {
+                  colatitude = colatitude - numbers::PI / 2.;
+                }
+
+              local_tidal_strain_rate = ( maximum_tidal_strain_rate - minimum_tidal_strain_rate ) / 2. * std::cos( colatitude * 2. ) + ( maximum_tidal_strain_rate + minimum_tidal_strain_rate ) / 2.;
             }
           else if (strain_rate_distribution == constant)
             {
@@ -132,7 +137,8 @@ namespace aspect
                              Patterns::Selection("constant|latitudinal variation"),
                              "Choose how the time-averaged tidal strain rate is distributed. "
                              "If 'constant', the tidal strain rate is fixed to 'Constant tidal strain rate'. "
-                             "If 'latitudinal variation', 'Maximum tidal strain rate' and 'Minimum tidal strain rate' are used.");
+                             "If 'latitudinal variation', 'Maximum tidal strain rate' and 'Minimum tidal strain rate' are used. "
+                             "On 2D geometry, y axis works as polar axis for latitudinal variation. ");
           prm.declare_entry ("Maximum tidal strain rate", "2.81e-10",
                              Patterns::Double (0),
                              "Maximum time-averaged tidal strain rate by lunar diurnal tide at the poles. "
@@ -167,7 +173,12 @@ namespace aspect
           if (prm.get ("Custom distribution of tidal strain rate") == "constant")
             strain_rate_distribution = constant;
           else if (prm.get ("Custom distribution of tidal strain rate") == "latitudinal variation")
-            strain_rate_distribution = latitudinal_variation;
+            {
+              if (dim==2 && Plugins::plugin_type_matches<GravityModel::RadialWithTidalPotential<dim>>(this->get_gravity_model()))
+                throw ExcMessage ("On 2D, tidal heating and gravity with tidal potential have different lateral variations: latitudinal and longitudinal variation, respectively");
+
+              strain_rate_distribution = latitudinal_variation;
+            }
           else
             AssertThrow (false, ExcMessage ("Not a valid custom distribution of tidal strain rate."));
           maximum_tidal_strain_rate = prm.get_double ("Maximum tidal strain rate");
@@ -194,6 +205,7 @@ namespace aspect
                                   "Selecting 'latitudinal variation' from 'Custom distribution of tidal strain rate' allows simplified latitudinal variation "
                                   "with cosine function, 'Maximum tidal strain rate' and 'Minimum tidal strain rate. "
                                   "Latitudinal variation of tidal strain rate is shown in Fig.3 from Nimmo et al. (2007) (https://doi.org/10.1016/j.icarus.2007.04.021). "
+                                  "On 2D geometry, y axis works as polar axis for latitudinal variation. "
                                   "Unit: \\si{\\watt\\per\\meter\\cubed}.")
   }
 }

--- a/tests/tidal_heating_latitude_2D.prm
+++ b/tests/tidal_heating_latitude_2D.prm
@@ -1,0 +1,100 @@
+# This parameter file tests the latitudinally varying tidal heating plugin on 2D geometry
+# where the viscosity is constant.
+
+
+set Dimension                              = 2
+set Use years instead of seconds           = true
+set End time                               = 1e5
+
+set Output directory                       = tidal_heating_latitude_2D
+
+set Maximum first time step                    = 1e5
+set CFL number                                 = 0.8
+set Maximum time step                          = 1e5
+
+
+set Pressure normalization                 = surface
+set Surface pressure                       = 0
+
+
+subsection Geometry model
+  set Model name = spherical shell
+  subsection Spherical shell
+    set Outer radius = 1560800
+    set Inner radius = 1460800
+    set Opening angle = 360
+  end
+end
+
+
+subsection Initial temperature model
+  set Model name = function
+  subsection Function
+    set Coordinate system = spherical
+    set Variable names = r, phi,theta
+    set Function expression = 100
+  end
+end
+
+
+subsection Boundary velocity model
+  set Zero velocity boundary indicators = top, bottom
+end
+
+
+subsection Gravity model
+  set Model name = radial constant
+
+  subsection Radial constant
+    set Magnitude = 0 #1.3
+  end
+end
+
+
+subsection Material model
+  set Model name = simpler
+  subsection Simpler model
+    set Reference density = 917
+    set Reference specific heat = 2110
+    set Reference temperature = 100
+    set Thermal conductivity = 0 #1.93
+    set Thermal expansion coefficient = 0 #1.6e-4
+    set Viscosity = 1e14
+  end
+end
+
+
+subsection Heating model
+  set List of model names = tidal heating
+  subsection Tidal heating
+    set Tidal frequency = 2.048e-5
+    set Elastic shear modulus = 3.3e9
+    set Custom distribution of tidal strain rate = latitudinal variation
+    set Maximum tidal strain rate = 2.81e-10
+    set Minimum tidal strain rate = 1.67e-10
+  end
+end
+
+
+subsection Formulation
+  set Formulation = Boussinesq approximation
+end
+
+
+subsection Mesh refinement
+  set Initial global refinement                = 1
+  set Initial adaptive refinement              = 0
+  set Time steps between mesh refinement       = 0
+end
+
+
+subsection Postprocess
+  set List of postprocessors = velocity statistics, temperature statistics, visualization, basic statistics, \
+			       pressure statistics, material statistics, heating statistics
+
+  subsection Visualization
+    set Time between graphical output = 1e5
+    set Output format                 = vtu
+    set List of output variables      = material properties, strain rate, shear stress, stress, nonadiabatic pressure, heating
+  end
+end

--- a/tests/tidal_heating_latitude_2D/screen-output
+++ b/tests/tidal_heating_latitude_2D/screen-output
@@ -1,0 +1,32 @@
+
+Number of active cells: 48 (on 2 levels)
+Number of degrees of freedom: 792 (480+72+240)
+
+*** Timestep 0:  t=0 years, dt=0 years
+   Solving temperature system... 0 iterations.
+   Solving Stokes system (GMG)... 0+0 iterations.
+
+   Postprocessing:
+     RMS, max velocity:                                 0 m/year, 0 m/year
+     Temperature min/avg/max:                           100 K, 100 K, 100 K
+     Writing graphical output:                          output-tidal_heating_latitude_2D/solution/solution-00000
+     Pressure min/avg/max:                              0 Pa, 0 Pa, 0 Pa
+     Average density / Average viscosity / Total mass:  917 kg/m^3, 1e+14 Pa s, 8.705e+14 kg
+     Heating rate (average/total):                      8.156e-09 W/kg, 7.1e+06 W
+
+*** Timestep 1:  t=100000 years, dt=100000 years
+   Solving temperature system... 10 iterations.
+   Solving Stokes system (GMG)... 0+0 iterations.
+
+   Postprocessing:
+     RMS, max velocity:                                 0 m/year, 0 m/year
+     Temperature min/avg/max:                           106.6 K, 112.2 K, 118.6 K
+     Writing graphical output:                          output-tidal_heating_latitude_2D/solution/solution-00001
+     Pressure min/avg/max:                              0 Pa, 0 Pa, 0 Pa
+     Average density / Average viscosity / Total mass:  917 kg/m^3, 1e+14 Pa s, 8.705e+14 kg
+     Heating rate (average/total):                      8.156e-09 W/kg, 7.1e+06 W
+
+Termination requested by criterion: end time
+
+
+

--- a/tests/tidal_heating_latitude_2D/statistics
+++ b/tests/tidal_heating_latitude_2D/statistics
@@ -1,0 +1,26 @@
+# 1: Time step number
+# 2: Time (years)
+# 3: Time step size (years)
+# 4: Number of mesh cells
+# 5: Number of Stokes degrees of freedom
+# 6: Number of temperature degrees of freedom
+# 7: Iterations for temperature solver
+# 8: Iterations for Stokes solver
+# 9: Velocity iterations in Stokes preconditioner
+# 10: Schur complement iterations in Stokes preconditioner
+# 11: RMS velocity (m/year)
+# 12: Max. velocity (m/year)
+# 13: Minimal temperature (K)
+# 14: Average temperature (K)
+# 15: Maximal temperature (K)
+# 16: Visualization file name
+# 17: Minimal pressure (Pa)
+# 18: Average pressure (Pa)
+# 19: Maximal pressure (Pa)
+# 20: Average density (kg/m^3)
+# 21: Average viscosity (Pa s)
+# 22: Total mass (kg)
+# 23: Average tidal heating rate (W/kg)
+# 24: Total tidal heating rate (W)
+0 0.000000000000e+00 0.000000000000e+00 48 552 240  0 0 0 0 0.00000000e+00 0.00000000e+00 1.00000000e+02 9.99999999e+01 1.00000000e+02 output-tidal_heating_latitude_2D/solution/solution-00000 0.00000000e+00 0.00000000e+00 0.00000000e+00 9.17000000e+02 1.00000000e+14 8.70474754e+14 8.15637557e-09 7.09991902e+06 
+1 1.000000000000e+05 1.000000000000e+05 48 552 240 10 0 0 0 0.00000000e+00 0.00000000e+00 1.06567124e+02 1.12198595e+02 1.18600255e+02 output-tidal_heating_latitude_2D/solution/solution-00001 0.00000000e+00 0.00000000e+00 0.00000000e+00 9.17000000e+02 1.00000000e+14 8.70474754e+14 8.15637557e-09 7.09991902e+06 


### PR DESCRIPTION
Hi, I create a PR for the 2D implementation of latitudinally varying tidal heating.

Previously, I made it to only work for 3D. Now it works for 2D, and here are main points of change.
1) longitudinal variation has different pattern from latitudinal variation. Therefore, I only let latitudinal variation.
2) On 2D, there is no theta component. Therefore, phi is converted to theta on tidal_heating.cc.
    First, line 82 takes last component in the spherical coordinate vector as double colatitude, which is theta for 3D, phi for 2D.
    Then, if 2D, phi is converted as phi - pi/2 so it can be colatitude on line 85.
3) Because tidal heating has latitudinal variation, I blocked latitudinal varying tidal heating to work with radial_with_tidal_potential.cc, which has equatorial variation.
I will work on better expression of tidal heating variation soon and update!

Cheers,
Hyunseong