### PR TITLE
material_model/rheology/visco_plastic.cc typo correction

### DIFF
--- a/source/material_model/rheology/visco_plastic.cc
+++ b/source/material_model/rheology/visco_plastic.cc
@@ -356,7 +356,7 @@ namespace aspect
             }
 
 
-            // Step 1e: multiply the viscosity by a constant (default value is 1)
+            // Step 1f: multiply the viscosity by a constant (default value is 1)
             non_yielding_viscosity = constant_viscosity_prefactors.compute_viscosity(non_yielding_viscosity, j);
 
             // Step 2: calculate strain weakening factors for the cohesion, friction, and pre-yield viscosity


### PR DESCRIPTION
Hi,
I create a PR because I found a typo in material_model/rheology/visco_plastic.cc
Thera are two Step 1e on line 344 and 359.
Therefore, I corrected latter one to be 1f on line 359.
Thank you very much!

Cheers,
Hyunseong