### PR TITLE
Allowing DG fields for solid component in melt models in general

### DIFF
--- a/doc/modules/changes/20260730_stoner
+++ b/doc/modules/changes/20260730_stoner
@@ -1,0 +1,8 @@
+Changed: Models with melt transport can now use discontinuous elements for
+compositional fields, with two exceptions: the porosity field and fields
+that are advected with the melt velocity still require continuous elements.
+Compositional fields that are advected as finite element fields with the
+solid velocity now use the same discontinuous Galerkin (DG) face terms as
+models without melt transport.
+<br>
+(Ryan Stoner, 2026/07/30)

--- a/source/simulator/melt.cc
+++ b/source/simulator/melt.cc
@@ -1749,6 +1749,20 @@ namespace aspect
           assemblers.advection_system[i].push_back(
             std::make_unique<Assemblers::MeltAdvectionSystem<dim>> ());
 
+        // non-melt discontinuous compositional fields need the face terms of the DG formulation.
+        if (i>0
+            && this->get_parameters().use_discontinuous_composition_discretization[i-1])
+          {
+            assemblers.advection_system_on_boundary_face[i].push_back(
+              std::make_unique<aspect::Assemblers::AdvectionSystemBoundaryFace<dim>>());
+
+            assemblers.advection_system_on_interior_face[i].push_back(
+              std::make_unique<aspect::Assemblers::AdvectionSystemInteriorFace<dim>>());
+
+            assemblers.advection_system_assembler_on_face_properties[i].need_face_material_model_data = true;
+            assemblers.advection_system_assembler_on_face_properties[i].need_face_finite_element_evaluation = true;
+          }
+
         if (this->get_parameters().fixed_heat_flux_boundary_indicators.size() != 0)
           {
             assemblers.advection_system_on_boundary_face[i].push_back(
@@ -1844,12 +1858,31 @@ namespace aspect
   void
   MeltHandler<dim>::initialize () const
   {
-    // The additional terms in the temperature systems have not been ported
+    // The additional terms in the temperature system have not been ported
     // to the DG formulation:
-    AssertThrow(!this->get_parameters().use_discontinuous_temperature_discretization &&
-                !this->get_parameters().have_discontinuous_composition_discretization,
+    AssertThrow(!this->get_parameters().use_discontinuous_temperature_discretization,
                 ExcMessage("Using discontinuous elements for temperature "
-                           "or composition in models with melt transport is currently not implemented.") );
+                           "in models with melt transport is currently not implemented.") );
+
+    // In models with melt transport, the assemblers for compositional
+    // fields that are advected as finite element fields (except for porosity
+    // and melt-advected fields) can include discontinuous Galerkin face terms.
+    // Compositional fields that are not advected as finite element fields,
+    // for example fields tracked by particles, can also use discontinuous
+    // elements.
+    for (unsigned int c=0; c<this->introspection().n_compositional_fields; ++c)
+      {
+        const typename Parameters<dim>::AdvectionFieldMethod::Kind method =
+          this->get_parameters().compositional_field_methods[c];
+
+        if (this->get_parameters().use_discontinuous_composition_discretization[c])
+          AssertThrow(method != Parameters<dim>::AdvectionFieldMethod::fem_melt_field &&
+                      !this->is_porosity(AdvectionField::composition(c)),
+                      ExcMessage("Using discontinuous elements for the porosity field "
+                                 "or for compositional fields that are advected with the "
+                                 "melt velocity is currently not implemented in models "
+                                 "with melt transport.") );
+      }
     if (melt_parameters.use_discontinuous_p_c)
       AssertThrow(!this->model_has_prescribed_stokes_solution(),
                   ExcMessage("You can not use a discontinuous p_c in a model "

--- a/tests/rising_melt_blob_dg.cc
+++ b/tests/rising_melt_blob_dg.cc
@@ -1,0 +1,1 @@
+#include "rising_melt_blob.cc"

--- a/tests/rising_melt_blob_dg.prm
+++ b/tests/rising_melt_blob_dg.prm
@@ -1,0 +1,13 @@
+# Identical to rising_melt_blob.prm, except that discontinuous
+# elements are used for peridotite. This tests the melt formulation
+# for discontinuous Galerkin (DG) elements for compositions, with
+# the exception of melt-advected fields and porosity.
+
+include $ASPECT_SOURCE_DIR/tests/rising_melt_blob.prm
+
+set Output directory = output-rising_melt_blob_dg
+
+# The peridotite field is discontinuous, the porosity field is continuous.
+subsection Discretization
+  set Use discontinuous composition discretization = false, true
+end

--- a/tests/rising_melt_blob_dg/screen-output
+++ b/tests/rising_melt_blob_dg/screen-output
@@ -1,0 +1,274 @@
+
+Loading shared library <./librising_melt_blob_dg.debug.so>
+
+Number of active cells: 512 (on 5 levels)
+Number of degrees of freedom: 20,136 (4,290+2,097+4,290+561+2,145+2,145+4,608)
+
+*** Timestep 0:  t=0 years, dt=0 years
+   Solving temperature system... 0 iterations.
+   Solving porosity system ... 0 iterations.
+   Solving peridotite system ... 0 iterations.
+   Rebuilding Stokes preconditioner...
+   Solving Stokes system (AMG)... 21+0 iterations.
+   Solving fluid velocity system... 12 iterations.
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 1.63865e-16, 1.54902e-16, 1.47936e-16, 0.168632
+      Relative nonlinear residual (total system) after nonlinear iteration 1: 0.168632
+
+   Solving temperature system... 0 iterations.
+   Solving porosity system ... 0 iterations.
+   Solving peridotite system ... 0 iterations.
+   Rebuilding Stokes preconditioner...
+   Solving Stokes system (AMG)... 0+0 iterations.
+   Solving fluid velocity system... 12 iterations.
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 1.63865e-16, 1.54902e-16, 1.47936e-16, 9.91185e-08
+      Relative nonlinear residual (total system) after nonlinear iteration 2: 9.91185e-08
+
+
+   Postprocessing:
+     Compositions min/max/mass: 1.438e-28/0.2/1.257e+08 // 1.438e-28/0.2/1.257e+08
+     Writing graphical output:  output-rising_melt_blob_dg/solution/solution-00000
+
+*** Timestep 1:  t=3443.44 years, dt=3443.44 years
+   Solving temperature system... 7 iterations.
+   Solving porosity system ... 10 iterations.
+   Solving peridotite system ... 2 iterations.
+   Rebuilding Stokes preconditioner...
+   Solving Stokes system (AMG)... 18+0 iterations.
+   Solving fluid velocity system... 12 iterations.
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0.00023904, 0.0308629, 0.00100708, 0.0163796
+      Relative nonlinear residual (total system) after nonlinear iteration 1: 0.0308629
+
+   Solving temperature system... 5 iterations.
+   Solving porosity system ... 9 iterations.
+   Solving peridotite system ... 2 iterations.
+   Rebuilding Stokes preconditioner...
+   Solving Stokes system (AMG)... 13+0 iterations.
+   Solving fluid velocity system... 12 iterations.
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 7.90203e-07, 0.00209119, 0.000128734, 0.000678522
+      Relative nonlinear residual (total system) after nonlinear iteration 2: 0.00209119
+
+   Solving temperature system... 4 iterations.
+   Solving porosity system ... 8 iterations.
+   Solving peridotite system ... 2 iterations.
+   Rebuilding Stokes preconditioner...
+   Solving Stokes system (AMG)... 10+0 iterations.
+   Solving fluid velocity system... 12 iterations.
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 8.79547e-08, 0.000130772, 5.47093e-06, 2.60127e-05
+      Relative nonlinear residual (total system) after nonlinear iteration 3: 0.000130772
+
+   Solving temperature system... 3 iterations.
+   Solving porosity system ... 7 iterations.
+   Solving peridotite system ... 2 iterations.
+   Rebuilding Stokes preconditioner...
+   Solving Stokes system (AMG)... 6+0 iterations.
+   Solving fluid velocity system... 12 iterations.
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 5.30773e-09, 1.22726e-05, 4.85559e-07, 3.63104e-06
+      Relative nonlinear residual (total system) after nonlinear iteration 4: 1.22726e-05
+
+   Solving temperature system... 2 iterations.
+   Solving porosity system ... 6 iterations.
+   Solving peridotite system ... 1 iterations.
+   Rebuilding Stokes preconditioner...
+   Solving Stokes system (AMG)... 3+0 iterations.
+   Solving fluid velocity system... 12 iterations.
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 3.60532e-10, 9.10973e-07, 2.60634e-08, 2.35883e-07
+      Relative nonlinear residual (total system) after nonlinear iteration 5: 9.10973e-07
+
+
+   Postprocessing:
+     Compositions min/max/mass: -1.979e-06/0.1989/1.257e+08 // 1.425e-28/0.2/1.256e+08
+     Writing graphical output:  output-rising_melt_blob_dg/solution/solution-00001
+
+*** Timestep 2:  t=6797.35 years, dt=3353.91 years
+   Solving temperature system... 6 iterations.
+   Solving porosity system ... 9 iterations.
+   Solving peridotite system ... 2 iterations.
+   Rebuilding Stokes preconditioner...
+   Solving Stokes system (AMG)... 14+0 iterations.
+   Solving fluid velocity system... 12 iterations.
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 9.14339e-06, 0.00168946, 8.26207e-05, 0.00380948
+      Relative nonlinear residual (total system) after nonlinear iteration 1: 0.00380948
+
+   Solving temperature system... 4 iterations.
+   Solving porosity system ... 8 iterations.
+   Solving peridotite system ... 2 iterations.
+   Rebuilding Stokes preconditioner...
+   Solving Stokes system (AMG)... 9+0 iterations.
+   Solving fluid velocity system... 12 iterations.
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 2.76481e-08, 0.00011615, 4.89125e-06, 5.42261e-05
+      Relative nonlinear residual (total system) after nonlinear iteration 2: 0.00011615
+
+   Solving temperature system... 3 iterations.
+   Solving porosity system ... 6 iterations.
+   Solving peridotite system ... 1 iterations.
+   Rebuilding Stokes preconditioner...
+   Solving Stokes system (AMG)... 5+0 iterations.
+   Solving fluid velocity system... 12 iterations.
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 1.2992e-09, 5.02239e-06, 2.968e-07, 1.95455e-06
+      Relative nonlinear residual (total system) after nonlinear iteration 3: 5.02239e-06
+
+
+   Postprocessing:
+     Compositions min/max/mass: -4.497e-06/0.1981/1.257e+08 // 1.402e-28/0.2/1.256e+08
+     Writing graphical output:  output-rising_melt_blob_dg/solution/solution-00002
+
+*** Timestep 3:  t=10088.6 years, dt=3291.27 years
+   Solving temperature system... 6 iterations.
+   Solving porosity system ... 9 iterations.
+   Solving peridotite system ... 2 iterations.
+   Rebuilding Stokes preconditioner...
+   Solving Stokes system (AMG)... 14+0 iterations.
+   Solving fluid velocity system... 12 iterations.
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 3.40742e-06, 0.00154026, 0.000105443, 0.00368832
+      Relative nonlinear residual (total system) after nonlinear iteration 1: 0.00368832
+
+   Solving temperature system... 4 iterations.
+   Solving porosity system ... 8 iterations.
+   Solving peridotite system ... 2 iterations.
+   Rebuilding Stokes preconditioner...
+   Solving Stokes system (AMG)... 9+0 iterations.
+   Solving fluid velocity system... 12 iterations.
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 2.05135e-08, 0.000110216, 3.25345e-06, 5.04961e-05
+      Relative nonlinear residual (total system) after nonlinear iteration 2: 0.000110216
+
+   Solving temperature system... 2 iterations.
+   Solving porosity system ... 6 iterations.
+   Solving peridotite system ... 1 iterations.
+   Rebuilding Stokes preconditioner...
+   Solving Stokes system (AMG)... 5+0 iterations.
+   Solving fluid velocity system... 12 iterations.
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 4.29343e-10, 4.01228e-06, 1.89107e-07, 1.5746e-06
+      Relative nonlinear residual (total system) after nonlinear iteration 3: 4.01228e-06
+
+
+   Postprocessing:
+     Compositions min/max/mass: -8.79e-06/0.1974/1.257e+08 // 1.363e-28/0.2/1.256e+08
+     Writing graphical output:  output-rising_melt_blob_dg/solution/solution-00003
+
+*** Timestep 4:  t=13329.1 years, dt=3240.44 years
+   Solving temperature system... 6 iterations.
+   Solving porosity system ... 9 iterations.
+   Solving peridotite system ... 2 iterations.
+   Rebuilding Stokes preconditioner...
+   Solving Stokes system (AMG)... 15+0 iterations.
+   Solving fluid velocity system... 12 iterations.
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 1.50664e-06, 0.00170367, 0.000110283, 0.00356014
+      Relative nonlinear residual (total system) after nonlinear iteration 1: 0.00356014
+
+   Solving temperature system... 4 iterations.
+   Solving porosity system ... 8 iterations.
+   Solving peridotite system ... 2 iterations.
+   Rebuilding Stokes preconditioner...
+   Solving Stokes system (AMG)... 9+0 iterations.
+   Solving fluid velocity system... 12 iterations.
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 2.60544e-08, 0.000107363, 2.84985e-06, 4.73745e-05
+      Relative nonlinear residual (total system) after nonlinear iteration 2: 0.000107363
+
+   Solving temperature system... 2 iterations.
+   Solving porosity system ... 6 iterations.
+   Solving peridotite system ... 1 iterations.
+   Rebuilding Stokes preconditioner...
+   Solving Stokes system (AMG)... 3+0 iterations.
+   Solving fluid velocity system... 12 iterations.
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 2.98938e-10, 3.90932e-06, 1.59755e-07, 1.53678e-06
+      Relative nonlinear residual (total system) after nonlinear iteration 3: 3.90932e-06
+
+
+   Postprocessing:
+     Compositions min/max/mass: -1.414e-05/0.1965/1.257e+08 // 1.304e-28/0.2/1.255e+08
+     Writing graphical output:  output-rising_melt_blob_dg/solution/solution-00004
+
+*** Timestep 5:  t=16524.3 years, dt=3195.23 years
+   Solving temperature system... 5 iterations.
+   Solving porosity system ... 9 iterations.
+   Solving peridotite system ... 2 iterations.
+   Rebuilding Stokes preconditioner...
+   Solving Stokes system (AMG)... 14+0 iterations.
+   Solving fluid velocity system... 12 iterations.
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 1.05919e-06, 0.00174377, 0.000109236, 0.00347564
+      Relative nonlinear residual (total system) after nonlinear iteration 1: 0.00347564
+
+   Solving temperature system... 4 iterations.
+   Solving porosity system ... 8 iterations.
+   Solving peridotite system ... 2 iterations.
+   Rebuilding Stokes preconditioner...
+   Solving Stokes system (AMG)... 9+0 iterations.
+   Solving fluid velocity system... 12 iterations.
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 2.37825e-08, 0.000103659, 2.72889e-06, 4.50757e-05
+      Relative nonlinear residual (total system) after nonlinear iteration 2: 0.000103659
+
+   Solving temperature system... 2 iterations.
+   Solving porosity system ... 6 iterations.
+   Solving peridotite system ... 1 iterations.
+   Rebuilding Stokes preconditioner...
+   Solving Stokes system (AMG)... 3+0 iterations.
+   Solving fluid velocity system... 12 iterations.
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 3.48558e-10, 3.81149e-06, 1.49853e-07, 1.52581e-06
+      Relative nonlinear residual (total system) after nonlinear iteration 3: 3.81149e-06
+
+
+   Postprocessing:
+     Compositions min/max/mass: -1.828e-05/0.1955/1.257e+08 // 1.218e-28/0.2/1.255e+08
+     Writing graphical output:  output-rising_melt_blob_dg/solution/solution-00005
+
+*** Timestep 6:  t=19677.7 years, dt=3153.4 years
+   Solving temperature system... 5 iterations.
+   Solving porosity system ... 9 iterations.
+   Solving peridotite system ... 2 iterations.
+   Rebuilding Stokes preconditioner...
+   Solving Stokes system (AMG)... 15+0 iterations.
+   Solving fluid velocity system... 12 iterations.
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 9.79371e-07, 0.0017283, 0.000106162, 0.00342903
+      Relative nonlinear residual (total system) after nonlinear iteration 1: 0.00342903
+
+   Solving temperature system... 4 iterations.
+   Solving porosity system ... 8 iterations.
+   Solving peridotite system ... 2 iterations.
+   Rebuilding Stokes preconditioner...
+   Solving Stokes system (AMG)... 9+0 iterations.
+   Solving fluid velocity system... 12 iterations.
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 2.66336e-08, 9.97322e-05, 2.68218e-06, 4.36399e-05
+      Relative nonlinear residual (total system) after nonlinear iteration 2: 9.97322e-05
+
+   Solving temperature system... 2 iterations.
+   Solving porosity system ... 6 iterations.
+   Solving peridotite system ... 1 iterations.
+   Rebuilding Stokes preconditioner...
+   Solving Stokes system (AMG)... 3+0 iterations.
+   Solving fluid velocity system... 12 iterations.
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 3.68576e-10, 3.62054e-06, 1.41932e-07, 1.48129e-06
+      Relative nonlinear residual (total system) after nonlinear iteration 3: 3.62054e-06
+
+
+   Postprocessing:
+     Compositions min/max/mass: -2.465e-05/0.1943/1.257e+08 // 1.1e-28/0.2/1.254e+08
+     Writing graphical output:  output-rising_melt_blob_dg/solution/solution-00006
+
+*** Timestep 7:  t=20000 years, dt=322.314 years
+   Solving temperature system... 4 iterations.
+   Solving porosity system ... 8 iterations.
+   Solving peridotite system ... 1 iterations.
+   Rebuilding Stokes preconditioner...
+   Solving Stokes system (AMG)... 11+0 iterations.
+   Solving fluid velocity system... 12 iterations.
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 5.54556e-08, 0.000101891, 5.88042e-06, 0.000192532
+      Relative nonlinear residual (total system) after nonlinear iteration 1: 0.000192532
+
+   Solving temperature system... 2 iterations.
+   Solving porosity system ... 6 iterations.
+   Solving peridotite system ... 1 iterations.
+   Rebuilding Stokes preconditioner...
+   Solving Stokes system (AMG)... 3+0 iterations.
+   Solving fluid velocity system... 12 iterations.
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 2.00768e-10, 7.60782e-07, 2.23009e-08, 3.28868e-07
+      Relative nonlinear residual (total system) after nonlinear iteration 2: 7.60782e-07
+
+
+   Postprocessing:
+     Compositions min/max/mass: -2.565e-05/0.1942/1.257e+08 // 1.086e-28/0.2/1.254e+08
+     Writing graphical output:  output-rising_melt_blob_dg/solution/solution-00007
+
+Termination requested by criterion: end time
+
+
+

--- a/tests/rising_melt_blob_dg/statistics
+++ b/tests/rising_melt_blob_dg/statistics
@@ -1,0 +1,29 @@
+# 1: Time step number
+# 2: Time (years)
+# 3: Time step size (years)
+# 4: Number of mesh cells
+# 5: Number of Stokes degrees of freedom
+# 6: Number of temperature degrees of freedom
+# 7: Number of degrees of freedom for all compositions
+# 8: Number of nonlinear iterations
+# 9: Iterations for temperature solver
+# 10: Iterations for composition solver 1
+# 11: Iterations for composition solver 2
+# 12: Iterations for Stokes solver
+# 13: Velocity iterations in Stokes preconditioner
+# 14: Schur complement iterations in Stokes preconditioner
+# 15: Minimal value for composition porosity
+# 16: Maximal value for composition porosity
+# 17: Global mass for composition porosity
+# 18: Minimal value for composition peridotite
+# 19: Maximal value for composition peridotite
+# 20: Global mass for composition peridotite
+# 21: Visualization file name
+0 0.000000000000e+00 0.000000000000e+00 512 4851 2145 4290 2  0  0 0 21 21  761  1.43755635e-28 2.00000000e-01 1.25663632e+08 1.43755635e-28 2.00000000e-01 1.25663632e+08 output-rising_melt_blob_dg/solution/solution-00000 
+1 3.443438389652e+03 3.443438389652e+03 512 4851 2145 4290 5 21 40 9 50 50 1867 -1.97933612e-06 1.98851278e-01 1.25663395e+08 1.42462296e-28 2.00007550e-01 1.25646616e+08 output-rising_melt_blob_dg/solution/solution-00001 
+2 6.797350800059e+03 3.353912410407e+03 512 4851 2145 4290 3 13 23 5 28 28 1011 -4.49718871e-06 1.98115810e-01 1.25663026e+08 1.40175013e-28 2.00013038e-01 1.25619298e+08 output-rising_melt_blob_dg/solution/solution-00002 
+3 1.008861938532e+04 3.291268585258e+03 512 4851 2145 4290 3 12 23 5 28 28 1067 -8.79000808e-06 1.97374878e-01 1.25662496e+08 1.36313613e-28 2.00016042e-01 1.25578744e+08 output-rising_melt_blob_dg/solution/solution-00003 
+4 1.332906008144e+04 3.240440696120e+03 512 4851 2145 4290 3 12 23 5 27 27 1111 -1.41434640e-05 1.96511083e-01 1.25661783e+08 1.30373400e-28 2.00016533e-01 1.25524491e+08 output-rising_melt_blob_dg/solution/solution-00004 
+5 1.652429023811e+04 3.195230156669e+03 512 4851 2145 4290 3 11 23 5 26 26 1064 -1.82772863e-05 1.95497467e-01 1.25660906e+08 1.21812637e-28 2.00014618e-01 1.25456884e+08 output-rising_melt_blob_dg/solution/solution-00005 
+6 1.967768576668e+04 3.153395528572e+03 512 4851 2145 4290 3 11 23 5 27 27 1096 -2.46450869e-05 1.94330365e-01 1.25659840e+08 1.10013074e-28 2.00010447e-01 1.25376535e+08 output-rising_melt_blob_dg/solution/solution-00006 
+7 2.000000000000e+04 3.223142333216e+02 512 4851 2145 4290 2  6 14 2 14 14  562 -2.56516956e-05 1.94204603e-01 1.25659720e+08 1.08611879e-28 2.00009894e-01 1.25367562e+08 output-rising_melt_blob_dg/solution/solution-00007 


### PR DESCRIPTION
This PR is spun off of #7066 and #7219 and allows DG fields to be used for solid components in melt models even when they are not on particles.

This loosens the assert to only disallow porosity, temperature, and any melt-advected fields.

The face terms are the same as in models without melt transport, registered in `MeltHandler::set_assemblers()` analogously to `Simulator::set_advection_assemblers()`. The new test `rising_melt_blob_dg` is identical to `rising_melt_blob` except that the peridotite field is discontinuous. Without the face terms, a DG field in a melt model assembles only cell terms: it cannot be advected across cell boundaries and freezes in place while the flow moves, without any solver warning.

@tjhei @naliboff 
### For all pull requests:

* [x] I have followed the [instructions for indenting my code](../blob/main/CONTRIBUTING.md#making-aspect-better).
* I followed the [AI Policy](../blob/main/CONTRIBUTING.md#policy-on-usage-of-ai):
  - [x] Significant parts of this PR were written by AI (please add a sentence below).
  - [] AI has not been used in significant ways.

*If yes, please describe your usage of AI models in the creation of this pull request*

AI was used to help generate the first draft of the .prm and .cc changes. All changes were checked and edited. 

### For new features/models or changes of existing features:

* [x] I have tested my new feature locally to ensure it is correct.
* [x] I have [created a testcase](https://aspect-documentation.readthedocs.io/en/latest/user/extending/testing/writing-tests.html) for the new feature/benchmark in the [tests/](../blob/main/tests/) directory.
* [x] I have added a changelog entry in the [doc/modules/changes](../blob/main/doc/modules/changes) directory that will inform other users of my change.
