### PR TITLE
Fix post-performance-results workflow

### DIFF
--- a/.github/workflows/post_performance_results.yml
+++ b/.github/workflows/post_performance_results.yml
@@ -21,10 +21,10 @@ jobs:
       ${{
         github.event.workflow_run.conclusion == 'success'
       }}
-  steps:
-    - name: Download artifacts
-      uses: actions/github-script@v8
-      with:
+    steps:
+      - name: Download artifacts
+        uses: actions/github-script@v8
+        with:
           script: |
             const fs = require('fs');
             const path = require('path');
@@ -64,8 +64,8 @@ jobs:
               core.info(`Saved ${filePath}`);
             }
 
-    - name: Unzip artifacts
-      run: |
+      - name: Unzip artifacts
+        run: |
           set -e
           for i in $(seq 1 8); do
             f="performance_${i}_results.zip"
@@ -76,11 +76,11 @@ jobs:
             fi
           done
 
-    - name: Retrieve performance benchmark 1
-      id: retrieve_performance_1
-      env:
-        benchmark_number: 1
-      run: |
+      - name: Retrieve performance benchmark 1
+        id: retrieve_performance_1
+        env:
+          benchmark_number: 1
+        run: |
           set -e
           file="$GITHUB_WORKSPACE/performance_1_results/analyze_1.log"
           cat "$file"
@@ -96,23 +96,23 @@ jobs:
             echo "wall_time_1_CI_low=$(echo "$line" | sed 's/\[/ /g; s/\]/ /g' | awk '{print $8}')"
             echo "wall_time_1_CI_high=$(echo "$line" | sed 's/\[/ /g; s/\]/ /g' | awk '{print $10}')"
           } >> "$GITHUB_OUTPUT"
-    - name: Find Comment
-      id: find_comment
-      continue-on-error: true
-      uses: peter-evans/find-comment@v4
-      with:
-        token: ${{ secrets.GITHUB_TOKEN }}
-        issue-number: ${{ github.event.number }}
-        comment-author: 'github-actions[bot]'
+      - name: Find Comment
+        id: find_comment
+        continue-on-error: true
+        uses: peter-evans/find-comment@v4
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          issue-number: ${{ github.event.workflow_run.pull_requests[0].number }}
+          comment-author: 'github-actions[bot]'
 
-    - name: Create or update comment
-      uses: peter-evans/create-or-update-comment@v5
-      with:
-        token: ${{ secrets.GITHUB_TOKEN }}
-        comment-id: ${{ steps.find_comment.outputs.comment-id }}
-        issue-number: ${{ github.event.number }} 
-        body: |
+      - name: Create or update comment
+        uses: peter-evans/create-or-update-comment@v5
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          comment-id: ${{ steps.find_comment.outputs.comment-id }}
+          issue-number: ${{ github.event.workflow_run.pull_requests[0].number }}
+          body: |
             | Benchmark | Main | Feature | Difference (99.9% CI) |
             | --- | --- | --- | --- |
             | Continental extension | ${{ steps.retrieve_performance_1.outputs.wall_time_1_main_mean }} ± ${{ steps.retrieve_performance_1.outputs.wall_time_1_main_std_dev }} (s=${{ steps.retrieve_performance_1.outputs.wall_time_1_main_samples }})| ${{ steps.retrieve_performance_1.outputs.wall_time_1_feature_mean }} ± ${{ steps.retrieve_performance_1.outputs.wall_time_1_feature_std_dev }} (s=${{ steps.retrieve_performance_1.outputs.wall_time_1_feature_samples }})| ${{ steps.retrieve_performance_1.outputs.wall_time_1_CI_low }} .. ${{ steps.retrieve_performance_1.outputs.wall_time_1_CI_high }} |
-        edit-mode: replace
+          edit-mode: replace


### PR DESCRIPTION
FYI @MFraters 

followup to #7247

This is codex GPT fixing the file:
```
• Fixed .github/workflows/post_performance_results.yml:

  - Nested all steps under the upload job.
  - Replaced invalid github.event.number with the triggering PR number from workflow_run.pull_requests[0].number.
  - Corrected the related YAML indentation.

  Verified it parses as YAML and has five steps under jobs.upload; git diff --check passes. The workflow file is staged.
```