### PR TITLE
Fix subsection for AsciiDataLayered

### DIFF
--- a/doc/modules/changes/20260801_glerum
+++ b/doc/modules/changes/20260801_glerum
@@ -1,0 +1,8 @@
+ Fixed: The Initial Composition and Initial
+ Temperature plugins ``Ascii data layered'' now
+ use their own subsection header ``Ascii data
+ layered'' instead of ``Ascii data model''.
+ Therefore the plugins now show up in the manual
+ with their own subsection.
+ <br>
+ (Anne Glerum 2026/08/01)

--- a/doc/sphinx/parameters/Initial_20composition_20model.md
+++ b/doc/sphinx/parameters/Initial_20composition_20model.md
@@ -81,6 +81,53 @@ The format of valid entries for this parameter is that of a map given as &ldquo;
 When &ldquo;composition is specified, the initial model is treated as a standard composition field with bounds between 0 and 1 assumed, The initial fluid fractions are then based on an iterated midpoint quadrature. Resultant volume fractions outside of the bounds will be coerced to the nearest valid value (ie 0 or 1). If &ldquo;level set&ldquo; is specified, the initial data will be assumed to be in the form of a signed distance level set function (i.e. a function which is positive when in the fluid, negative outside, and zero on the interface and the magnitude is always the distance to the interface so the gradient is one everywhere).
 ::::
 
+(parameters:Initial_20composition_20model/Ascii_20data_20layered)=
+## **Subsection:** Initial composition model / Ascii data layered
+::::{dropdown} __Parameter:__ {ref}`Data directory<parameters:Initial_20composition_20model/Ascii_20data_20layered/Data_20directory>`
+:name: parameters:Initial_20composition_20model/Ascii_20data_20layered/Data_20directory
+**Default value:** $ASPECT_SOURCE_DIR/data/initial-composition/ascii-data/test/
+
+**Pattern:** [DirectoryName]
+
+**Documentation:** The name of a directory that contains the model data. This path may either be absolute (if starting with a &lsquo;/&rsquo;) or relative to the current directory. The path may also include the special text &lsquo;$ASPECT_SOURCE_DIR&rsquo; which will be interpreted as the path in which the ASPECT source files were located when ASPECT was compiled. This interpretation allows, for example, to reference files located in the &lsquo;data/&rsquo; subdirectory of ASPECT. A trailing slash at the end of the directory path is optional; the plugin will automatically append a &rsquo;/&rsquo; when the parameters are parsed if it is missing.
+::::
+
+::::{dropdown} __Parameter:__ {ref}`Data file name<parameters:Initial_20composition_20model/Ascii_20data_20layered/Data_20file_20name>`
+:name: parameters:Initial_20composition_20model/Ascii_20data_20layered/Data_20file_20name
+**Default value:** initial_composition_top_mantle_box_3d.txt
+
+**Pattern:** [Anything]
+
+**Documentation:** The file name of the model data.
+::::
+
+::::{dropdown} __Parameter:__ {ref}`Data file names<parameters:Initial_20composition_20model/Ascii_20data_20layered/Data_20file_20names>`
+:name: parameters:Initial_20composition_20model/Ascii_20data_20layered/Data_20file_20names
+**Default value:** initial_composition_top_mantle_box_3d.txt
+
+**Pattern:** [List of <[Anything]> of length 0...4294967295 (inclusive)]
+
+**Documentation:** The file names of the model data (comma separated).
+::::
+
+::::{dropdown} __Parameter:__ {ref}`Interpolation scheme<parameters:Initial_20composition_20model/Ascii_20data_20layered/Interpolation_20scheme>`
+:name: parameters:Initial_20composition_20model/Ascii_20data_20layered/Interpolation_20scheme
+**Default value:** linear
+
+**Pattern:** [Selection piecewise constant|linear ]
+
+**Documentation:** Method to interpolate between layer boundaries. Select from piecewise constant or linear. Piecewise constant takes the value from the nearest layer boundary above the data point. The linear option interpolates linearly between layer boundaries. Above and below the domain given by the layer boundaries, the values aregiven by the top and bottom layer boundary.
+::::
+
+::::{dropdown} __Parameter:__ {ref}`Scale factor<parameters:Initial_20composition_20model/Ascii_20data_20layered/Scale_20factor>`
+:name: parameters:Initial_20composition_20model/Ascii_20data_20layered/Scale_20factor
+**Default value:** 1.
+
+**Pattern:** [Double -MAX_DOUBLE...MAX_DOUBLE (inclusive)]
+
+**Documentation:** Scalar factor, which is applied to the model data. You might want to use this to scale the input to a reference model. Another way to use this factor is to convert units of the input files. For instance, if you provide velocities in cm/yr set this factor to 0.01.
+::::
+
 (parameters:Initial_20composition_20model/Ascii_20data_20model)=
 ## **Subsection:** Initial composition model / Ascii data model
 ::::{dropdown} __Parameter:__ {ref}`Data directory<parameters:Initial_20composition_20model/Ascii_20data_20model/Data_20directory>`
@@ -94,20 +141,11 @@ When &ldquo;composition is specified, the initial model is treated as a standard
 
 ::::{dropdown} __Parameter:__ {ref}`Data file name<parameters:Initial_20composition_20model/Ascii_20data_20model/Data_20file_20name>`
 :name: parameters:Initial_20composition_20model/Ascii_20data_20model/Data_20file_20name
-**Default value:** initial_composition_top_mantle_box_3d.txt
+**Default value:** box_2d.txt
 
 **Pattern:** [Anything]
 
 **Documentation:** The file name of the model data.
-::::
-
-::::{dropdown} __Parameter:__ {ref}`Data file names<parameters:Initial_20composition_20model/Ascii_20data_20model/Data_20file_20names>`
-:name: parameters:Initial_20composition_20model/Ascii_20data_20model/Data_20file_20names
-**Default value:** initial_composition_top_mantle_box_3d.txt
-
-**Pattern:** [List of <[Anything]> of length 0...4294967295 (inclusive)]
-
-**Documentation:** The file names of the model data (comma separated).
 ::::
 
 ::::{dropdown} __Parameter:__ {ref}`First point on slice<parameters:Initial_20composition_20model/Ascii_20data_20model/First_20point_20on_20slice>`
@@ -117,15 +155,6 @@ When &ldquo;composition is specified, the initial model is treated as a standard
 **Pattern:** [Anything]
 
 **Documentation:** Point that determines the plane in which the 2d slice lies in. This variable is only used if &rsquo;Slice dataset in 2d plane&rsquo; is true. The slice will go through this point, the point defined by the parameter &rsquo;Second point on slice&rsquo;, and the center of the model domain. After the rotation, this first point will lie along the (0,1,0) axis of the coordinate system. The coordinates of the point have to be given in Cartesian coordinates.
-::::
-
-::::{dropdown} __Parameter:__ {ref}`Interpolation scheme<parameters:Initial_20composition_20model/Ascii_20data_20model/Interpolation_20scheme>`
-:name: parameters:Initial_20composition_20model/Ascii_20data_20model/Interpolation_20scheme
-**Default value:** linear
-
-**Pattern:** [Selection piecewise constant|linear ]
-
-**Documentation:** Method to interpolate between layer boundaries. Select from piecewise constant or linear. Piecewise constant takes the value from the nearest layer boundary above the data point. The linear option interpolates linearly between layer boundaries. Above and below the domain given by the layer boundaries, the values aregiven by the top and bottom layer boundary.
 ::::
 
 ::::{dropdown} __Parameter:__ {ref}`Scale factor<parameters:Initial_20composition_20model/Ascii_20data_20model/Scale_20factor>`

--- a/doc/sphinx/parameters/Initial_20temperature_20model.md
+++ b/doc/sphinx/parameters/Initial_20temperature_20model.md
@@ -377,6 +377,53 @@ If the function you are describing represents a vector-valued function with mult
 **Documentation:** The value of the surface temperature. Units: $\text{K}$.
 ::::
 
+(parameters:Initial_20temperature_20model/Ascii_20data_20layered)=
+## **Subsection:** Initial temperature model / Ascii data layered
+::::{dropdown} __Parameter:__ {ref}`Data directory<parameters:Initial_20temperature_20model/Ascii_20data_20layered/Data_20directory>`
+:name: parameters:Initial_20temperature_20model/Ascii_20data_20layered/Data_20directory
+**Default value:** $ASPECT_SOURCE_DIR/data/initial-temperature/ascii-data/test/
+
+**Pattern:** [DirectoryName]
+
+**Documentation:** The name of a directory that contains the model data. This path may either be absolute (if starting with a &lsquo;/&rsquo;) or relative to the current directory. The path may also include the special text &lsquo;$ASPECT_SOURCE_DIR&rsquo; which will be interpreted as the path in which the ASPECT source files were located when ASPECT was compiled. This interpretation allows, for example, to reference files located in the &lsquo;data/&rsquo; subdirectory of ASPECT. A trailing slash at the end of the directory path is optional; the plugin will automatically append a &rsquo;/&rsquo; when the parameters are parsed if it is missing.
+::::
+
+::::{dropdown} __Parameter:__ {ref}`Data file name<parameters:Initial_20temperature_20model/Ascii_20data_20layered/Data_20file_20name>`
+:name: parameters:Initial_20temperature_20model/Ascii_20data_20layered/Data_20file_20name
+**Default value:** initial_isotherm_500K_box_3d.txt
+
+**Pattern:** [Anything]
+
+**Documentation:** The file name of the model data.
+::::
+
+::::{dropdown} __Parameter:__ {ref}`Data file names<parameters:Initial_20temperature_20model/Ascii_20data_20layered/Data_20file_20names>`
+:name: parameters:Initial_20temperature_20model/Ascii_20data_20layered/Data_20file_20names
+**Default value:** initial_isotherm_500K_box_3d.txt
+
+**Pattern:** [List of <[Anything]> of length 0...4294967295 (inclusive)]
+
+**Documentation:** The file names of the model data (comma separated).
+::::
+
+::::{dropdown} __Parameter:__ {ref}`Interpolation scheme<parameters:Initial_20temperature_20model/Ascii_20data_20layered/Interpolation_20scheme>`
+:name: parameters:Initial_20temperature_20model/Ascii_20data_20layered/Interpolation_20scheme
+**Default value:** linear
+
+**Pattern:** [Selection piecewise constant|linear ]
+
+**Documentation:** Method to interpolate between layer boundaries. Select from piecewise constant or linear. Piecewise constant takes the value from the nearest layer boundary above the data point. The linear option interpolates linearly between layer boundaries. Above and below the domain given by the layer boundaries, the values aregiven by the top and bottom layer boundary.
+::::
+
+::::{dropdown} __Parameter:__ {ref}`Scale factor<parameters:Initial_20temperature_20model/Ascii_20data_20layered/Scale_20factor>`
+:name: parameters:Initial_20temperature_20model/Ascii_20data_20layered/Scale_20factor
+**Default value:** 1.
+
+**Pattern:** [Double -MAX_DOUBLE...MAX_DOUBLE (inclusive)]
+
+**Documentation:** Scalar factor, which is applied to the model data. You might want to use this to scale the input to a reference model. Another way to use this factor is to convert units of the input files. For instance, if you provide velocities in cm/yr set this factor to 0.01.
+::::
+
 (parameters:Initial_20temperature_20model/Ascii_20data_20model)=
 ## **Subsection:** Initial temperature model / Ascii data model
 ::::{dropdown} __Parameter:__ {ref}`Data directory<parameters:Initial_20temperature_20model/Ascii_20data_20model/Data_20directory>`
@@ -390,20 +437,11 @@ If the function you are describing represents a vector-valued function with mult
 
 ::::{dropdown} __Parameter:__ {ref}`Data file name<parameters:Initial_20temperature_20model/Ascii_20data_20model/Data_20file_20name>`
 :name: parameters:Initial_20temperature_20model/Ascii_20data_20model/Data_20file_20name
-**Default value:** initial_isotherm_500K_box_3d.txt
+**Default value:** box_2d.txt
 
 **Pattern:** [Anything]
 
 **Documentation:** The file name of the model data.
-::::
-
-::::{dropdown} __Parameter:__ {ref}`Data file names<parameters:Initial_20temperature_20model/Ascii_20data_20model/Data_20file_20names>`
-:name: parameters:Initial_20temperature_20model/Ascii_20data_20model/Data_20file_20names
-**Default value:** initial_isotherm_500K_box_3d.txt
-
-**Pattern:** [List of <[Anything]> of length 0...4294967295 (inclusive)]
-
-**Documentation:** The file names of the model data (comma separated).
 ::::
 
 ::::{dropdown} __Parameter:__ {ref}`First point on slice<parameters:Initial_20temperature_20model/Ascii_20data_20model/First_20point_20on_20slice>`
@@ -413,15 +451,6 @@ If the function you are describing represents a vector-valued function with mult
 **Pattern:** [Anything]
 
 **Documentation:** Point that determines the plane in which the 2d slice lies in. This variable is only used if &rsquo;Slice dataset in 2d plane&rsquo; is true. The slice will go through this point, the point defined by the parameter &rsquo;Second point on slice&rsquo;, and the center of the model domain. After the rotation, this first point will lie along the (0,1,0) axis of the coordinate system. The coordinates of the point have to be given in Cartesian coordinates.
-::::
-
-::::{dropdown} __Parameter:__ {ref}`Interpolation scheme<parameters:Initial_20temperature_20model/Ascii_20data_20model/Interpolation_20scheme>`
-:name: parameters:Initial_20temperature_20model/Ascii_20data_20model/Interpolation_20scheme
-**Default value:** linear
-
-**Pattern:** [Selection piecewise constant|linear ]
-
-**Documentation:** Method to interpolate between layer boundaries. Select from piecewise constant or linear. Piecewise constant takes the value from the nearest layer boundary above the data point. The linear option interpolates linearly between layer boundaries. Above and below the domain given by the layer boundaries, the values aregiven by the top and bottom layer boundary.
 ::::
 
 ::::{dropdown} __Parameter:__ {ref}`Scale factor<parameters:Initial_20temperature_20model/Ascii_20data_20model/Scale_20factor>`

--- a/source/initial_composition/ascii_data_layered.cc
+++ b/source/initial_composition/ascii_data_layered.cc
@@ -61,7 +61,8 @@ namespace aspect
       {
         Utilities::AsciiDataLayered<dim>::declare_parameters(prm,
                                                              "$ASPECT_SOURCE_DIR/data/initial-composition/ascii-data/test/",
-                                                             "initial_composition_top_mantle_box_3d.txt");
+                                                             "initial_composition_top_mantle_box_3d.txt",
+                                                             "Ascii data layered");
       }
       prm.leave_subsection();
     }
@@ -73,7 +74,8 @@ namespace aspect
     {
       prm.enter_subsection("Initial composition model");
       {
-        Utilities::AsciiDataLayered<dim>::parse_parameters(prm);
+        Utilities::AsciiDataLayered<dim>::parse_parameters(prm,
+                                                           "Ascii data layered");
       }
       prm.leave_subsection();
     }

--- a/source/initial_temperature/ascii_data_layered.cc
+++ b/source/initial_temperature/ascii_data_layered.cc
@@ -63,7 +63,8 @@ namespace aspect
       {
         Utilities::AsciiDataLayered<dim>::declare_parameters(prm,
                                                              "$ASPECT_SOURCE_DIR/data/initial-temperature/ascii-data/test/",
-                                                             "initial_isotherm_500K_box_3d.txt");
+                                                             "initial_isotherm_500K_box_3d.txt",
+                                                             "Ascii data layered");
       }
       prm.leave_subsection();
     }
@@ -75,7 +76,8 @@ namespace aspect
     {
       prm.enter_subsection ("Initial temperature model");
       {
-        Utilities::AsciiDataLayered<dim>::parse_parameters(prm);
+        Utilities::AsciiDataLayered<dim>::parse_parameters(prm,
+                                                           "Ascii data layered");
       }
       prm.leave_subsection();
     }

--- a/tests/ascii_data_layered_initial_composition_2d_box.prm
+++ b/tests/ascii_data_layered_initial_composition_2d_box.prm
@@ -33,7 +33,7 @@ end
 subsection Initial composition model
   set Model name = ascii data layered
 
-  subsection Ascii data model
+  subsection Ascii data layered
     set Data directory        = $ASPECT_SOURCE_DIR/data/initial-composition/ascii-data/test/
     set Data file names       = initial_composition_top_mantle_box_2d.txt, initial_composition_top_crust_box_2d.txt
     set Interpolation scheme  = piecewise constant

--- a/tests/ascii_data_layered_initial_temperature_2d_box.prm
+++ b/tests/ascii_data_layered_initial_temperature_2d_box.prm
@@ -21,7 +21,7 @@ end
 subsection Initial temperature model
   set Model name = ascii data layered
 
-  subsection Ascii data model
+  subsection Ascii data layered
     set Data directory        = $ASPECT_SOURCE_DIR/data/initial-temperature/ascii-data/test/
     set Data file names       = initial_isotherm_1000K_box_2d.txt, initial_isotherm_500K_box_2d.txt
     set Interpolation scheme  = linear

--- a/tests/ascii_data_layered_initial_temperature_2d_chunk.prm
+++ b/tests/ascii_data_layered_initial_temperature_2d_chunk.prm
@@ -23,7 +23,7 @@ end
 subsection Initial temperature model
   set Model name = ascii data layered
 
-  subsection Ascii data model
+  subsection Ascii data layered
     set Data directory        = $ASPECT_SOURCE_DIR/data/initial-temperature/ascii-data/test/
     set Data file names       = initial_isotherm_1000K_chunk_2d.txt, initial_isotherm_500K_chunk_2d.txt
     set Interpolation scheme  = linear

--- a/tests/ascii_data_layered_initial_temperature_3d_box.prm
+++ b/tests/ascii_data_layered_initial_temperature_3d_box.prm
@@ -23,7 +23,7 @@ end
 subsection Initial temperature model
   set Model name = ascii data layered
 
-  subsection Ascii data model
+  subsection Ascii data layered
     set Data directory        = $ASPECT_SOURCE_DIR/data/initial-temperature/ascii-data/test/
     set Data file names       = initial_isotherm_1000K_box_3d.txt, initial_isotherm_500K_box_3d.txt
     set Interpolation scheme  = linear

--- a/tests/ascii_data_layered_initial_temperature_3d_chunk.prm
+++ b/tests/ascii_data_layered_initial_temperature_3d_chunk.prm
@@ -30,7 +30,7 @@ end
 subsection Initial temperature model
   set Model name = ascii data layered
 
-  subsection Ascii data model
+  subsection Ascii data layered
     set Data directory        = $ASPECT_SOURCE_DIR/data/initial-temperature/ascii-data/test/
     set Data file names       = initial_isotherm_1000K_chunk_3d.txt, initial_isotherm_500K_chunk_3d.txt
     set Interpolation scheme  = linear

--- a/tests/ascii_data_layered_initial_temperature_piecewise_constant_3d_box.prm
+++ b/tests/ascii_data_layered_initial_temperature_piecewise_constant_3d_box.prm
@@ -22,7 +22,7 @@ end
 subsection Initial temperature model
   set Model name = ascii data layered
 
-  subsection Ascii data model
+  subsection Ascii data layered
     set Data directory        = $ASPECT_SOURCE_DIR/data/initial-temperature/ascii-data/test/
     set Data file names       = initial_isotherm_1000K_box_3d.txt, initial_isotherm_500K_box_3d.txt
     set Interpolation scheme  = piecewise constant


### PR DESCRIPTION
At the moment, the AsciiDataLayered plugins use the default subsection heading of AsciiDataBase, which is `Ascii data model`. This interferes with the same subsection heading for AsciiData plugins. Therefore `ascii data layered` shows up in the manual as an option for Initial temperature and composition, but there is no corresponding subsection in the manual that prescribes the AsciiDataLayered parameters.

This PR sets the subsection name to `Ascii data layered`, which leads to the inclusion of the corresponding plugins in the manual.

### For all pull requests:

* [x] I have followed the [instructions for indenting my code](../blob/main/CONTRIBUTING.md#making-aspect-better).
* I followed the [AI Policy](../blob/main/CONTRIBUTING.md#policy-on-usage-of-ai):
  - [ ] Significant parts of this PR were written by AI (please add a sentence below).
  - [ ] AI has not been used in significant ways.

*If yes, please describe your usage of AI models in the creation of this pull request*

### For new features/models or changes of existing features:

* [x] I have tested my new feature locally to ensure it is correct.
* [ ] I have [created a testcase](https://aspect-documentation.readthedocs.io/en/latest/user/extending/testing/writing-tests.html) for the new feature/benchmark in the [tests/](../blob/main/tests/) directory.
* [ ] I have added a changelog entry in the [doc/modules/changes](../blob/main/doc/modules/changes) directory that will inform other users of my change.
