### PR TITLE
[WIP] Reduce allocations in aspect

### DIFF
--- a/include/aspect/heating_model/compositional_heating.h
+++ b/include/aspect/heating_model/compositional_heating.h
@@ -93,6 +93,9 @@ namespace aspect
          * production computation.
          */
         bool use_background_field_for_heat_production_averaging;
+
+        Utilities::ScratchSpace<std::vector<double>> volume_fractions_space;
+
     };
   }
 }

--- a/include/aspect/material_model/rheology/visco_plastic.h
+++ b/include/aspect/material_model/rheology/visco_plastic.h
@@ -21,6 +21,7 @@
 #ifndef _aspect_material_model_rheology_visco_plastic_h
 #define _aspect_material_model_rheology_visco_plastic_h
 
+#include "aspect/utilities.h"
 #include <aspect/global.h>
 #include <aspect/material_model/interface.h>
 #include <aspect/material_model/utilities.h>
@@ -205,6 +206,23 @@ namespace aspect
           calculate_isostrain_viscosities ( const MaterialModel::MaterialModelInputs<dim> &in,
                                             const unsigned int i,
                                             const std::vector<double> &volume_fractions,
+                                            const std::vector<double> &phase_function_values = std::vector<double>(),
+                                            const std::vector<unsigned int> &n_phase_transitions_per_composition =
+                                              std::vector<unsigned int>()) const;
+
+          /**
+           * This function calculates viscosities assuming that all the compositional fields
+           * experience the same strain rate (isostrain).
+           * If @p n_phase_transitions_per_composition points to a vector of
+           * unsigned integers this is considered the number of phase transitions
+           * for each compositional field and viscosity will be first computed on
+           * each phase and then averaged for each compositional field.
+           */
+          void
+          calculate_isostrain_viscosities ( const MaterialModel::MaterialModelInputs<dim> &in,
+                                            const unsigned int i,
+                                            const std::vector<double> &volume_fractions,
+                                            IsostrainViscosities &output_parameters,
                                             const std::vector<double> &phase_function_values = std::vector<double>(),
                                             const std::vector<unsigned int> &n_phase_transitions_per_composition =
                                               std::vector<unsigned int>()) const;
@@ -457,6 +475,7 @@ namespace aspect
            */
           Rheology::DruckerPrager<dim> drucker_prager_plasticity;
 
+          aspect::Utilities::ScratchSpace<IsostrainViscosities> isostrain_viscosities_space;
       };
     }
   }

--- a/include/aspect/material_model/utilities.h
+++ b/include/aspect/material_model/utilities.h
@@ -378,6 +378,26 @@ namespace aspect
       compute_only_composition_fractions(const std::vector<double> &compositional_fields,
                                          const std::vector<unsigned int> &indices_to_use,
                                          const double minimum_fraction = -std::numeric_limits<double>::max());
+      /**
+       * For multicomponent material models: Given a vector of compositional
+       * field values of length N, of which M indices correspond to mass or
+       * volume fractions, this function returns a vector of fractions
+       * of length M+1, corresponding to the fraction of a ``background
+       * material'' as the first entry, and fractions for each of the input
+       * fields as the following entries. The returned vector will sum to one.
+       * If the sum of the compositional_fields is greater than
+       * one, we assume that there is no background field (i.e., that field value
+       * is zero). Otherwise, the difference between the sum of the compositional
+       * fields and 1.0 is assumed to be the amount of the background field.
+       * This function makes no assumptions about the units of the
+       * compositional field values; for example, they could correspond to
+       * mass or volume fractions.
+       */
+      void
+      compute_only_composition_fractions(const std::vector<double> &compositional_fields,
+                                         const std::vector<unsigned int> &indices_to_use,
+                                         std::vector<double> &volume_fractions,
+                                         const double minimum_fraction = -std::numeric_limits<double>::max());
 
       /**
        * For multicomponent material models: Given a vector of compositional
@@ -404,6 +424,31 @@ namespace aspect
       compute_composition_fractions(const std::vector<double> &compositional_fields,
                                     const ComponentMask &field_mask = ComponentMask(),
                                     const double minimum_fraction = -std::numeric_limits<double>::max());
+      /**
+             * For multicomponent material models: Given a vector of compositional
+             * field values of length N, this function returns a vector of fractions
+             * of length N+1, corresponding to the fraction of a ``background
+             * material'' as the first entry, and fractions for each of the input
+             * fields as the following entries. The returned vector will sum to one.
+             * If the sum of the compositional_fields is greater than
+             * one, we assume that there is no background field (i.e., that field value
+             * is zero). Otherwise, the difference between the sum of the compositional
+             * fields and 1.0 is assumed to be the amount of the background field.
+             * Optionally, one can input a component mask that determines which of the
+             * compositional fields to use during the computation (e.g. because
+             * some fields contain unrelated quantities (like strain,
+             * porosity, or trace elements). By default, all fields are included.
+             * This function makes no assumptions about the units of the
+             * compositional field values; for example, they could correspond to
+             * mass or volume fractions.
+             */
+
+      void
+      compute_composition_fractions(const std::vector<double> &compositional_fields,
+                                    std::vector<double> &fractions,
+                                    const ComponentMask &field_mask = ComponentMask(),
+                                    const double minimum_fraction = -std::numeric_limits<double>::max());
+
 
       /**
        * Given a vector of component masses,

--- a/include/aspect/material_model/visco_plastic.h
+++ b/include/aspect/material_model/visco_plastic.h
@@ -21,6 +21,7 @@
 #ifndef _aspect_material_model_visco_plastic_h
 #define _aspect_material_model_visco_plastic_h
 
+#include "aspect/utilities.h"
 #include <aspect/simulator_access.h>
 #include <aspect/material_model/interface.h>
 #include <aspect/material_model/equation_of_state/multicomponent_incompressible.h>
@@ -294,6 +295,12 @@ namespace aspect
          * Record the mapping of reaction progress to phase transitions used in the material model
          */
         std::vector<unsigned int> reaction_progress_mapping;
+        Utilities::ScratchSpace<std::vector<double>> composition_fractions_space;
+        Utilities::ScratchSpace<std::vector<double>> phase_function_values_space;
+        Utilities::ScratchSpace<std::vector<double>>  average_elastic_shear_moduli_space;
+        Utilities::ScratchSpace<std::vector<double>> phase_function_discrete_values_space;
+        Utilities::ScratchSpace<std::vector<double>> volume_fractions_space;
+        aspect::Utilities::ScratchSpace<IsostrainViscosities> isostrain_viscosities_space;
 
     };
 

--- a/include/aspect/particle/interpolator/linear_least_squares.h
+++ b/include/aspect/particle/interpolator/linear_least_squares.h
@@ -23,6 +23,7 @@
 
 #include <aspect/particle/interpolator/interface.h>
 #include <aspect/simulator_access.h>
+#include <aspect/utilities.h>
 
 #include <aspect/particle/interpolator/cell_average.h>
 
@@ -95,6 +96,10 @@ namespace aspect
            * perform a linear least squares interpolation.
            */
           Interpolator::CellAverage<dim> fallback_interpolator;
+
+          Utilities::ScratchSpace<std::vector<std::vector<double>>> vector_vector_double_space;
+          Utilities::ScratchSpace<std::vector<Vector<double>>> vector_Vector_double_space;
+          Utilities::ScratchSpace<std::vector<double>> vector_double_space;
       };
     }
   }

--- a/include/aspect/particle/property/viscoplastic_strain_invariants.h
+++ b/include/aspect/particle/property/viscoplastic_strain_invariants.h
@@ -88,6 +88,11 @@ namespace aspect
         private:
           unsigned int n_components;
 
+          bool compositional_name_exists_plastic_strain;
+          bool compositional_name_exists_viscous_strain;
+          bool compositional_name_exists_total_strain;
+          bool compositional_name_exists_noninitial_plastic_strain;
+
           /**
            * An object that is used to compute the particle property. Since the
            * object is expensive to create and is needed often it is kept as a

--- a/include/aspect/utilities.h
+++ b/include/aspect/utilities.h
@@ -155,6 +155,27 @@ namespace aspect
                                  const std::string &id_text);
 
     /**
+     * Given an array @p values, consider three cases:
+     * - If it has size @p N, return the original array.
+     * - If it has size one, return an array of size @p N where all
+     *   elements are equal to the one element of @p value.
+     * - If it has any other size, throw an exception that uses
+     *   @p id_text as an identifying string.
+     *
+     * This function is typically used for parameter lists that can either
+     * contain different values for each of a set of objects (e.g., for
+     * each compositional field), or contain a single value that is then
+     * used for each object.
+     */
+    template <typename T>
+    void 
+    possibly_extend_from_1_to_N (const std::vector<T> &values,
+                                 const unsigned int N,
+                                 const std::string &id_text,
+                                 std::vector<T>& out);
+
+
+    /**
      * A namespace that contains options and functions able to parse
      * a map of double values from a string representation of the form
      * "key1 : value1, key2 : value2, etc". The parsing and output
@@ -1334,6 +1355,7 @@ namespace aspect
       // will be happy
       return std::vector<T> ();
     }
+
 
     inline
     void

--- a/include/aspect/utilities.h
+++ b/include/aspect/utilities.h
@@ -168,11 +168,11 @@ namespace aspect
      * used for each object.
      */
     template <typename T>
-    void 
+    void
     possibly_extend_from_1_to_N (const std::vector<T> &values,
                                  const unsigned int N,
                                  const std::string &id_text,
-                                 std::vector<T>& out);
+                                 std::vector<T> &out);
 
 
     /**

--- a/source/heating_model/compositional_heating.cc
+++ b/source/heating_model/compositional_heating.cc
@@ -35,11 +35,15 @@ namespace aspect
               const MaterialModel::MaterialModelOutputs<dim> &/*material_model_outputs*/,
               HeatingModel::HeatingModelOutputs &heating_model_outputs) const
     {
+      typename aspect::Utilities::ScratchSpace<std::vector<double>>::ScopedScratchObject scoped_volume_fractions_space(volume_fractions_space);
+      std::vector<double> &volume_fractions = scoped_volume_fractions_space;
+
+      //std::vector<double> volume_fractions;
       for (unsigned int q = 0; q < heating_model_outputs.heating_source_terms.size(); ++q)
         {
           // Compute compositional volume fractions
-          const std::vector<double> volume_fractions = MaterialModel::MaterialUtilities::compute_composition_fractions(material_model_inputs.composition[q],
-                                                       ComponentMask(fields_used_in_heat_production_averaging));
+          MaterialModel::MaterialUtilities::compute_composition_fractions(material_model_inputs.composition[q],volume_fractions,
+                                                                          ComponentMask(fields_used_in_heat_production_averaging));
 
           // Calculate average compositional heat production
           double compositional_heat_production = 0.;

--- a/source/material_model/rheology/visco_plastic.cc
+++ b/source/material_model/rheology/visco_plastic.cc
@@ -18,7 +18,11 @@
   <http://www.gnu.org/licenses/>.
 */
 
+<<<<<<< HEAD
 #include <algorithm>
+=======
+#include "aspect/material_model/rheology/drucker_prager.h"
+>>>>>>> f227e5131 (reduce allocation in aspect.)
 #include <aspect/material_model/rheology/visco_plastic.h>
 #include <aspect/material_model/utilities.h>
 #include <aspect/utilities.h>
@@ -28,6 +32,7 @@
 #include <deal.II/base/signaling_nan.h>
 #include <deal.II/base/parameter_handler.h>
 #include <deal.II/fe/fe_values.h>
+#include <limits>
 
 namespace aspect
 {
@@ -164,15 +169,42 @@ namespace aspect
                                        const std::vector<unsigned int> &n_phase_transitions_per_composition) const
       {
         IsostrainViscosities output_parameters;
+        calculate_isostrain_viscosities(in,i,volume_fractions, output_parameters, phase_function_values,n_phase_transitions_per_composition);
+        return output_parameters;
+      }
 
+      template <int dim>
+      void
+      ViscoPlastic<dim>::
+      calculate_isostrain_viscosities (const MaterialModel::MaterialModelInputs<dim> &in,
+                                       const unsigned int i,
+                                       const std::vector<double> &volume_fractions,
+                                       IsostrainViscosities &output_parameters,
+                                       const std::vector<double> &phase_function_values,
+                                       const std::vector<unsigned int> &n_phase_transitions_per_composition) const
+      {
+        //IsostrainViscosities output_parameters;
+
+        //static Utilities::ScratchSpace<std::vector<double>> vector_doubles_space;
+        //static Utilities::ScratchSpace<std::vector<bool>> vector_boolss_space;
+        //static Utilities::ScratchSpace<std::vector<std::vector<Rheology::DruckerPragerParameters>>> DruckerPragerParameters_space;
+        //typename aspect::Utilities::ScratchSpace<std::vector<double>>::ScopedScratchObject scoped_volume_fractions_space(volume_fractions_space);
+        //std::vector<double>& volume_fractions = scoped_volume_fractions_space;
         // Initialize or fill variables used to calculate viscosities
         output_parameters.composition_yielding.resize(volume_fractions.size(), false);
+        std::fill( output_parameters.composition_yielding.begin(), output_parameters.composition_yielding.end(),false);
         output_parameters.composition_viscosities.resize(volume_fractions.size(), numbers::signaling_nan<double>());
+        std::fill( output_parameters.composition_viscosities.begin(), output_parameters.composition_viscosities.end(),numbers::signaling_nan<double>());
         output_parameters.drucker_prager_parameters.resize(volume_fractions.size());
+        std::fill( output_parameters.drucker_prager_parameters.begin(), output_parameters.drucker_prager_parameters.end(),DruckerPragerParameters());
         output_parameters.dilation_lhs_terms.resize(volume_fractions.size(), numbers::signaling_nan<double>());
+        std::fill(output_parameters.dilation_lhs_terms.begin(),output_parameters.dilation_lhs_terms.end(),numbers::signaling_nan<double>());
         output_parameters.dilation_rhs_terms.resize(volume_fractions.size(), numbers::signaling_nan<double>());
+        std::fill(output_parameters.dilation_rhs_terms.begin(),output_parameters.dilation_rhs_terms.end(),numbers::signaling_nan<double>());
         output_parameters.diffusion_viscosities.resize(volume_fractions.size(), std::numeric_limits<double>::max());
+        std::fill(output_parameters.diffusion_viscosities.begin(),output_parameters.diffusion_viscosities.end(),std::numeric_limits<double>::max());
         output_parameters.dislocation_viscosities.resize(volume_fractions.size(), std::numeric_limits<double>::max());
+        std::fill( output_parameters.dislocation_viscosities.begin(), output_parameters.dislocation_viscosities.end(),std::numeric_limits<double>::max());
 
         // Assemble current and old stress tensor if elastic behavior is enabled
         SymmetricTensor<2, dim> stress_0_advected = numbers::signaling_nan<SymmetricTensor<2, dim>>();
@@ -510,7 +542,6 @@ namespace aspect
               }
           }
 
-        return output_parameters;
       }
 
 
@@ -553,6 +584,7 @@ namespace aspect
 
             const SymmetricTensor<2,dim> current_strain_rate = in.strain_rate[i];
 
+
             // For each independent component, compute the derivative.
             for (unsigned int component = 0; component < SymmetricTensor<2,dim>::n_independent_components; ++component)
               {
@@ -565,9 +597,10 @@ namespace aspect
 
                 in_derivatives.strain_rate[i] = forward_strain_rate;
 
-                const IsostrainViscosities forward_isostrain_values =
-                  calculate_isostrain_viscosities(in_derivatives, i, volume_fractions,
-                                                  phase_function_values, n_phase_transitions_per_composition);
+                typename aspect::Utilities::ScratchSpace<IsostrainViscosities>::ScopedScratchObject scoped_isostrain_viscosities_space(isostrain_viscosities_space);
+                IsostrainViscosities &forward_isostrain_values = scoped_isostrain_viscosities_space;
+                calculate_isostrain_viscosities(in_derivatives, i, volume_fractions, forward_isostrain_values,
+                                                phase_function_values, n_phase_transitions_per_composition);
 
                 // For each composition of the independent component, compute the derivative.
                 for (unsigned int composition_index = 0; composition_index < n_compositions; ++composition_index)
@@ -603,9 +636,10 @@ namespace aspect
             // Modify the in_derivatives object again to take the original strain rate.
             in_derivatives.strain_rate[i] = current_strain_rate;
 
-            const IsostrainViscosities forward_isostrain_values =
-              calculate_isostrain_viscosities(in_derivatives, i, volume_fractions,
-                                              phase_function_values, n_phase_transitions_per_composition);
+            typename aspect::Utilities::ScratchSpace<IsostrainViscosities>::ScopedScratchObject scoped_isostrain_viscosities_space(isostrain_viscosities_space);
+            IsostrainViscosities &forward_isostrain_values = scoped_isostrain_viscosities_space;
+            calculate_isostrain_viscosities(in_derivatives, i, volume_fractions, forward_isostrain_values,
+                                            phase_function_values, n_phase_transitions_per_composition);
 
             for (unsigned int composition_index = 0; composition_index < n_compositions; ++composition_index)
               {

--- a/source/material_model/utilities.cc
+++ b/source/material_model/utilities.cc
@@ -33,6 +33,8 @@
 #include <aspect/utilities.h>
 
 #include <boost/lexical_cast.hpp>
+#include <deal.II/base/exception_macros.h>
+#include <deal.II/base/exceptions.h>
 #include <list>
 
 
@@ -877,7 +879,6 @@ namespace aspect
       }
 
 
-
       std::vector<double>
       compute_only_composition_fractions(const std::vector<double> &compositional_fields,
                                          const std::vector<unsigned int> &indices_to_use,
@@ -886,12 +887,30 @@ namespace aspect
         AssertThrow(minimum_fraction <= 1.0,
                     ExcMessage("The minimum composition fraction must not be greater than one."));
 
-        std::vector<double> composition_fractions(indices_to_use.size()+1);
+        static aspect::Utilities::ScratchSpace<std::vector<double>> composition_fractions_space;
+        typename aspect::Utilities::ScratchSpace<std::vector<double>>::ScopedScratchObject scoped_composition_fractions_space(composition_fractions_space);
+        std::vector<double> &composition_fractions = scoped_composition_fractions_space;
+        compute_only_composition_fractions(compositional_fields,indices_to_use,composition_fractions,minimum_fraction);
+        return composition_fractions;
+      }
+
+      void
+      compute_only_composition_fractions(const std::vector<double> &compositional_fields,
+                                         const std::vector<unsigned int> &indices_to_use,
+                                         std::vector<double> &composition_fractions,
+                                         const double minimum_fraction)
+      {
+        composition_fractions.resize(indices_to_use.size()+1);
+        std::fill(composition_fractions.begin(),composition_fractions.end(),0);
 
         // Clip the compositional fields so they are between zero and one,
         // and sum the compositional fields for normalization purposes.
         double sum_composition = 0.0;
-        std::vector<double> x_comp (indices_to_use.size());
+
+        static aspect::Utilities::ScratchSpace<std::vector<double>> x_comp_space;
+        typename aspect::Utilities::ScratchSpace<std::vector<double>>::ScopedScratchObject scoped_x_comp_space(x_comp_space);
+        std::vector<double> &x_comp = scoped_x_comp_space;
+        x_comp.resize(indices_to_use.size());
 
         for (unsigned int i=0; i < x_comp.size(); ++i)
           {
@@ -917,10 +936,7 @@ namespace aspect
             else
               composition_fractions[i+1] = x_comp[i];
           }
-
-        return composition_fractions;
       }
-
 
 
       std::vector<double>
@@ -928,10 +944,23 @@ namespace aspect
                                     const ComponentMask &field_mask,
                                     const double minimum_fraction)
       {
+        std::vector<double> volume_fractions;
+        compute_composition_fractions(compositional_fields,volume_fractions,field_mask);
+        return volume_fractions;
+      }
+
+
+      void
+      compute_composition_fractions(const std::vector<double> &compositional_fields,
+                                    std::vector<double> &composition_fractions,
+                                    const ComponentMask &field_mask,
+                                    const double minimum_fraction)
+      {
+
         AssertThrow(minimum_fraction <= 1.0,
                     ExcMessage("The minimum composition fraction must not be greater than one."));
 
-        std::vector<double> composition_fractions(compositional_fields.size()+1);
+        composition_fractions.resize(compositional_fields.size()+1);
 
         // Clip the compositional fields so they are between zero and one,
         // and sum the compositional fields for normalization purposes.
@@ -964,7 +993,6 @@ namespace aspect
                 composition_fractions[i+1] = x_comp[i];
             }
 
-        return composition_fractions;
       }
 
 

--- a/source/material_model/visco_plastic.cc
+++ b/source/material_model/visco_plastic.cc
@@ -48,9 +48,13 @@ namespace aspect
     {
       Assert(in.n_evaluation_points() == 1, ExcInternalError());
 
-      const std::vector<double> volume_fractions = MaterialUtilities::compute_only_composition_fractions(in.composition[0],
-                                                   this->introspection().chemical_composition_field_indices(),
-                                                   this->get_parameters().minimum_composition_fraction);
+      static Utilities::ScratchSpace<std::vector<double>> volume_fractions_space;
+      typename aspect::Utilities::ScratchSpace<std::vector<double>>::ScopedScratchObject scoped_volume_fractions_space(volume_fractions_space);
+      std::vector<double> &volume_fractions = scoped_volume_fractions_space;
+      MaterialUtilities::compute_only_composition_fractions(in.composition[0],
+                                                            this->introspection().chemical_composition_field_indices(),
+                                                            volume_fractions,
+                                                            this->get_parameters().minimum_composition_fraction);
 
       /* The following handles phases in a similar way as in the 'evaluate' function.
        * Results then enter the calculation of plastic yielding.
@@ -89,10 +93,12 @@ namespace aspect
       /* The following returns whether or not the material is plastically yielding
        * as documented in evaluate.
        */
-      const IsostrainViscosities isostrain_viscosities = rheology->calculate_isostrain_viscosities(in, 0, volume_fractions, phase_function_values, phase_function.n_phase_transitions_for_each_composition());
+      typename aspect::Utilities::ScratchSpace<IsostrainViscosities>::ScopedScratchObject scoped_isostrain_viscosities_space(isostrain_viscosities_space);
+      IsostrainViscosities &isostrain_viscosities = scoped_isostrain_viscosities_space;
+      rheology->calculate_isostrain_viscosities(in, 0, volume_fractions,isostrain_viscosities, phase_function_values, phase_function.n_phase_transitions_for_each_composition());
 
-      const std::vector<double>::const_iterator max_composition = std::max_element(volume_fractions.begin(), volume_fractions.end());
-      const bool plastic_yielding = isostrain_viscosities.composition_yielding[std::distance(volume_fractions.begin(), max_composition)];
+      std::vector<double>::const_iterator max_composition = std::max_element(volume_fractions.begin(), volume_fractions.end());
+      const bool plastic_yielding = isostrain_viscosities.composition_yielding[std::distance(volume_fractions.cbegin(), max_composition)];
 
       return plastic_yielding;
     }
@@ -108,16 +114,23 @@ namespace aspect
       EquationOfStateOutputs<dim> eos_outputs (this->introspection().get_number_of_fields_of_type(CompositionalFieldDescription::chemical_composition)+1);
       EquationOfStateOutputs<dim> eos_outputs_all_phases (n_phases);
 
-      std::vector<double> average_elastic_shear_moduli (in.n_evaluation_points());
+      typename aspect::Utilities::ScratchSpace<std::vector<double>>::ScopedScratchObject scoped_average_elastic_shear_moduli_space(average_elastic_shear_moduli_space);
+      std::vector<double> &average_elastic_shear_moduli = scoped_average_elastic_shear_moduli_space;
+      average_elastic_shear_moduli.resize(in.n_evaluation_points());
 
       // Store value of phase function for each phase and composition
       // While the number of phases is fixed, the value of the phase function is updated for every point
-      std::vector<double> phase_function_values(phase_function.n_phase_transitions(), 0.0);
+      typename aspect::Utilities::ScratchSpace<std::vector<double>>::ScopedScratchObject scoped_phase_function_values_space(phase_function_values_space);
+      std::vector<double> &phase_function_values = scoped_phase_function_values_space;
+      phase_function_values.resize(phase_function.n_phase_transitions(), 0.0);
+      std::fill( phase_function_values.begin(), phase_function_values.end(),0);
 
       std::vector<double> phase_function_discrete_values = (use_dominant_phase_for_viscosity?
                                                             std::vector<double>(phase_function_discrete->n_phase_transitions(), 0.0): std::vector<double>());
 
 
+      typename aspect::Utilities::ScratchSpace<std::vector<double>>::ScopedScratchObject scoped_volume_fractions_space(volume_fractions_space);
+      std::vector<double> &volume_fractions = scoped_volume_fractions_space;
       // Loop through all requested points
       for (unsigned int i=0; i < in.n_evaluation_points(); ++i)
         {
@@ -169,9 +182,10 @@ namespace aspect
                                                   n_phase_transitions_for_each_chemical_composition,
                                                   eos_outputs);
 
-          const std::vector<double> volume_fractions = MaterialUtilities::compute_only_composition_fractions(in.composition[i],
-                                                       this->introspection().chemical_composition_field_indices(),
-                                                       this->get_parameters().minimum_composition_fraction);
+          MaterialUtilities::compute_only_composition_fractions(in.composition[i],
+                                                                this->introspection().chemical_composition_field_indices(),
+                                                                volume_fractions,
+                                                                this->get_parameters().minimum_composition_fraction);
 
           // not strictly correct if thermal expansivities are different, since we are interpreting
           // these compositions as volume fractions, but the error introduced should not be too bad.
@@ -213,7 +227,9 @@ namespace aspect
           // Also always compute the viscosity if additional outputs are requested, because the viscosity is needed
           // to compute the elastic force term and the elastic reaction rates.
           bool plastic_yielding = false;
-          IsostrainViscosities isostrain_viscosities;
+          typename aspect::Utilities::ScratchSpace<IsostrainViscosities>::ScopedScratchObject scoped_isostrain_viscosities_space(isostrain_viscosities_space);
+          IsostrainViscosities &isostrain_viscosities = scoped_isostrain_viscosities_space;
+          //IsostrainViscosities isostrain_viscosities;
 
           if (in.requests_property(MaterialProperties::viscosity) || in.requests_property(MaterialProperties::additional_outputs) ||
               (this->get_parameters().enable_elasticity && in.requests_property(MaterialProperties::reaction_rates) ))
@@ -232,13 +248,11 @@ namespace aspect
                       phase_inputs.phase_transition_index = j;
                       phase_function_discrete_values[j] = phase_function_discrete->compute_value(phase_inputs);
                     }
-                  isostrain_viscosities =
-                    rheology->calculate_isostrain_viscosities(in, i, volume_fractions, phase_function_discrete_values,  phase_function_discrete->n_phase_transitions_for_each_chemical_composition());
+                  rheology->calculate_isostrain_viscosities(in, i, volume_fractions,isostrain_viscosities, phase_function_discrete_values,  phase_function_discrete->n_phase_transitions_for_each_chemical_composition());
                 }
               else
                 {
-                  isostrain_viscosities =
-                    rheology->calculate_isostrain_viscosities(in, i, volume_fractions, phase_function_values, n_phase_transitions_for_each_chemical_composition);
+                  rheology->calculate_isostrain_viscosities(in, i, volume_fractions,isostrain_viscosities, phase_function_values, n_phase_transitions_for_each_chemical_composition);
                 }
 
               // The isostrain condition implies that the viscosity averaging should be arithmetic (see above).
@@ -252,7 +266,7 @@ namespace aspect
               // holds values that are either 0 or 1), but might not be consistent with the viscosity
               // averaging chosen.
               std::vector<double>::const_iterator max_composition = std::max_element(volume_fractions.begin(), volume_fractions.end());
-              plastic_yielding = isostrain_viscosities.composition_yielding[std::distance(volume_fractions.begin(), max_composition)];
+              plastic_yielding = isostrain_viscosities.composition_yielding[std::distance(volume_fractions.cbegin(), max_composition)];
 
               // Compute viscosity derivatives if they are requested
               if (const std::shared_ptr<MaterialModel::MaterialModelDerivatives<dim>> derivatives =

--- a/source/particle/interpolator/linear_least_squares.cc
+++ b/source/particle/interpolator/linear_least_squares.cc
@@ -25,6 +25,7 @@
 #include <deal.II/grid/grid_tools.h>
 #include <deal.II/base/signaling_nan.h>
 #include <deal.II/lac/qr.h>
+#include <limits>
 
 namespace aspect
 {
@@ -49,9 +50,14 @@ namespace aspect
         const typename ParticleHandler<dim>::particle_iterator_range particle_range =
           particle_handler.particles_in_cell(cell);
 
-        std::vector<std::vector<double>> cell_properties(positions.size(),
-                                                          std::vector<double>(n_particle_properties,
-                                                                              numbers::signaling_nan<double>()));
+        typename aspect::Utilities::ScratchSpace<std::vector<std::vector<double>>>::ScopedScratchObject scoped_cell_properties_space(vector_vector_double_space);
+        std::vector<std::vector<double>> &cell_properties = scoped_cell_properties_space;
+        cell_properties.resize(positions.size());
+        for (std::vector<double> &cell_property : cell_properties)
+          {
+            cell_property.resize(n_particle_properties, numbers::signaling_nan<double>());
+            std::fill(cell_property.begin(),cell_property.end(),numbers::signaling_nan<double>());
+          }
 
         const unsigned int n_particles = std::distance(particle_range.begin(), particle_range.end());
         const unsigned int n_matrix_columns = (dim == 2) ? 3 : 4;
@@ -69,15 +75,45 @@ namespace aspect
         // least squares solution of Ac=r by solving the reduced QR factorization
         // Ac = QRc = b -> Q^TQRc = Rc =Q^Tb
         // A is a std::vector of Vectors(which are it's columns) so that we
-        // create what the ImplicitQR class needs.
-        std::vector<Vector<double>> A(n_matrix_columns, Vector<double>(n_particles));
-        std::vector<Vector<double>> b(n_particle_properties, Vector<double>(n_particles));
+
+        typename aspect::Utilities::ScratchSpace<std::vector<Vector<double>>>::ScopedScratchObject scoped_A_space(vector_Vector_double_space);
+        std::vector<Vector<double>> &A = scoped_A_space;
+        A.resize(n_matrix_columns);
+        for (Vector<double> &A_sub : A)
+          {
+            A_sub.grow_or_shrink(n_particles);
+            //A_sub=numbers::quite_nan<double>();
+            std::fill(A_sub.begin(),A_sub.end(),numbers::signaling_nan<double>());
+          }
+
+        typename aspect::Utilities::ScratchSpace<std::vector<Vector<double>>>::ScopedScratchObject scoped_b_space(vector_Vector_double_space);
+        std::vector<Vector<double>> &b = scoped_b_space;
+        b.resize(n_particle_properties);
+        for (Vector<double> &b_sub : b)
+          {
+            b_sub.grow_or_shrink(n_particles);
+            //b_sub=numbers::signaling_nan<double>();
+            std::fill(b_sub.begin(),b_sub.end(),numbers::signaling_nan<double>());
+          }
+
+        //std::vector<Vector<double>> A(n_matrix_columns, Vector<double>(n_particles));
+        //std::vector<Vector<double>> b(n_particle_properties, Vector<double>(n_particles));
 
         unsigned int particle_index = 0;
         // The unit cell of deal.II is [0,1]^dim. The limiter needs a 'unit' cell of [-.5,.5]^dim.
         const double unit_offset = 0.5;
-        std::vector<double> property_minimums(n_particle_properties, std::numeric_limits<double>::max());
-        std::vector<double> property_maximums(n_particle_properties, std::numeric_limits<double>::lowest());
+
+        typename aspect::Utilities::ScratchSpace<std::vector<double>>::ScopedScratchObject scoped_property_minimums_space(vector_double_space);
+        std::vector<double> &property_minimums = scoped_property_minimums_space;
+        property_minimums.resize(n_particle_properties,std::numeric_limits<double>::max());
+        std::fill(property_minimums.begin(),property_minimums.end(),std::numeric_limits<double>::max());
+
+        typename aspect::Utilities::ScratchSpace<std::vector<double>>::ScopedScratchObject scoped_property_maximums_space(vector_double_space);
+        std::vector<double> &property_maximums = scoped_property_maximums_space;
+        property_maximums.resize(n_particle_properties,std::numeric_limits<double>::lowest());
+        std::fill(property_maximums.begin(),property_maximums.end(),std::numeric_limits<double>::lowest());
+        //std::vector<double> property_minimums(n_particle_properties, std::numeric_limits<double>::max());
+        //std::vector<double> property_maximums(n_particle_properties, std::numeric_limits<double>::lowest());
         for (const auto &particle : particle_range)
           {
             const ArrayView<const double> particle_property_value = particle.get_properties();

--- a/source/particle/property/viscoplastic_strain_invariants.cc
+++ b/source/particle/property/viscoplastic_strain_invariants.cc
@@ -54,16 +54,44 @@ namespace aspect
 
         // Find out which fields are used.
         if (this->introspection().compositional_name_exists("plastic_strain"))
-          n_components += 1;
+          {
+            compositional_name_exists_plastic_strain = true;
+            n_components += 1;
+          }
+        else
+          {
+            compositional_name_exists_plastic_strain = false;
+          }
 
         if (this->introspection().compositional_name_exists("viscous_strain"))
-          n_components += 1;
+          {
+            compositional_name_exists_viscous_strain = true;
+            n_components += 1;
+          }
+        else
+          {
+            compositional_name_exists_viscous_strain = false;
+          }
 
         if (this->introspection().compositional_name_exists("total_strain"))
-          n_components += 1;
+          {
+            compositional_name_exists_total_strain = true;
+            n_components += 1;
+          }
+        else
+          {
+            compositional_name_exists_total_strain = false;
+          }
 
         if (this->introspection().compositional_name_exists("noninitial_plastic_strain"))
-          n_components += 1;
+          {
+            compositional_name_exists_noninitial_plastic_strain = true;
+            n_components += 1;
+          }
+        else
+          {
+            compositional_name_exists_noninitial_plastic_strain = false;
+          }
 
         if (n_components == 0)
           AssertThrow(false,
@@ -80,16 +108,16 @@ namespace aspect
                                                                          std::vector<double> &data) const
       {
         // Give each strain field its initial composition if one is prescribed.
-        if (this->introspection().compositional_name_exists("plastic_strain"))
+        if (compositional_name_exists_plastic_strain)
           data.push_back(this->get_initial_composition_manager().initial_composition(position,this->introspection().compositional_index_for_name("plastic_strain")));
 
-        if (this->introspection().compositional_name_exists("viscous_strain"))
+        if (compositional_name_exists_viscous_strain)
           data.push_back(this->get_initial_composition_manager().initial_composition(position,this->introspection().compositional_index_for_name("viscous_strain")));
 
-        if (this->introspection().compositional_name_exists("total_strain"))
+        if (compositional_name_exists_total_strain)
           data.push_back(this->get_initial_composition_manager().initial_composition(position,this->introspection().compositional_index_for_name("total_strain")));
 
-        if (this->introspection().compositional_name_exists("noninitial_plastic_strain"))
+        if (compositional_name_exists_noninitial_plastic_strain)
           data.push_back(this->get_initial_composition_manager().initial_composition(position,this->introspection().compositional_index_for_name("noninitial_plastic_strain")));
 
       }
@@ -155,10 +183,10 @@ namespace aspect
              * If these assumptions change in the future, they will need to be updated.
              * */
 
-            if (this->introspection().compositional_name_exists("plastic_strain") && plastic_yielding == true)
+            if (compositional_name_exists_plastic_strain && plastic_yielding == true)
               data[data_position] += strain_update;
 
-            if (this->introspection().compositional_name_exists("viscous_strain") && plastic_yielding == false)
+            if (compositional_name_exists_viscous_strain && plastic_yielding == false)
               {
                 // Not yielding and only one field, which tracks the viscous strain.
                 if (n_components == 1)
@@ -176,11 +204,11 @@ namespace aspect
 
             // Only one field, which tracks total strain and is updated regardless of whether the
             // material is yielding or not.
-            if (this->introspection().compositional_name_exists("total_strain"))
+            if (compositional_name_exists_total_strain)
               data[data_position] += strain_update;
 
             // Yielding, and noninitial plastic strain (last data position, updated below) is tracked.
-            if (this->introspection().compositional_name_exists("noninitial_plastic_strain") && plastic_yielding == true)
+            if (compositional_name_exists_noninitial_plastic_strain && plastic_yielding == true)
               data[data_position+(n_components-1)] += strain_update;
 
             ++p;

--- a/source/simulator/core.cc
+++ b/source/simulator/core.cc
@@ -590,13 +590,13 @@ namespace aspect
         AssertThrow (prm_out,
                      ExcMessage (std::string("Could not open file <") +
                                  parameters.output_directory + "parameters.prm>."));
-        prm.print_parameters(prm_out, ParameterHandler::PRM);
+        //prm.print_parameters(prm_out, ParameterHandler::PRM);
 
         std::ofstream json_out ((parameters.output_directory + "parameters.json"));
         AssertThrow (json_out,
                      ExcMessage (std::string("Could not open file <") +
                                  parameters.output_directory + "parameters.json>."));
-        prm.print_parameters(json_out, ParameterHandler::JSON);
+        //prm.print_parameters(json_out, ParameterHandler::JSON);
       }
 
     // check that the boundary condition selection is consistent


### PR DESCRIPTION
This is a work in progess. The code itself hasn't really been cleaned, and still will at least require some refactors to make the usage a bit more ergonomic. 

For the continental extension performance benchmark, I have been able to reduce the number of allocations from 107e6 to 64e6, as measured by heaptrack. This pull request of mostly to use the new testers to see if it actually makes a difference in the performance or not.

### Before your first pull request:

* [x] I have read the guidelines in our [CONTRIBUTING.md](../blob/main/CONTRIBUTING.md) document.

### For all pull requests:

* [ ] I have followed the [instructions for indenting my code](../blob/main/CONTRIBUTING.md#making-aspect-better).
* I followed the [AI Policy](../blob/main/CONTRIBUTING.md#policy-on-usage-of-ai):
  - [ ] Significant parts of this PR were written by AI (please add a sentence below).
  - [x] AI has not been used in significant ways.
