### PR TITLE
[DO NOT MERGE] update default ascii data file name for initial composition model

### DIFF
--- a/doc/sphinx/parameters/Initial_20composition_20model.md
+++ b/doc/sphinx/parameters/Initial_20composition_20model.md
@@ -94,7 +94,7 @@ When &ldquo;composition is specified, the initial model is treated as a standard
 
 ::::{dropdown} __Parameter:__ {ref}`Data file name<parameters:Initial_20composition_20model/Ascii_20data_20model/Data_20file_20name>`
 :name: parameters:Initial_20composition_20model/Ascii_20data_20model/Data_20file_20name
-**Default value:** initial_composition_top_mantle_box_3d.txt
+**Default value:** box_2d.txt
 
 **Pattern:** [Anything]
 


### PR DESCRIPTION
make parameters on main produces this change. Not sure why it wasn't caught, or if it's only on my machine.