### PR TITLE
Adjust particle information postprocessor for multiline output.

### DIFF
--- a/source/postprocess/particle_information.cc
+++ b/source/postprocess/particle_information.cc
@@ -23,6 +23,7 @@
 #include <aspect/particle/manager.h>
 
 #include <limits>
+#include <sstream>
 
 
 namespace aspect
@@ -38,11 +39,12 @@ namespace aspect
           || this->get_pre_refinement_step() != std::numeric_limits<unsigned int>::max())
         return {"", ""};
 
+      std::ostringstream output;
       for (unsigned int particle_manager_index = 0;
            particle_manager_index < this->n_particle_managers();
            ++particle_manager_index)
         {
-          this->get_pcout() << "     Particle manager " << particle_manager_index+1 << " properties:" << std::endl;
+          output << "Particle manager " << particle_manager_index+1 << " properties:" << std::endl;
 
           const auto property_names = this->get_particle_manager(particle_manager_index)
                                       .get_property_manager()
@@ -52,10 +54,10 @@ namespace aspect
             // The particle integrator adds internal storage to every world.
             // This is not a particle property selected by the user.
             if (property_name != "internal: integrator properties")
-              this->get_pcout() << "       " << property_name << std::endl;
+              output << "  " << property_name << std::endl;
         }
 
-      return {"", ""};
+      return {"Particle information:", output.str()};
     }
   }
 }

--- a/tests/particles/particle_information/screen-output
+++ b/tests/particles/particle_information/screen-output
@@ -18,11 +18,11 @@ Number of degrees of freedom: 3,238 (1,518+202+759+759)
    Solving Stokes system (GMG)... 17+0 iterations.
 
    Postprocessing:
-     Particle manager 1 properties:
-       initial anomaly
-     Particle manager 2 properties:
-       function
      Writing particle output: output-particle_information/particles/particles-00000, output-particle_information/particles-2/particles-2-00000
+     Particle information:    Particle manager 1 properties:
+                                initial anomaly
+                              Particle manager 2 properties:
+                                function
 
 Termination requested by criterion: end time
 


### PR DESCRIPTION
Follow-up to #7243, to adjust for #7258. In reference to #7218.

The output changes because #7243 let the postprocessor write to the screen *immediately*, rather than buffering everything until all postprocessor have been run and then outputting in the order in which postprocessors are run. We now buffer, and so the particle information output moves down (which looks like the other output moves up in the diff).

### For all pull requests:

* [x] I have followed the [instructions for indenting my code](../blob/main/CONTRIBUTING.md#making-aspect-better).
* I followed the [AI Policy](../blob/main/CONTRIBUTING.md#policy-on-usage-of-ai):
  - [x] Significant parts of this PR were written by AI (please add a sentence below).
  - [ ] AI has not been used in significant ways.

*If yes, please describe your usage of AI models in the creation of this pull request*

### For new features/models or changes of existing features:

* [x] I have tested my new feature locally to ensure it is correct.
* [ ] I have [created a testcase](https://aspect-documentation.readthedocs.io/en/latest/user/extending/testing/writing-tests.html) for the new feature/benchmark in the [tests/](../blob/main/tests/) directory.
* [ ] I have added a changelog entry in the [doc/modules/changes](../blob/main/doc/modules/changes) directory that will inform other users of my change.
