### PR TITLE
Adjust finite element information postprocessor for multiline output.

### DIFF
--- a/source/postprocess/finite_element_information.cc
+++ b/source/postprocess/finite_element_information.cc
@@ -22,6 +22,7 @@
 #include <aspect/postprocess/finite_element_information.h>
 
 #include <limits>
+#include <sstream>
 
 
 namespace aspect
@@ -36,7 +37,7 @@ namespace aspect
       if (this->get_timestep_number() > 0 || this->get_pre_refinement_step() != std::numeric_limits<unsigned int>::max())
         return {"", ""};
 
-      this->get_pcout() << "     Finite element spaces:" << std::endl;
+      std::ostringstream output;
 
       unsigned int compositional_field_index = 0;
       const auto &compositional_field_names = this->introspection().get_composition_names();
@@ -46,19 +47,18 @@ namespace aspect
         if (variable.name == "compositions")
           for (unsigned int i = 0; i < variable.multiplicity; ++i)
             {
-              this->get_pcout() << "       "
-                                << "composition " << compositional_field_index << ": "
-                                << compositional_field_names[compositional_field_index]
-                                << " (" << CompositionalFieldDescription::type_to_string(compositional_field_descriptions[compositional_field_index].type)
-                                << "): " << variable.fe->get_name()
-                                << std::endl;
+              output << "composition " << compositional_field_index << ": "
+                     << compositional_field_names[compositional_field_index]
+                     << " (" << CompositionalFieldDescription::type_to_string(compositional_field_descriptions[compositional_field_index].type)
+                     << "): " << variable.fe->get_name()
+                     << std::endl;
               ++compositional_field_index;
             }
         else
-          this->get_pcout() << "       " << variable.name << ": "
-                            << variable.fe->get_name() << std::endl;
+          output << variable.name << ": "
+                 << variable.fe->get_name() << std::endl;
 
-      return {"", ""};
+      return {"Finite element spaces:", output.str()};
     }
   }
 }

--- a/tests/composition_cg_dg_fem2/screen-output
+++ b/tests/composition_cg_dg_fem2/screen-output
@@ -24,15 +24,6 @@ Number of degrees of freedom: 1,275 (386+55+193+40+193+193+55+160)
    Solving Stokes system (GMG)... 13+0 iterations.
 
    Postprocessing:
-     Finite element spaces:
-       velocity: FE_Q<2>(2)
-       pressure: FE_Q<2>(1)
-       temperature: FE_Q<2>(2)
-       composition 0: C_1 (chemical composition): FE_DGQ<2>(0)
-       composition 1: C_2 (chemical composition): FE_Q<2>(2)
-       composition 2: C_3 (chemical composition): FE_Q<2>(2)
-       composition 3: C_4 (chemical composition): FE_Q<2>(1)
-       composition 4: C_5 (chemical composition): FE_DGQ<2>(1)
      Temperature min/avg/max:   0 K, 0.5 K, 1 K
      Compositions min/max/mass: 0/1/0.5 // 0/1/0.4583 // 0/1/0.4583 // 0/1/0.375 // 0/1/0.375
      
@@ -51,6 +42,14 @@ Number of degrees of freedom: 1,275 (386+55+193+40+193+193+55+160)
      Total system preconditioner matrix memory consumption: 0.00 MB.
      Total system preconditioner matrix nnz: 0
      system preconditioner matrix nnz by block: 
+     Finite element spaces:     velocity: FE_Q<2>(2)
+                                pressure: FE_Q<2>(1)
+                                temperature: FE_Q<2>(2)
+                                composition 0: C_1 (chemical composition): FE_DGQ<2>(0)
+                                composition 1: C_2 (chemical composition): FE_Q<2>(2)
+                                composition 2: C_3 (chemical composition): FE_Q<2>(2)
+                                composition 3: C_4 (chemical composition): FE_Q<2>(1)
+                                composition 4: C_5 (chemical composition): FE_DGQ<2>(1)
 
 *** Timestep 1:  t=0.0625 seconds, dt=0.0625 seconds
    Solving temperature system... 10 iterations.

--- a/tests/composition_cg_dg_particle/screen-output
+++ b/tests/composition_cg_dg_particle/screen-output
@@ -9,17 +9,16 @@ Number of degrees of freedom: 7,973 (2,178+289+1,089+1,089+1,024+2,304)
    Solving Stokes system (GMG)... 12+0 iterations.
 
    Postprocessing:
-     Finite element spaces:
-       velocity: FE_Q<2>(2)
-       pressure: FE_Q<2>(1)
-       temperature: FE_Q<2>(2)
-       composition 0: advection_field (chemical composition): FE_Q<2>(2)
-       composition 1: advection_particle (chemical composition): FE_DGQ<2>(1)
-       composition 2: advection_particle2 (chemical composition): FE_DGQ<2>(2)
      RMS, max velocity:         0.000181 m/s, 0.000404 m/s
      Compositions min/max/mass: 0/1/0.1825 // 0/1/0.07566 // 0/0/0
      Writing particle output:   output-composition_cg_dg_particle/particles/particles-00000
      Writing graphical output:  output-composition_cg_dg_particle/solution/solution-00000
+     Finite element spaces:     velocity: FE_Q<2>(2)
+                                pressure: FE_Q<2>(1)
+                                temperature: FE_Q<2>(2)
+                                composition 0: advection_field (chemical composition): FE_Q<2>(2)
+                                composition 1: advection_particle (chemical composition): FE_DGQ<2>(1)
+                                composition 2: advection_particle2 (chemical composition): FE_DGQ<2>(2)
 
 *** Timestep 1:  t=70 seconds, dt=70 seconds
    Skipping temperature solve because RHS is zero.


### PR DESCRIPTION
Follow-up to #7212, to adjust for #7258. In reference to #7218.

The output changes because #7243 let the postprocessor write to the screen immediately, rather than buffering everything until all postprocessor have been run and then outputting in the order in which postprocessors are run. We now buffer, and so the particle information output moves down (which looks like the other output moves up in the diff).


### For all pull requests:

* [x] I have followed the [instructions for indenting my code](../blob/main/CONTRIBUTING.md#making-aspect-better).
* I followed the [AI Policy](../blob/main/CONTRIBUTING.md#policy-on-usage-of-ai):
  - [x] Significant parts of this PR were written by AI (please add a sentence below).
  - [ ] AI has not been used in significant ways.

*If yes, please describe your usage of AI models in the creation of this pull request*

### For new features/models or changes of existing features:

* [ ] I have tested my new feature locally to ensure it is correct.
* [ ] I have [created a testcase](https://aspect-documentation.readthedocs.io/en/latest/user/extending/testing/writing-tests.html) for the new feature/benchmark in the [tests/](../blob/main/tests/) directory.
* [ ] I have added a changelog entry in the [doc/modules/changes](../blob/main/doc/modules/changes) directory that will inform other users of my change.
