### PR TITLE
Remove functions now no longer necessary.

### DIFF
--- a/include/aspect/particle/generator/interface.h
+++ b/include/aspect/particle/generator/interface.h
@@ -73,12 +73,6 @@ namespace aspect
           void
           update() override;
 
-          void
-          save (std::map<std::string, std::string> &status_strings) const override;
-
-          void
-          load (const std::map<std::string, std::string> &status_strings) override;
-
           /**
            * Generate particles. Every derived class
            * has to decide on the method and number of particles to generate,

--- a/source/particle/generator/interface.cc
+++ b/source/particle/generator/interface.cc
@@ -71,32 +71,6 @@ namespace aspect
 
 
       template <int dim>
-      void
-      Interface<dim>::save (std::map<std::string, std::string> &status_strings) const
-      {
-        std::ostringstream os;
-        os << random_number_generator;
-        status_strings["ParticleGenerator"] = os.str();
-      }
-
-
-
-      template <int dim>
-      void
-      Interface<dim>::load (const std::map<std::string, std::string> &status_strings)
-      {
-        const auto saved_state = status_strings.find("ParticleGenerator");
-        if (saved_state != status_strings.end())
-          {
-            std::istringstream is (saved_state->second);
-            is >> random_number_generator;
-            AssertThrow(!is.fail(), ExcMessage("Could not restore the particle generator random number generator."));
-          }
-      }
-
-
-
-      template <int dim>
       std::pair<Particles::internal::LevelInd,Particle<dim>>
       Interface<dim>::generate_particle(const Point<dim> &position,
                                         const types::particle_index id) const


### PR DESCRIPTION
In hindsight, since we are no longer consider the particle generators' random number generator part of its state (see #7278), we also no longer have to serialize/deserialize it. This patch removes the functions that do that, falling back to the default implementation of the functions in the base class (which don't do anything at all).

Part of #6744.

### For all pull requests:

* [ ] I have followed the [instructions for indenting my code](../blob/main/CONTRIBUTING.md#making-aspect-better).
* I followed the [AI Policy](../blob/main/CONTRIBUTING.md#policy-on-usage-of-ai):
  - [ ] Significant parts of this PR were written by AI (please add a sentence below).
  - [ ] AI has not been used in significant ways.

*If yes, please describe your usage of AI models in the creation of this pull request*

### For new features/models or changes of existing features:

* [ ] I have tested my new feature locally to ensure it is correct.
* [ ] I have [created a testcase](https://aspect-documentation.readthedocs.io/en/latest/user/extending/testing/writing-tests.html) for the new feature/benchmark in the [tests/](../blob/main/tests/) directory.
* [ ] I have added a changelog entry in the [doc/modules/changes](../blob/main/doc/modules/changes) directory that will inform other users of my change.
