### PR TITLE
Ease the way to use base interpolation schemes for particle interpolators

### DIFF
--- a/include/aspect/particle/interpolator/interface.h
+++ b/include/aspect/particle/interpolator/interface.h
@@ -113,10 +113,27 @@ namespace aspect
                                       void (*declare_parameters_function) (ParameterHandler &),
                                       std::unique_ptr<Interface<dim>> (*factory_function) ());
 
+
       /**
-       * A function that given the name of a model returns a pointer to an
-       * object that describes it. Ownership of the pointer is transferred to
-       * the caller.
+       * A function that given the name of an interpolation scheme
+       * returns a pointer to an object that describes it.
+       * Ownership of the pointer is transferred to the caller.
+       *
+       * The model object returned is not yet initialized and has not
+       * read its runtime parameters yet.
+       *
+       * @ingroup ParticleInterpolators
+       */
+      template <int dim>
+      std::unique_ptr<Interface<dim>>
+      create_particle_interpolator (const std::string &interpolator_name);
+
+
+      /**
+       * A function that reads the name of an interpolation scheme
+       * from the parameter object and then returns a pointer
+       * to an object that describes it.
+       * Ownership of the pointer is transferred to the caller.
        *
        * The model object returned is not yet initialized and has not
        * read its runtime parameters yet.

--- a/include/aspect/particle/interpolator/interface.h
+++ b/include/aspect/particle/interpolator/interface.h
@@ -84,11 +84,15 @@ namespace aspect
 
 
       /**
-       * Return a list of names (separated by '|') of possible interpolator
-       * classes for particles.
+       * Return a string that consists of the names of interpolator classes
+       * for particles that can be selected.
+       * These names are separated by a vertical line '|' so
+       * that the string can be an input to the deal.II classes
+       * Patterns::Selection or Patterns::MultipleSelection.
        */
+      template <int dim>
       std::string
-      interpolator_object_names ();
+      get_valid_interpolator_names_pattern ();
 
 
       /**

--- a/source/particle/interpolator/interface.cc
+++ b/source/particle/interpolator/interface.cc
@@ -58,18 +58,27 @@ namespace aspect
 
       template <int dim>
       std::unique_ptr<Interface<dim>>
-      create_particle_interpolator (ParameterHandler &prm)
+      create_particle_interpolator (const std::string &interpolator_name)
       {
-        std::string name;
-        name = prm.get ("Interpolation scheme");
-
         // 'bilinear least squares' is the deprecated old name of the 'linear least squares'
         // interpolator. The old name will be removed in the future.
-        if (name == "bilinear least squares")
-          name = "linear least squares";
+        if (interpolator_name == "bilinear least squares")
+          return std::get<dim>(registered_plugins).create_plugin ("linear least squares",
+                                                                  "Particle::Interpolator name");
+        else
+          return std::get<dim>(registered_plugins).create_plugin (interpolator_name,
+                                                                  "Particle::Interpolator name");
+      }
 
-        return std::get<dim>(registered_plugins).create_plugin (name,
-                                                                "Particle::Interpolator name");
+
+
+      template <int dim>
+      std::unique_ptr<Interface<dim>>
+      create_particle_interpolator (ParameterHandler &prm)
+      {
+        const std::string name = prm.get ("Interpolation scheme");
+
+        return create_particle_interpolator<dim> (name);
       }
 
 
@@ -135,6 +144,10 @@ namespace aspect
   template \
   void \
   write_plugin_graph<dim> (std::ostream &); \
+  \
+  template \
+  std::unique_ptr<Interface<dim>> \
+  create_particle_interpolator<dim> (const std::string &interpolator_name); \
   \
   template \
   std::unique_ptr<Interface<dim>> \

--- a/source/particle/interpolator/interface.cc
+++ b/source/particle/interpolator/interface.cc
@@ -82,6 +82,13 @@ namespace aspect
       }
 
 
+      template <int dim>
+      std::string
+      get_valid_interpolator_names_pattern ()
+      {
+        return std::get<dim>(registered_plugins).get_pattern_of_names ();
+      }
+
 
       template <int dim>
       void
@@ -89,7 +96,7 @@ namespace aspect
       {
         // declare the entry in the parameter file
         const std::string pattern_of_names
-          = std::get<dim>(registered_plugins).get_pattern_of_names ();
+          = get_valid_interpolator_names_pattern<dim>();
 
         // 'bilinear least squares' is the deprecated old name of the 'linear least squares'
         // interpolator. The old name will be removed in the future.
@@ -136,6 +143,10 @@ namespace aspect
                                        const std::string &, \
                                        void ( *) (ParameterHandler &), \
                                        std::unique_ptr<Interface<dim>>( *) ()); \
+  \
+  template \
+  std::string \
+  get_valid_interpolator_names_pattern<dim> (); \
   \
   template  \
   void \


### PR DESCRIPTION
I added an overload to aspect::Particle::Interpolator::create_particle_interpolator, which takes an interpolation scheme as a string input. This way one can use the base model functionality that many material models use also for particle interpolators. 

Furthermore i added the function get_valid_interpolator_names similar to get_valid_model_names for Material models. It replaces the already existing function "interpolator_object_names", which was declared but did not have any function definition in the interface.cc file. There was no occurrence in aspect where it was used.

For this i also slightly changed the documentation of the existing create particle interpolator, which said that it would take a model name as input though it actually read the interpolator name from a prm. 

This functionality will be used in a new interpolator for rotations, where only a set of properties will be averaged with a special algorithm and the rest of the properties should be averaged with a fallback interpolator of the users choice. 

### Before your first pull request:

* [x] I have read the guidelines in our [CONTRIBUTING.md](../blob/main/CONTRIBUTING.md) document.

### For all pull requests:

* [x] I have followed the [instructions for indenting my code](../blob/main/CONTRIBUTING.md#making-aspect-better).
* I followed the [AI Policy](../blob/main/CONTRIBUTING.md#policy-on-usage-of-ai):
  - [ ] Significant parts of this PR were written by AI (please add a sentence below).
  - [x] AI has not been used in significant ways.

Only honest copy and paste from the material model interface has been used for this PR. 

### For new features/models or changes of existing features:

* [x] I have tested my new feature locally to ensure it is correct.
* [ ] I have [created a testcase](https://aspect-documentation.readthedocs.io/en/latest/user/extending/testing/writing-tests.html) for the new feature/benchmark in the [tests/](../blob/main/tests/) directory.
* [ ] I have added a changelog entry in the [doc/modules/changes](../blob/main/doc/modules/changes) directory that will inform other users of my change.
