### PR TITLE
fix aspect --validate

### DIFF
--- a/source/main.cc
+++ b/source/main.cc
@@ -598,8 +598,11 @@ namespace
           {
             parse_parameters (input_as_string, prm);
           }
-        catch (...)
+        catch (const std::exception &exc)
           {
+            if (i_am_proc_0)
+              std::cerr << "Validation failed:\n\n" << exc.what() << std::endl;
+
             throw aspect::QuietException();
           }
         if (i_am_proc_0)


### PR DESCRIPTION
A recent change causes --validate to no longer print the exception befor exiting, which made --validate not work for bad .prm files. Fix this by printing the exception message.
