### PR TITLE
Periodic constraints fix

### DIFF
--- a/source/simulator/core.cc
+++ b/source/simulator/core.cc
@@ -1558,17 +1558,11 @@ namespace aspect
     // Reconstruct the constraint-matrix:
     constraints.reinit (dof_handler.locally_owned_dofs(), introspection.index_sets.system_relevant_set);
 
-    // Set up the constraints for periodic boundary conditions:
-
-    // Note: this has to happen _before_ we do hanging node constraints,
-    // because inconsistent constraints could be generated in parallel otherwise.
-    geometry_model->make_periodicity_constraints(dof_handler,
-                                                 constraints);
-
-    //  Make hanging node constraints:
+    //  Make hanging node constraints (for adaptivity) and then periodic constraints:
     DoFTools::make_hanging_node_constraints (dof_handler,
                                              constraints);
-
+    geometry_model->make_periodicity_constraints(dof_handler,
+                                                 constraints);
 
     compute_initial_velocity_boundary_constraints(constraints);
     constraints.close();

--- a/tests/periodic_box_adaptive_amg.prm
+++ b/tests/periodic_box_adaptive_amg.prm
@@ -1,0 +1,76 @@
+# 3d periodic box with hanging nodes. Used to crash with a "cycle in constraints"
+# error.
+
+set Dimension                              = 3
+set End time                               = 0
+set Pressure normalization                 = volume
+set Nonlinear solver scheme                = no Advection, single Stokes
+set Max nonlinear iterations               = 1
+set Use years instead of seconds           = false
+
+subsection Solver parameters
+  subsection Stokes solver parameters
+    set Stokes solver type = block AMG
+    set Number of cheap Stokes solver steps             = 1000
+    set Maximum number of expensive Stokes solver steps = 0
+    set Linear solver tolerance                         = 1e-8
+    set GMRES solver restart length                     = 100
+  end
+
+  subsection Matrix Free
+    set Output details = true
+  end
+end
+
+subsection Discretization
+  set Use locally conservative discretization = false
+end
+
+subsection Geometry model
+  set Model name = box
+
+  subsection Box
+    set X extent = 1
+    set Y extent = 1
+    set Z extent = 1
+    set X periodic = true
+  end
+end
+
+subsection Boundary velocity model
+  set Zero velocity boundary indicators = bottom,top,front,back
+end
+
+subsection Material model
+  set Model name = simpler
+
+  subsection Simpler model
+    set Viscosity = 1
+  end
+end
+
+subsection Gravity model
+  set Model name = vertical
+
+  subsection Vertical
+    set Magnitude = 1
+  end
+end
+
+subsection Initial temperature model
+  set List of model names = function
+end
+
+subsection Mesh refinement
+  set Initial global refinement = 2
+  set Initial adaptive refinement = 1
+  set Adapt by fraction of cells = true
+  set Strategy = velocity
+  set Run postprocessors on initial refinement = true
+  set Coarsening fraction       = 0.0
+  set Refinement fraction       = 0.147
+end
+
+subsection Postprocess
+  set List of postprocessors = visualization
+end

--- a/tests/periodic_box_adaptive_amg/screen-output
+++ b/tests/periodic_box_adaptive_amg/screen-output
@@ -1,0 +1,25 @@
+
+Number of active cells: 64 (on 3 levels)
+Number of degrees of freedom: 3,041 (2,187+125+729)
+
+*** Timestep 0:  t=0 seconds, dt=0 seconds
+   Rebuilding Stokes preconditioner...
+   Solving Stokes system (AMG)... 40+0 iterations.
+
+   Postprocessing:
+     Writing graphical output: output-periodic_box_adaptive_amg/solution/solution-00000
+
+Number of active cells: 127 (on 4 levels)
+Number of degrees of freedom: 6,197 (4,470+237+1,490)
+
+*** Timestep 0:  t=0 seconds, dt=0 seconds
+   Rebuilding Stokes preconditioner...
+   Solving Stokes system (AMG)... 42+0 iterations.
+
+   Postprocessing:
+     Writing graphical output: output-periodic_box_adaptive_amg/solution/solution-00001
+
+Termination requested by criterion: end time
+
+
+

--- a/tests/periodic_box_adaptive_gmggc.prm
+++ b/tests/periodic_box_adaptive_gmggc.prm
@@ -1,0 +1,77 @@
+# 3d periodic box with hanging nodes. Used to crash with a "cycle in constraints"
+# error.
+
+set Dimension                              = 3
+set End time                               = 0
+set Pressure normalization                 = volume
+set Nonlinear solver scheme                = no Advection, single Stokes
+set Max nonlinear iterations               = 1
+set Use years instead of seconds           = false
+
+subsection Solver parameters
+  subsection Stokes solver parameters
+    set Stokes solver type = block GMG
+    set Stokes GMG type = global coarsening
+    set Number of cheap Stokes solver steps             = 1000
+    set Maximum number of expensive Stokes solver steps = 0
+    set Linear solver tolerance                         = 1e-8
+    set GMRES solver restart length                     = 100
+  end
+
+  subsection Matrix Free
+    set Output details = true
+  end
+end
+
+subsection Discretization
+  set Use locally conservative discretization = false
+end
+
+subsection Geometry model
+  set Model name = box
+
+  subsection Box
+    set X extent = 1
+    set Y extent = 1
+    set Z extent = 1
+    set X periodic = true
+  end
+end
+
+subsection Boundary velocity model
+  set Zero velocity boundary indicators = bottom,top,front,back
+end
+
+subsection Material model
+  set Model name = simpler
+
+  subsection Simpler model
+    set Viscosity = 1
+  end
+end
+
+subsection Gravity model
+  set Model name = vertical
+
+  subsection Vertical
+    set Magnitude = 1
+  end
+end
+
+subsection Initial temperature model
+  set List of model names = function
+end
+
+subsection Mesh refinement
+  set Initial global refinement = 2
+  set Initial adaptive refinement = 1
+  set Adapt by fraction of cells = true
+  set Strategy = velocity
+  set Run postprocessors on initial refinement = true
+  set Coarsening fraction       = 0.0
+  set Refinement fraction       = 0.147
+end
+
+subsection Postprocess
+  set List of postprocessors = visualization
+end

--- a/tests/periodic_box_adaptive_gmggc/screen-output
+++ b/tests/periodic_box_adaptive_gmggc/screen-output
@@ -1,0 +1,35 @@
+
+Number of active cells: 64 (on 3 levels)
+Number of degrees of freedom: 3,041 (2,187+125+729)
+
+*** Timestep 0:  t=0 seconds, dt=0 seconds
+   Solving Stokes system (GMG-GC)... 
+     GMG coarse size A: 81, coarse size S: 8
+     GMG levels: 3
+     Viscosity range: 1 - 1
+     Stokes solver (GMRES): 17+0 iterations.
+     Schur complement preconditioner: 18+0 iterations.
+     A block preconditioner: 18+0 iterations.
+
+   Postprocessing:
+     Writing graphical output: output-periodic_box_adaptive_gmggc/solution/solution-00000
+
+Number of active cells: 127 (on 4 levels)
+Number of degrees of freedom: 6,197 (4,470+237+1,490)
+
+*** Timestep 0:  t=0 seconds, dt=0 seconds
+   Solving Stokes system (GMG-GC)... 
+     GMG coarse size A: 81, coarse size S: 8
+     GMG levels: 4
+     Viscosity range: 1 - 1
+     Stokes solver (GMRES): 18+0 iterations.
+     Schur complement preconditioner: 19+0 iterations.
+     A block preconditioner: 19+0 iterations.
+
+   Postprocessing:
+     Writing graphical output: output-periodic_box_adaptive_gmggc/solution/solution-00001
+
+Termination requested by criterion: end time
+
+
+


### PR DESCRIPTION
This fixes a crash with a "cycle in constraints detected" based on the ordering the constraints that are applied if you have hanging nodes and periodic boundaries. In contrast to the old comment in ASPECT, deal.II recommends the new ordering of the two functions since 2018:
"it is recommended to call this function prior to other functions that constrain DoFs with respect to others such as [make_periodicity_constraints()](https://dealii.org/developer/doxygen/deal.II/namespaceDoFTools.html#af2bdda829a7d9eb27bf5d1ff171d0eae)." see https://dealii.org/developer/doxygen/deal.II/group__constraints.html#ga3b4ea7dfd313e388d868c4e4aa685799 and step-45.