### PR TITLE
Remove unused header includes

### DIFF
--- a/include/aspect/simulator/solver/stokes_matrix_free.h
+++ b/include/aspect/simulator/solver/stokes_matrix_free.h
@@ -21,16 +21,9 @@
 #ifndef _aspect_simulator_solver_stokes_matrix_free_h
 #define _aspect_simulator_solver_stokes_matrix_free_h
 
-#include <aspect/simulator/solver/matrix_free_operators.h>
 #include <aspect/global.h>
 #include <aspect/parameters.h>
 #include <aspect/simulator/solver/interface.h>
-#include <aspect/utilities.h>
-
-#include <deal.II/multigrid/mg_transfer_matrix_free.h>
-#include <deal.II/multigrid/mg_transfer_global_coarsening.templates.h>
-
-#include <deal.II/lac/solver_bicgstab.h>
 
 namespace aspect
 {

--- a/source/simulator/solver.cc
+++ b/source/simulator/solver.cc
@@ -22,18 +22,11 @@
 #include <aspect/simulator.h>
 #include <aspect/global.h>
 #include <aspect/melt.h>
-#include <aspect/simulator/solver/block_stokes_preconditioner.h>
 #include <aspect/simulator/solver/stokes_matrix_based.h>
 #include <aspect/simulator/solver/stokes_matrix_free.h>
 #include <aspect/simulator/solver/stokes_direct.h>
-#include <aspect/mesh_deformation/interface.h>
 
-#include <deal.II/base/signaling_nan.h>
 #include <deal.II/lac/solver_gmres.h>
-#include <deal.II/lac/solver_bicgstab.h>
-#include <deal.II/lac/solver_cg.h>
-#include <deal.II/fe/fe_values.h>
-#include <deal.II/lac/trilinos_vector.h>
 
 namespace aspect
 {

--- a/source/simulator/solver/matrix_free_operators.cc
+++ b/source/simulator/solver/matrix_free_operators.cc
@@ -39,11 +39,7 @@
 #include <deal.II/fe/fe_dgq.h>
 #include <deal.II/fe/fe_values.h>
 
-#include <deal.II/lac/solver_gmres.h>
 #include <deal.II/lac/read_write_vector.templates.h>
-#include <deal.II/lac/solver_idr.h>
-#include <deal.II/lac/solver_cg.h>
-#include <deal.II/lac/solver_bicgstab.h>
 
 #include <deal.II/grid/manifold.h>
 

--- a/source/simulator/solver/stokes_matrix_based.cc
+++ b/source/simulator/solver/stokes_matrix_based.cc
@@ -24,7 +24,6 @@
 #include <aspect/global.h>
 #include <aspect/simulator/solver/block_stokes_preconditioner.h>
 
-#include <deal.II/base/signaling_nan.h>
 #include <deal.II/lac/solver_gmres.h>
 #include <deal.II/lac/solver_cg.h>
 

--- a/source/simulator/solver/stokes_matrix_free_global_coarsening.cc
+++ b/source/simulator/solver/stokes_matrix_free_global_coarsening.cc
@@ -23,11 +23,8 @@
 #include <aspect/simulator/solver/stokes_matrix_free.h>
 #include <aspect/simulator/solver/stokes_matrix_free_global_coarsening.h>
 #include <aspect/simulator/solver/block_stokes_preconditioner.h>
-#include <aspect/mesh_deformation/interface.h>
 
 #include <aspect/mesh_deformation/interface.h>
-#include <aspect/mesh_deformation/free_surface.h>
-#include <aspect/melt.h>
 #include <aspect/newton.h>
 
 #include <deal.II/fe/mapping_q.h>
@@ -36,10 +33,7 @@
 
 #include <deal.II/matrix_free/tools.h>
 #include <deal.II/lac/solver_gmres.h>
-#include <deal.II/lac/read_write_vector.templates.h>
 #include <deal.II/lac/solver_idr.h>
-#include <deal.II/lac/solver_cg.h>
-#include <deal.II/lac/solver_bicgstab.h>
 #include <deal.II/lac/precondition.h>
 #include <deal.II/dofs/dof_tools.h>
 #include <deal.II/dofs/dof_handler.h>

--- a/source/simulator/solver/stokes_matrix_free_local_smoothing.cc
+++ b/source/simulator/solver/stokes_matrix_free_local_smoothing.cc
@@ -27,7 +27,6 @@
 
 #include <aspect/mesh_deformation/interface.h>
 #include <aspect/mesh_deformation/free_surface.h>
-#include <aspect/melt.h>
 #include <aspect/newton.h>
 
 #include <deal.II/base/template_constraints.h>
@@ -35,10 +34,7 @@
 
 #include <deal.II/matrix_free/tools.h>
 #include <deal.II/lac/solver_gmres.h>
-#include <deal.II/lac/read_write_vector.templates.h>
 #include <deal.II/lac/solver_idr.h>
-#include <deal.II/lac/solver_cg.h>
-#include <deal.II/lac/solver_bicgstab.h>
 #include <deal.II/lac/precondition.h>
 #include <deal.II/dofs/dof_tools.h>
 #include <deal.II/dofs/dof_handler.h>


### PR DESCRIPTION
Small follow-up to #7307 removing a lot of unused include directives. I tested that everything still compiles when not precompiling header files and in a no-unity build.