### PR TITLE
Use Stokes solver interface class

### DIFF
--- a/include/aspect/simulator.h
+++ b/include/aspect/simulator.h
@@ -97,6 +97,9 @@ namespace aspect
   namespace StokesSolver
   {
     template <int dim>
+    class Interface;
+
+    template <int dim>
     class Direct;
 
     template <int dim>
@@ -1653,6 +1656,17 @@ namespace aspect
       stokes_A_block_is_symmetric () const;
 
       /**
+       * Return whether the Stokes solver is a matrix-free solver. A lot of
+       * assembly operations work differently depending on whether a matrix
+       * needs to be assembled or not.
+       *
+       * This function is implemented in
+       * <code>source/simulator/helper_functions.cc</code>.
+       */
+      bool
+      is_stokes_matrix_free() const;
+
+      /**
        * This function checks that the user-selected formulations of the
        * equations are consistent with the other inputs. If an incorrect
        * selection is detected it throws an exception. It for example assures that
@@ -2134,20 +2148,9 @@ namespace aspect
       std::unique_ptr<MeshDeformation::MeshDeformationHandler<dim>> mesh_deformation;
 
       /**
-       * Unique pointer for the matrix-free Stokes solver
+       * Unique pointer to the Stokes solver
        */
-      std::unique_ptr<StokesMatrixFreeHandler<dim>> stokes_matrix_free;
-
-      /**
-       * Unique pointer for the matrix-based Stokes solver
-       */
-      std::unique_ptr<StokesSolver::MatrixBased<dim>> stokes_matrix_based;
-
-      /**
-       * Unique pointer for the direct Stokes solver
-       */
-      std::unique_ptr<StokesSolver::Direct<dim>> stokes_direct;
-
+      std::unique_ptr<StokesSolver::Interface<dim>> stokes_solver;
 
       friend class boost::serialization::access;
       friend class SimulatorAccess<dim>;

--- a/include/aspect/simulator_access.h
+++ b/include/aspect/simulator_access.h
@@ -152,6 +152,11 @@ namespace aspect
     template <int dim> class Manager;
   }
 
+  namespace StokesSolver
+  {
+    template <int dim> class Interface;
+  }
+
   namespace TimeStepping
   {
     template <int dim> class Manager;
@@ -1038,7 +1043,7 @@ namespace aspect
       /**
        * Return true if using the block GMG Stokes solver.
        */
-      bool is_stokes_matrix_free();
+      bool is_stokes_matrix_free() const;
 
       /**
        * Return a reference to the StokesMatrixFreeHandler that controls the
@@ -1046,6 +1051,12 @@ namespace aspect
        */
       const StokesMatrixFreeHandler<dim> &
       get_stokes_matrix_free () const;
+
+      /**
+       * Return a reference to the active Stokes solver.
+       */
+      const StokesSolver::Interface<dim> &
+      get_stokes_solver () const;
 
       /**
        * Return a reference to the PrescribedSolution::Manager that manages the

--- a/source/simulator/assembly.cc
+++ b/source/simulator/assembly.cc
@@ -381,7 +381,7 @@ namespace aspect
   void
   Simulator<dim>::assemble_stokes_preconditioner ()
   {
-    if (stokes_matrix_free)
+    if (is_stokes_matrix_free())
       return;
 
     system_preconditioner_matrix = 0;
@@ -764,7 +764,7 @@ namespace aspect
 
     if (assemble_newton_stokes_system)
       {
-        if (!assemble_newton_stokes_matrix && !stokes_matrix_free)
+        if (!assemble_newton_stokes_matrix && !is_stokes_matrix_free())
           timer_section_name += " rhs";
         else if (assemble_newton_stokes_matrix && newton_handler->parameters.newton_derivative_scaling_factor == 0)
           timer_section_name += " Picard";
@@ -772,7 +772,7 @@ namespace aspect
           timer_section_name += " Newton";
       }
 
-    if (stokes_matrix_free)
+    if (is_stokes_matrix_free())
       {
         rebuild_stokes_matrix = false;
         assemble_newton_stokes_matrix = false;
@@ -793,7 +793,7 @@ namespace aspect
     // Note that for Dirichlet boundary conditions in matrix-free computations,
     // we will update the right-hand side with boundary information in
     // StokesMatrixFreeHandler::correct_stokes_rhs().
-    if (!stokes_matrix_free)
+    if (!is_stokes_matrix_free())
       Assert(rebuild_stokes_matrix || boundary_velocity_manager.get_prescribed_boundary_velocity_indicators().empty(),
              ExcInternalError("If we have inhomogeneous constraints, we must re-assemble the system matrix."));
 
@@ -885,8 +885,8 @@ namespace aspect
     system_rhs.compress(VectorOperation::add);
 
     // If we change the system_rhs, matrix-free Stokes must update
-    if (stokes_matrix_free)
-      stokes_matrix_free->assemble();
+    if (is_stokes_matrix_free())
+      dynamic_cast<StokesMatrixFreeHandler<dim>*>(stokes_solver.get())->assemble();
 
     // if the model is compressible then we need to adjust the right hand
     // side of the equation to make it compatible with the matrix on the

--- a/source/simulator/core.cc
+++ b/source/simulator/core.cc
@@ -461,26 +461,15 @@ namespace aspect
     select_default_solver_and_averaging();
 
     if (parameters.stokes_solver_type == Parameters<dim>::StokesSolverType::block_gmg)
-      {
-        stokes_matrix_free = create_matrix_free_solver<dim>(*this, parameters);
-        stokes_matrix_free->initialize_simulator(*this);
-        stokes_matrix_free->parse_parameters(prm);
-        stokes_matrix_free->initialize();
-      }
+      stokes_solver = create_matrix_free_solver<dim>(*this, parameters);
     else if (parameters.stokes_solver_type == Parameters<dim>::StokesSolverType::direct_solver)
-      {
-        stokes_direct = std::make_unique<StokesSolver::Direct<dim>>();
-        stokes_direct->initialize_simulator(*this);
-        stokes_direct->parse_parameters(prm);
-        stokes_direct->initialize();
-      }
+      stokes_solver = std::make_unique<StokesSolver::Direct<dim>>();
     else
-      {
-        stokes_matrix_based = std::make_unique<StokesSolver::MatrixBased<dim>>(*this);
-        stokes_matrix_based->initialize_simulator(*this);
-        stokes_matrix_based->parse_parameters(prm);
-        stokes_matrix_based->initialize();
-      }
+      stokes_solver = std::make_unique<StokesSolver::MatrixBased<dim>>(*this);
+
+    stokes_solver->initialize_simulator(*this);
+    stokes_solver->parse_parameters(prm);
+    stokes_solver->initialize();
 
     postprocess_manager.initialize_simulator (*this);
     postprocess_manager.parse_parameters (prm);
@@ -1015,10 +1004,10 @@ namespace aspect
     if (solver_scheme_solves_stokes_equations(parameters))
       {
         // The matrix-free solver does not work with melt transport
-        Assert(!(parameters.include_melt_transport && stokes_matrix_free),
+        Assert(!(parameters.include_melt_transport && is_stokes_matrix_free()),
                ExcNotImplemented());
 
-        if (stokes_matrix_free)
+        if (is_stokes_matrix_free())
           {
             // nothing couples in the matrix free solver
           }
@@ -1594,8 +1583,8 @@ namespace aspect
     rebuild_stokes_preconditioner = true;
 
     // Setup matrix-free dofs
-    if (stokes_matrix_free)
-      stokes_matrix_free->setup_dofs();
+    if (is_stokes_matrix_free())
+      dynamic_cast<StokesMatrixFreeHandler<dim>*>(stokes_solver.get())->setup_dofs();
 
     computing_timer.leave_subsection("Setup dof systems");
   }
@@ -2005,8 +1994,8 @@ namespace aspect
         compute_current_constraints ();
 
         // GMG boundary conditions are currently handled as part of setup_dofs()
-        if (stokes_matrix_free)
-          stokes_matrix_free->setup_dofs();
+        if (is_stokes_matrix_free())
+          dynamic_cast<StokesMatrixFreeHandler<dim>*>(stokes_solver.get())->setup_dofs();
 
         // if compute_current_constraints() changed which DoFs are constrained,
         // we need to rebuild the system matrices
@@ -2434,8 +2423,6 @@ namespace aspect
     pcout << resource_output.str();
 
     CitationInfo::print_info_block (pcout);
-
-    stokes_matrix_free.reset();
   }
 }
 

--- a/source/simulator/helper_functions.cc
+++ b/source/simulator/helper_functions.cc
@@ -39,6 +39,7 @@
 #include <aspect/postprocess/visualization.h>
 #include <aspect/prescribed_solution/interface.h>
 #include <aspect/prescribed_stokes_solution/interface.h>
+#include <aspect/simulator/solver/stokes_matrix_free.h>
 
 #include <deal.II/base/index_set.h>
 #include <deal.II/base/conditional_ostream.h>
@@ -1296,6 +1297,15 @@ namespace aspect
       return false;
     else
       return true;
+  }
+
+
+
+  template <int dim>
+  bool
+  Simulator<dim>::is_stokes_matrix_free() const
+  {
+    return dynamic_cast<StokesMatrixFreeHandler<dim>*>(stokes_solver.get()) != nullptr;
   }
 
 
@@ -2886,6 +2896,7 @@ namespace aspect
   template double Simulator<dim>::compute_initial_stokes_residual(); \
   template bool Simulator<dim>::stokes_matrix_depends_on_solution() const; \
   template bool Simulator<dim>::stokes_A_block_is_symmetric() const; \
+  template bool Simulator<dim>::is_stokes_matrix_free() const; \
   template void Simulator<dim>::interpolate_onto_velocity_system(const TensorFunction<1,dim> &func, LinearAlgebra::Vector &vec) const;\
   template void Simulator<dim>::apply_limiter_to_dg_solutions(const AdvectionField &advection_field); \
   template void Simulator<dim>::compute_unique_advection_support_points(const std::vector<AdvectionField> &advection_fields, \

--- a/source/simulator/simulator_access.cc
+++ b/source/simulator/simulator_access.cc
@@ -23,6 +23,7 @@
 #include <aspect/advection_field.h>
 #include <aspect/mesh_deformation/free_surface.h>
 #include <aspect/mesh_deformation/interface.h>
+#include <aspect/simulator/solver/stokes_matrix_free.h>
 #include <aspect/particle/manager.h>
 
 namespace WorldBuilder
@@ -910,9 +911,9 @@ namespace aspect
 
 
   template <int dim>
-  bool SimulatorAccess<dim>::is_stokes_matrix_free()
+  bool SimulatorAccess<dim>::is_stokes_matrix_free() const
   {
-    return (simulator->stokes_matrix_free ? true : false);
+    return simulator->is_stokes_matrix_free();
   }
 
 
@@ -921,9 +922,18 @@ namespace aspect
   const StokesMatrixFreeHandler<dim> &
   SimulatorAccess<dim>::get_stokes_matrix_free () const
   {
-    Assert (simulator->stokes_matrix_free.get() != nullptr,
+    Assert (simulator->is_stokes_matrix_free(),
             ExcMessage("You can not call this function if the matrix-free Stokes solver is not used."));
-    return *(simulator->stokes_matrix_free);
+    return *dynamic_cast<StokesMatrixFreeHandler<dim>*>(simulator->stokes_solver.get());
+  }
+
+
+
+  template <int dim>
+  const StokesSolver::Interface<dim> &
+  SimulatorAccess<dim>::get_stokes_solver () const
+  {
+    return *(simulator->stokes_solver.get());
   }
 
 

--- a/source/simulator/solver.cc
+++ b/source/simulator/solver.cc
@@ -22,9 +22,7 @@
 #include <aspect/simulator.h>
 #include <aspect/global.h>
 #include <aspect/melt.h>
-#include <aspect/simulator/solver/stokes_matrix_based.h>
-#include <aspect/simulator/solver/stokes_matrix_free.h>
-#include <aspect/simulator/solver/stokes_direct.h>
+#include <aspect/simulator/solver/interface.h>
 
 #include <deal.II/lac/solver_gmres.h>
 
@@ -211,44 +209,15 @@ namespace aspect
   {
     computing_timer.enter_subsection("Solve Stokes system");
 
-    const std::string name = [&]() -> std::string
-    {
-      if (parameters.stokes_solver_type == Parameters<dim>::StokesSolverType::block_gmg)
-        return stokes_matrix_free->name();
-      if (parameters.use_direct_stokes_solver)
-        return stokes_direct->name();
-
-      return stokes_matrix_based->name();
-    }();
-
-    pcout << "   Solving Stokes system (" << name << ")... " << std::flush;
+    pcout << "   Solving Stokes system (" << stokes_solver->name() << ")... " << std::flush;
 
     StokesSolver::SolverOutputs outputs;
 
-    if (parameters.stokes_solver_type == Parameters<dim>::StokesSolverType::block_gmg)
-      {
-        outputs = stokes_matrix_free->solve(system_matrix,
-                                            system_rhs,
-                                            assemble_newton_stokes_system,
-                                            last_pressure_normalization_adjustment,
-                                            solution_vector);
-      }
-    else if (parameters.use_direct_stokes_solver)
-      {
-        outputs = stokes_direct->solve(system_matrix,
-                                       system_rhs,
-                                       assemble_newton_stokes_system,
-                                       last_pressure_normalization_adjustment,
-                                       solution_vector);
-      }
-    else
-      {
-        outputs = stokes_matrix_based->solve(system_matrix,
-                                             system_rhs,
-                                             assemble_newton_stokes_system,
-                                             last_pressure_normalization_adjustment,
-                                             solution_vector);
-      }
+    outputs = stokes_solver->solve(system_matrix,
+                                   system_rhs,
+                                   assemble_newton_stokes_system,
+                                   last_pressure_normalization_adjustment,
+                                   solution_vector);
 
     last_pressure_normalization_adjustment = outputs.pressure_normalization_adjustment;
 

--- a/source/simulator/solver_schemes.cc
+++ b/source/simulator/solver_schemes.cc
@@ -507,8 +507,8 @@ namespace aspect
     assemble_stokes_system ();
 
     // build the preconditioner
-    if (stokes_matrix_free)
-      stokes_matrix_free->build_preconditioner();
+    if (is_stokes_matrix_free())
+      dynamic_cast<StokesMatrixFreeHandler<dim>*>(stokes_solver.get())->build_preconditioner();
     else
       build_stokes_preconditioner();
 
@@ -596,8 +596,8 @@ namespace aspect
     // build the preconditioner
     auto build_preconditioner = [&]()
     {
-      if (stokes_matrix_free)
-        stokes_matrix_free->build_preconditioner();
+      if (is_stokes_matrix_free())
+        dynamic_cast<StokesMatrixFreeHandler<dim>*>(stokes_solver.get())->build_preconditioner();
       else
         build_stokes_preconditioner();
     };


### PR DESCRIPTION
A small extension to #7307 (and building on #7310 at the moment).

Now that all Stokes solvers have their own classes, we can let Simulator only store a single pointer to the base solver class. This simplifies management of the different solvers.