### PR TITLE
Relax reaction progress tolerance by default (1e20)

### DIFF
--- a/include/aspect/material_model/reaction_model/reaction_chain.h
+++ b/include/aspect/material_model/reaction_model/reaction_chain.h
@@ -79,8 +79,7 @@ namespace aspect
           std::vector<std::shared_ptr<Cahn1956Interface<dim>>> kinetics_models;
 
           /**
-           * Allowed excursion/slack before a reaction progress value is considered unphysical or violates monotonicity ordering.
-           * Accepts values between [0, 1)
+           * Allowed excursion/slack before a reaction progress value is considered too extreme for a given timestep.
            */
           double tolerance_in_reaction_progress;
       };

--- a/source/material_model/reaction_model/reaction_chain.cc
+++ b/source/material_model/reaction_model/reaction_chain.cc
@@ -54,24 +54,25 @@ namespace aspect
                     ExcMessage("Size of 'reaction_progress_values' (" + std::to_string(reaction_progress_values.size()) +
                                ") does not match number of reactions (" + std::to_string(reactions.size()) + ")."));
 
-        // Sanity check: reaction progress values should be close to [0, 1]
         for (unsigned int i = 0; i < reaction_progress_values.size(); ++i)
           {
             const double val = reaction_progress_values[i];
 
+            // Check: reaction progress values should be finite
             AssertThrow(std::isfinite(val),
                         ExcMessage("'reaction_progress_values[" + std::to_string(i) + "]' = " + std::to_string(val) +
                                    " is not finite (NaN or Inf)."));
 
+            // Check: reaction progress values should be close to [0, 1] within tolerance
             AssertThrow(val > -tolerance_in_reaction_progress && val < 1.0 + tolerance_in_reaction_progress,
                         ExcMessage("'reaction_progress_values[" + std::to_string(i) + "]' = " + std::to_string(val) +
                                    " is too far outside the physical range [0, 1] (allowed excursion is " +
                                    std::to_string(tolerance_in_reaction_progress) + ")."));
           }
 
-        // Sanity check: reaction progress values should be close to monotonic
+        // Check: reaction progress values should be close to monotonic within tolerance
         for (unsigned int i = 1; i < reaction_progress_values.size(); ++i)
-          AssertThrow(reaction_progress_values[i] < reaction_progress_values[i-1] + tolerance_in_reaction_progress,
+          AssertThrow(reaction_progress_values[i] <= reaction_progress_values[i-1] + tolerance_in_reaction_progress,
                       ExcMessage("'reaction_progress_values[" + std::to_string(i) + "]' = " +
                                  std::to_string(reaction_progress_values[i]) + " exceeds "
                                  "'reaction_progress_values[" + std::to_string(i-1) + "]' = " +
@@ -121,7 +122,7 @@ namespace aspect
           volume_fraction_values[i] = std::max(0.0, reaction_progress_values_clamped[i-1] - reaction_progress_values_clamped[i]);
         volume_fraction_values.back() = std::max(0.0, reaction_progress_values_clamped.back());
 
-        // Sanity check: by construction these should sum to 1 and be non-negative
+        // Check: by construction these should sum to 1 and be non-negative
         const double volume_fraction_sum = std::accumulate(volume_fraction_values.begin(), volume_fraction_values.end(), 0.0);
         AssertThrow(std::abs(volume_fraction_sum - 1.0) < 1e-10,
                     ExcMessage("Computed phase volume fractions sum to " + std::to_string(volume_fraction_sum) + " instead of 1."));
@@ -169,9 +170,9 @@ namespace aspect
                             "sets the number of reactions N, which must equal the number of compositional fields tracking reaction progress.");
 
           prm.declare_entry("Tolerance in reaction progress",
-                            "0.1",
+                            "1e20",
                             Patterns::Double(0.0),
-                            "Allowed excursion before a reaction progress value outside [0, 1] is considered unphysical.");
+                            "Allowed excursion before a reaction progress value outside [0, 1] is considered too extreme for a given timestep.");
 
           // One subsection per registered kinetics model (not per reaction).
           ReactionModelPluginList<dim>::declare_parameters(prm);
@@ -186,10 +187,6 @@ namespace aspect
         prm.enter_subsection("Reaction chain");
         {
           tolerance_in_reaction_progress = prm.get_double("Tolerance in reaction progress");
-
-          AssertThrow(tolerance_in_reaction_progress >= 0.0 && tolerance_in_reaction_progress < 1.0,
-                      ExcMessage("The 'Tolerance in reaction progress' must be between [0, 1), "
-                                 "but was set to " + std::to_string(tolerance_in_reaction_progress) + "."));
 
           const std::vector<std::string> kinetic_model_names = Utilities::split_string_list(prm.get("Kinetic models"), '|');
           const unsigned int n_reactions = kinetic_model_names.size();

--- a/unit_tests/reaction_model_kinetics.cc
+++ b/unit_tests/reaction_model_kinetics.cc
@@ -225,7 +225,6 @@ TEST_CASE("Reaction Chain Processing")
   prm.enter_subsection("Reaction chain");
   {
     prm.set("Kinetic models", "Interface controlled growth|Eutectoid decomposition|Interface controlled growth");
-    prm.set("Tolerance in reaction progress", "0.05");
 
     prm.enter_subsection("Interface controlled growth");
     {
@@ -246,24 +245,54 @@ TEST_CASE("Reaction Chain Processing")
 
   reaction_chain.parse_parameters(prm);
 
-  SECTION("Clamping cumulative reaction progress within custom tolerance")
+  SECTION("Clamping cumulative reaction progress to physical range")
   {
-    const std::vector<double> xi_raw = {1.04, 0.85, -0.04};
-    const std::vector<double> xi_clamped = reaction_chain.clamp_cumulative_progress(xi_raw);
-
-    const std::vector<double> expected = {1.0, 0.85, 0.0};
-    compare_vectors_approx(xi_clamped, expected);
+    compare_vectors_approx(reaction_chain.clamp_cumulative_progress({1.04, 0.85, -0.04}), {1.0, 0.85, 0.0});
   }
 
-  SECTION("Clamping throws on non-physical bounds exceeding tolerance")
+  SECTION("Without strict tolerance, out-of-range and non-monotonic values are clamped")
   {
-    CHECK_THROWS_AS(reaction_chain.clamp_cumulative_progress({1.06, 0.5, 0.1}), dealii::ExceptionBase);
-    CHECK_THROWS_AS(reaction_chain.clamp_cumulative_progress({0.8, 0.5, -0.06}), dealii::ExceptionBase);
+    // Values below 0 (reverse reaction completed) or above 1 (forward reaction completed) are clamped to [0, 1]
+    compare_vectors_approx(reaction_chain.clamp_cumulative_progress({1.06, 0.5, 0.1}), {1.0, 0.5, 0.1});
+    compare_vectors_approx(reaction_chain.clamp_cumulative_progress({0.8, 0.5, -0.06}), {0.8, 0.5, 0.0});
+
+    // Non-monotonic values are clamped to enforce xi[i] <= xi[i-1]
+    compare_vectors_approx(reaction_chain.clamp_cumulative_progress({0.80, 0.87, 0.1}), {0.80, 0.80, 0.1});
   }
 
-  SECTION("Clamping throws on non-monotonic values exceeding tolerance")
+  SECTION("With strict tolerance, out-of-range and non-monotonic values throw")
   {
-    CHECK_THROWS_AS(reaction_chain.clamp_cumulative_progress({0.80, 0.87, 0.1}), dealii::ExceptionBase);
+    dealii::ParameterHandler strict_prm;
+    ReactionChain<2> strict_reaction_chain;
+    ReactionChain<2>::declare_parameters(strict_prm);
+
+    strict_prm.enter_subsection("Reaction chain");
+    {
+      strict_prm.set("Kinetic models", "Interface controlled growth|Eutectoid decomposition|Interface controlled growth");
+      strict_prm.set("Tolerance in reaction progress", "0.05");
+
+      strict_prm.enter_subsection("Interface controlled growth");
+      {
+        strict_prm.set("Kinetic prefactors", "7.0e7|7.0e7");
+        strict_prm.set("Activation enthalpies", "274e3|274e3");
+        strict_prm.set("Activation volumes", "3.3e-6|3.3e-6");
+      }
+      strict_prm.leave_subsection();
+
+      strict_prm.enter_subsection("Eutectoid decomposition");
+      {
+        strict_prm.set("Kinetic prefactors", "2.7e-16");
+        strict_prm.set("Activation energies", "355e3");
+      }
+      strict_prm.leave_subsection();
+    }
+    strict_prm.leave_subsection();
+
+    strict_reaction_chain.parse_parameters(strict_prm);
+
+    CHECK_THROWS_AS(strict_reaction_chain.clamp_cumulative_progress({1.06, 0.5, 0.1}), dealii::ExceptionBase);
+    CHECK_THROWS_AS(strict_reaction_chain.clamp_cumulative_progress({0.8, 0.5, -0.06}), dealii::ExceptionBase);
+    CHECK_THROWS_AS(strict_reaction_chain.clamp_cumulative_progress({0.80, 0.87, 0.1}), dealii::ExceptionBase);
   }
 
   SECTION("Clamping throws on NaN or Inf input")
@@ -427,23 +456,5 @@ TEST_CASE("Reaction Chain Kinetic Models Parsing")
     prm.leave_subsection();
 
     CHECK(parsed_default == "Interface controlled growth");
-  }
-
-  SECTION("Parsing throws on invalid 'Tolerance in reaction progress'")
-  {
-    SECTION("Tolerance >= 1.0 throws")
-    {
-      dealii::ParameterHandler prm;
-      ReactionChain<2> reaction_chain;
-      ReactionChain<2>::declare_parameters(prm);
-
-      prm.enter_subsection("Reaction chain");
-      {
-        prm.set("Tolerance in reaction progress", "1.0");
-      }
-      prm.leave_subsection();
-
-      CHECK_THROWS_AS(reaction_chain.parse_parameters(prm), dealii::ExceptionBase);
-    }
   }
 }


### PR DESCRIPTION
Pull Request Checklist. Please read and check each box with an X. Delete any part not applicable. Ask on the [forum](https://community.geodynamics.org/c/aspect) if you need help with any step.

*Describe what you did in this PR and why you did it.*

### Before your first pull request:

* [X] I have read the guidelines in our [CONTRIBUTING.md](../blob/main/CONTRIBUTING.md) document.

### For all pull requests:

* [X] I have followed the [instructions for indenting my code](../blob/main/CONTRIBUTING.md#making-aspect-better).
* I followed the [AI Policy](../blob/main/CONTRIBUTING.md#policy-on-usage-of-ai):
  - [X] Significant parts of this PR were written by AI (please add a sentence below).
  - [ ] AI has not been used in significant ways.

*If yes, please describe your usage of AI models in the creation of this pull request*

I used a coding agent (mainly DeepSeek V4 Flash) to explore and test possible solutions to this issue. I ran initial tests to generate output, described the issue, and guided the agent as it isolated the root cause. I asked for possible fixes and chose the recommended solution, which it presented as the "cleanest" fix.

## Summary

This PR relaxes the constraint on the reaction progress field in `material_model/reaction_model/reaction_chain.{h,cc}`. The previous constraint was too strict, causing models to immediately crash during initialization or after a few timesteps. Unit tests are revised/added to test expected behavior.

The underlying problem of numerical overshoots/undershoots of reaction progress fields is documented in issue #7287. This PR combined with PR https://github.com/buchanankerswell/aspect/pull/1 should close issue #7287.

