### PR TITLE
Reduce usage of simulator pointer in solver classes

### DIFF
--- a/include/aspect/simulator.h
+++ b/include/aspect/simulator.h
@@ -2159,7 +2159,6 @@ namespace aspect
       friend class StokesMatrixFreeHandler<dim>;
       friend class StokesSolver::MatrixBased<dim>;
       template <int dimension, int velocity_degree> friend class StokesMatrixFreeHandlerLocalSmoothingImplementation;
-      template <int dimension, int velocity_degree> friend class StokesMatrixFreeHandlerGlobalCoarseningImplementation;
       friend struct Parameters<dim>;
   };
 }

--- a/include/aspect/simulator/solver/stokes_matrix_free.h
+++ b/include/aspect/simulator/solver/stokes_matrix_free.h
@@ -53,7 +53,7 @@ namespace aspect
        * model and storing the information necessary for a later call
        * to solve().
        */
-      virtual void assemble()=0;
+      virtual void assemble(LinearAlgebra::BlockVector &system_rhs)=0;
 
       /**
        * Computes and sets the diagonal for both the mass matrix

--- a/include/aspect/simulator/solver/stokes_matrix_free.h
+++ b/include/aspect/simulator/solver/stokes_matrix_free.h
@@ -51,7 +51,8 @@ namespace aspect
        * for. Note that we are not assembling a matrix (as this is a
        * matrix-free algorithm), but we are evaluating the material
        * model and storing the information necessary for a later call
-       * to solve().
+       * to solve(). The function can modify @p system_rhs to account
+       * for boundary conditions as is necessary for matrix-free methods.
        */
       virtual void assemble(LinearAlgebra::BlockVector &system_rhs)=0;
 

--- a/include/aspect/simulator/solver/stokes_matrix_free_global_coarsening.h
+++ b/include/aspect/simulator/solver/stokes_matrix_free_global_coarsening.h
@@ -117,7 +117,8 @@ namespace aspect
        * for. Note that we are not assembling a matrix (as this is a
        * matrix-free algorithm), but we are evaluating the material
        * model and storing the information necessary for a later call
-       * to solve().
+       * to solve(). The function can modify @p system_rhs to account
+       * for boundary conditions as is necessary for matrix-free methods.
        */
       void assemble(LinearAlgebra::BlockVector &system_rhs) override;
 

--- a/include/aspect/simulator/solver/stokes_matrix_free_global_coarsening.h
+++ b/include/aspect/simulator/solver/stokes_matrix_free_global_coarsening.h
@@ -119,7 +119,7 @@ namespace aspect
        * model and storing the information necessary for a later call
        * to solve().
        */
-      void assemble() override;
+      void assemble(LinearAlgebra::BlockVector &system_rhs) override;
 
       /**
        * Computes and sets the diagonal for both the mass matrix operator and the A-block
@@ -171,11 +171,11 @@ namespace aspect
        * Add correction to system RHS for non-zero boundary condition. See description in
        * StokesMatrixFreeHandler::correct_stokes_rhs() for more information.
        */
-      void correct_stokes_rhs();
+      void correct_stokes_rhs(LinearAlgebra::BlockVector &system_rhs);
 
-
-      Simulator<dim> &sim;
-
+      /**
+       * Print detailed debug information about the GMG solver.
+       */
       bool print_details;
 
       /**

--- a/include/aspect/simulator/solver/stokes_matrix_free_local_smoothing.h
+++ b/include/aspect/simulator/solver/stokes_matrix_free_local_smoothing.h
@@ -119,7 +119,7 @@ namespace aspect
        * model and storing the information necessary for a later call
        * to solve().
        */
-      void assemble() override;
+      void assemble(LinearAlgebra::BlockVector &system_rhs) override;
 
       /**
        * Computes and sets the diagonal for both the mass matrix operator and the A-block
@@ -171,7 +171,7 @@ namespace aspect
        * Add correction to system RHS for non-zero boundary condition. See description in
        * StokesMatrixFreeHandler::correct_stokes_rhs() for more information.
        */
-      void correct_stokes_rhs();
+      void correct_stokes_rhs(LinearAlgebra::BlockVector &system_rhs);
 
 
       Simulator<dim> &sim;

--- a/include/aspect/simulator/solver/stokes_matrix_free_local_smoothing.h
+++ b/include/aspect/simulator/solver/stokes_matrix_free_local_smoothing.h
@@ -117,7 +117,8 @@ namespace aspect
        * for. Note that we are not assembling a matrix (as this is a
        * matrix-free algorithm), but we are evaluating the material
        * model and storing the information necessary for a later call
-       * to solve().
+       * to solve(). The function can modify @p system_rhs to account
+       * for boundary conditions as is necessary for matrix-free methods.
        */
       void assemble(LinearAlgebra::BlockVector &system_rhs) override;
 

--- a/include/aspect/simulator_access.h
+++ b/include/aspect/simulator_access.h
@@ -983,6 +983,16 @@ namespace aspect
       pressure_rhs_needs_compatibility_modification() const;
 
       /**
+       * Return whether to the best of our knowledge the A block of the
+       * Stokes system is symmetric. This is the case for most models, except
+       * if additional non-symmetric terms are added by special assemblers
+       * (e.g., the free surface stabilization term). This can be important
+       * information for picking the preconditioner of the A block.
+       */
+      bool
+      stokes_A_block_is_symmetric() const;
+
+      /**
        * Return whether the model uses a prescribed Stokes solution.
        */
       bool

--- a/source/simulator/assembly.cc
+++ b/source/simulator/assembly.cc
@@ -886,7 +886,7 @@ namespace aspect
 
     // If we change the system_rhs, matrix-free Stokes must update
     if (is_stokes_matrix_free())
-      dynamic_cast<StokesMatrixFreeHandler<dim>*>(stokes_solver.get())->assemble();
+      dynamic_cast<StokesMatrixFreeHandler<dim>*>(stokes_solver.get())->assemble(system_rhs);
 
     // if the model is compressible then we need to adjust the right hand
     // side of the equation to make it compatible with the matrix on the

--- a/source/simulator/simulator_access.cc
+++ b/source/simulator/simulator_access.cc
@@ -851,12 +851,15 @@ namespace aspect
   }
 
 
+
   template <int dim>
   double
   SimulatorAccess<dim>::get_pressure_scaling () const
   {
     return (simulator->pressure_scaling);
   }
+
+
 
   template <int dim>
   bool
@@ -865,12 +868,25 @@ namespace aspect
     return simulator->do_pressure_rhs_compatibility_modification;
   }
 
+
+
+  template <int dim>
+  bool
+  SimulatorAccess<dim>::stokes_A_block_is_symmetric () const
+  {
+    return simulator->stokes_A_block_is_symmetric();
+  }
+
+
+
   template <int dim>
   bool
   SimulatorAccess<dim>::model_has_prescribed_stokes_solution () const
   {
     return (simulator->prescribed_stokes_solution.get() != nullptr);
   }
+
+
 
   template <int dim>
   const Postprocess::Manager<dim> &

--- a/source/simulator/solver/stokes_matrix_based.cc
+++ b/source/simulator/solver/stokes_matrix_based.cc
@@ -587,7 +587,7 @@ namespace aspect
         system_matrix.block(velocity_block_index,velocity_block_index),
         *sim.Amg_preconditioner,
         /* do_solve_A = */ false,
-        sim.stokes_A_block_is_symmetric(),
+        this->stokes_A_block_is_symmetric(),
         this->get_parameters().linear_solver_A_block_tolerance);
       const aspect::internal::BlockSchurPreconditioner<aspect::internal::InverseVelocityBlock<LinearAlgebra::PreconditionAMG, LinearAlgebra::Vector, LinearAlgebra::SparseMatrix>,
             internal::SchurComplementOperator, LinearAlgebra::SparseMatrix, LinearAlgebra::BlockVector>
@@ -601,7 +601,7 @@ namespace aspect
         system_matrix.block(velocity_block_index,velocity_block_index),
         *sim.Amg_preconditioner,
         /* do_solve_A = */ true,
-        sim.stokes_A_block_is_symmetric(),
+        this->stokes_A_block_is_symmetric(),
         this->get_parameters().linear_solver_A_block_tolerance);
       const aspect::internal::BlockSchurPreconditioner<aspect::internal::InverseVelocityBlock<LinearAlgebra::PreconditionAMG, LinearAlgebra::Vector, LinearAlgebra::SparseMatrix>,
             internal::SchurComplementOperator, LinearAlgebra::SparseMatrix, LinearAlgebra::BlockVector>
@@ -747,10 +747,10 @@ namespace aspect
                                              solver_control_expensive);
 
       // do some cleanup now that we have the solution
-      sim.remove_nullspace(solution_vector, distributed_stokes_solution);
+      this->remove_nullspace(solution_vector, distributed_stokes_solution);
 
       if (solve_newton_system == false)
-        outputs.pressure_normalization_adjustment = sim.normalize_pressure(solution_vector);
+        outputs.pressure_normalization_adjustment = this->normalize_pressure(solution_vector);
 
       return outputs;
     }

--- a/source/simulator/solver/stokes_matrix_based.cc
+++ b/source/simulator/solver/stokes_matrix_based.cc
@@ -691,6 +691,7 @@ namespace aspect
             {
               ++sim.linear_solver_failures;
 
+              // *this is converted to a pointer to SimulatorAccess for the signal
               this->get_signals().post_stokes_solver(*this,
                                                      schur->n_iterations(),
                                                      inverse_velocity_block_cheap.n_iterations()+inverse_velocity_block_expensive.n_iterations(),
@@ -740,6 +741,7 @@ namespace aspect
       solution_vector.block(pressure_block_index) = distributed_stokes_solution.block(pressure_block_index);
 
       // signal successful solver
+      // *this is converted to a pointer to SimulatorAccess for the signal
       this->get_signals().post_stokes_solver(*this,
                                              schur->n_iterations(),
                                              inverse_velocity_block_cheap.n_iterations()+inverse_velocity_block_expensive.n_iterations(),

--- a/source/simulator/solver/stokes_matrix_free_global_coarsening.cc
+++ b/source/simulator/solver/stokes_matrix_free_global_coarsening.cc
@@ -1343,6 +1343,7 @@ namespace aspect
         // if the solver fails trigger the post stokes solver signal and throw an exception
         catch (const std::exception &exc)
           {
+            // *this is converted to a pointer to SimulatorAccess for the signal
             this->get_signals().post_stokes_solver(*this,
                                                    schur_approximation_cheap.n_iterations() + schur_approximation_expensive.n_iterations(),
                                                    inverse_velocity_block_cheap.n_iterations() + inverse_velocity_block_expensive.n_iterations(),
@@ -1365,6 +1366,7 @@ namespace aspect
       }
 
     // signal successful solver
+    // *this is converted to a pointer to SimulatorAccess for the signal
     this->get_signals().post_stokes_solver(*this,
                                            schur_approximation_cheap.n_iterations() + schur_approximation_expensive.n_iterations(),
                                            inverse_velocity_block_cheap.n_iterations() + inverse_velocity_block_expensive.n_iterations(),

--- a/source/simulator/solver/stokes_matrix_free_global_coarsening.cc
+++ b/source/simulator/solver/stokes_matrix_free_global_coarsening.cc
@@ -84,24 +84,23 @@ namespace aspect
 
 
   template <int dim, int velocity_degree>
-  StokesMatrixFreeHandlerGlobalCoarseningImplementation<dim, velocity_degree>::StokesMatrixFreeHandlerGlobalCoarseningImplementation (Simulator<dim> &simulator, const Parameters<dim> &parameters)
-    : sim(simulator),
+  StokesMatrixFreeHandlerGlobalCoarseningImplementation<dim, velocity_degree>::StokesMatrixFreeHandlerGlobalCoarseningImplementation (Simulator<dim> &/*simulator*/, const Parameters<dim> &parameters)
+    :
+    fe_v (FE_Q<dim>(parameters.stokes_velocity_degree), dim),
+    fe_p (FE_Q<dim>(parameters.stokes_velocity_degree-1), 1),
 
-      fe_v (FE_Q<dim>(parameters.stokes_velocity_degree), dim),
-      fe_p (FE_Q<dim>(parameters.stokes_velocity_degree-1), 1),
-
-      // The finite element used to describe the viscosity on the active level
-      // and to project the viscosity to GMG levels needs to be DGQ1 if we are
-      // using a degree 1 representation of viscosity, and DGQ0 if we are using
-      // a cellwise constant average.
-      fe_projection(FE_DGQ<dim>(parameters.material_averaging
-                                ==
-                                MaterialModel::MaterialAveraging::AveragingOperation::project_to_Q1
-                                ||
-                                parameters.material_averaging
-                                ==
-                                MaterialModel::MaterialAveraging::AveragingOperation::project_to_Q1_only_viscosity
-                                ? 1 : 0), 1)
+    // The finite element used to describe the viscosity on the active level
+    // and to project the viscosity to GMG levels needs to be DGQ1 if we are
+    // using a degree 1 representation of viscosity, and DGQ0 if we are using
+    // a cellwise constant average.
+    fe_projection(FE_DGQ<dim>(parameters.material_averaging
+                              ==
+                              MaterialModel::MaterialAveraging::AveragingOperation::project_to_Q1
+                              ||
+                              parameters.material_averaging
+                              ==
+                              MaterialModel::MaterialAveraging::AveragingOperation::project_to_Q1_only_viscosity
+                              ? 1 : 0), 1)
   {}
 
 
@@ -141,7 +140,7 @@ namespace aspect
 
 
   template <int dim, int velocity_degree>
-  void StokesMatrixFreeHandlerGlobalCoarseningImplementation<dim, velocity_degree>::assemble ()
+  void StokesMatrixFreeHandlerGlobalCoarseningImplementation<dim, velocity_degree>::assemble (LinearAlgebra::BlockVector &system_rhs)
   {
     if (this->get_parameters().mesh_deformation_enabled)
       {
@@ -155,7 +154,7 @@ namespace aspect
 
     evaluate_material_model();
 
-    correct_stokes_rhs();
+    correct_stokes_rhs(system_rhs);
   }
 
 
@@ -635,7 +634,7 @@ namespace aspect
 
 
   template <int dim, int velocity_degree>
-  void StokesMatrixFreeHandlerGlobalCoarseningImplementation<dim, velocity_degree>::correct_stokes_rhs()
+  void StokesMatrixFreeHandlerGlobalCoarseningImplementation<dim, velocity_degree>::correct_stokes_rhs(LinearAlgebra::BlockVector &system_rhs)
   {
     // We never include Newton terms in step 0 and after that we solve with zero boundary conditions.
     // Therefore, we don't need to include Newton terms here.
@@ -764,8 +763,8 @@ namespace aspect
     LinearAlgebra::BlockVector stokes_rhs_correction (this->introspection().index_sets.stokes_partitioning, this->get_mpi_communicator());
     internal::ChangeVectorTypes::copy(stokes_rhs_correction,rhs_correction);
 
-    sim.system_rhs.block(0) += stokes_rhs_correction.block(0);
-    sim.system_rhs.block(1) += stokes_rhs_correction.block(1);
+    system_rhs.block(0) += stokes_rhs_correction.block(0);
+    system_rhs.block(1) += stokes_rhs_correction.block(1);
   }
 
 
@@ -1061,13 +1060,13 @@ namespace aspect
     inverse_velocity_block_cheap(A_block_matrix,
                                  prec_A,
                                  /*do_solve_A = */ false,
-                                 sim.stokes_A_block_is_symmetric(),
+                                 this->stokes_A_block_is_symmetric(),
                                  this->get_parameters().linear_solver_A_block_tolerance);
     internal::InverseVelocityBlock<GMGPreconditioner, VectorType, ABlockMatrixType>
     inverse_velocity_block_expensive(A_block_matrix,
                                      prec_A,
                                      /*do_solve_A = */ true,
-                                     sim.stokes_A_block_is_symmetric(),
+                                     this->stokes_A_block_is_symmetric(),
                                      this->get_parameters().linear_solver_A_block_tolerance
                                     );
     using SchurApproximationType=internal::SchurApproximation<GMGPreconditioner, StokesMatrixType, SchurComplementMatrixType, VectorType>;
@@ -1344,7 +1343,7 @@ namespace aspect
         // if the solver fails trigger the post stokes solver signal and throw an exception
         catch (const std::exception &exc)
           {
-            this->get_signals().post_stokes_solver(sim,
+            this->get_signals().post_stokes_solver(*this,
                                                    schur_approximation_cheap.n_iterations() + schur_approximation_expensive.n_iterations(),
                                                    inverse_velocity_block_cheap.n_iterations() + inverse_velocity_block_expensive.n_iterations(),
                                                    solver_control_cheap,
@@ -1365,8 +1364,8 @@ namespace aspect
           }
       }
 
-    //signal successful solver
-    this->get_signals().post_stokes_solver(sim,
+    // signal successful solver
+    this->get_signals().post_stokes_solver(*this,
                                            schur_approximation_cheap.n_iterations() + schur_approximation_expensive.n_iterations(),
                                            inverse_velocity_block_cheap.n_iterations() + inverse_velocity_block_expensive.n_iterations(),
                                            solver_control_cheap,
@@ -1570,10 +1569,10 @@ namespace aspect
                   }
               }
 
-            sim.prescribed_solution_manager.constrain_solution(constraint);
+            this->get_prescribed_solution().constrain_solution(constraint);
 
             // Let plugins add more constraints if they so choose:
-            sim.signals.post_constraints_creation(*this, constraint);
+            this->get_signals().post_constraints_creation(*this, constraint);
 
             constraint.close();
           }

--- a/source/simulator/solver/stokes_matrix_free_local_smoothing.cc
+++ b/source/simulator/solver/stokes_matrix_free_local_smoothing.cc
@@ -1352,6 +1352,7 @@ namespace aspect
           {
             ++sim.linear_solver_failures;
 
+            // *this is converted to a pointer to SimulatorAccess for the signal
             this->get_signals().post_stokes_solver(*this,
                                                    schur_approximation_cheap.n_iterations() + schur_approximation_expensive.n_iterations(),
                                                    inverse_velocity_block_cheap.n_iterations() + inverse_velocity_block_expensive.n_iterations(),
@@ -1389,6 +1390,7 @@ namespace aspect
       }
 
     // signal successful solver
+    // *this is converted to a pointer to SimulatorAccess for the signal
     this->get_signals().post_stokes_solver(*this,
                                            schur_approximation_cheap.n_iterations() + schur_approximation_expensive.n_iterations(),
                                            inverse_velocity_block_cheap.n_iterations() + inverse_velocity_block_expensive.n_iterations(),

--- a/source/simulator/solver/stokes_matrix_free_local_smoothing.cc
+++ b/source/simulator/solver/stokes_matrix_free_local_smoothing.cc
@@ -149,7 +149,7 @@ namespace aspect
 
 
   template <int dim, int velocity_degree>
-  void StokesMatrixFreeHandlerLocalSmoothingImplementation<dim, velocity_degree>::assemble ()
+  void StokesMatrixFreeHandlerLocalSmoothingImplementation<dim, velocity_degree>::assemble (LinearAlgebra::BlockVector &system_rhs)
   {
     if (this->get_parameters().mesh_deformation_enabled)
       {
@@ -163,7 +163,7 @@ namespace aspect
 
     evaluate_material_model();
 
-    correct_stokes_rhs();
+    correct_stokes_rhs(system_rhs);
   }
 
   template <int dim, int velocity_degree>
@@ -611,7 +611,7 @@ namespace aspect
 
 
   template <int dim, int velocity_degree>
-  void StokesMatrixFreeHandlerLocalSmoothingImplementation<dim, velocity_degree>::correct_stokes_rhs()
+  void StokesMatrixFreeHandlerLocalSmoothingImplementation<dim, velocity_degree>::correct_stokes_rhs(LinearAlgebra::BlockVector &system_rhs)
   {
     // We never include Newton terms in step 0 and after that we solve with zero boundary conditions.
     // Therefore, we don't need to include Newton terms here.
@@ -741,8 +741,8 @@ namespace aspect
     LinearAlgebra::BlockVector stokes_rhs_correction (this->introspection().index_sets.stokes_partitioning, this->get_mpi_communicator());
     internal::ChangeVectorTypes::copy(stokes_rhs_correction,rhs_correction);
 
-    sim.system_rhs.block(0) += stokes_rhs_correction.block(0);
-    sim.system_rhs.block(1) += stokes_rhs_correction.block(1);
+    system_rhs.block(0) += stokes_rhs_correction.block(0);
+    system_rhs.block(1) += stokes_rhs_correction.block(1);
   }
 
 
@@ -1060,14 +1060,14 @@ namespace aspect
       A_block_matrix,
       prec_A,
       /* do_solve_A = */ false,
-      sim.stokes_A_block_is_symmetric(),
+      this->stokes_A_block_is_symmetric(),
       this->get_parameters().linear_solver_A_block_tolerance);
 
     internal::InverseVelocityBlock<GMGPreconditioner,VectorType, ABlockMatrixType> inverse_velocity_block_expensive(
       A_block_matrix,
       prec_A,
       /* do_solve_A = */ true,
-      sim.stokes_A_block_is_symmetric(),
+      this->stokes_A_block_is_symmetric(),
       this->get_parameters().linear_solver_A_block_tolerance);
 
     using SchurApproximationType = internal::SchurApproximation<GMGPreconditioner,StokesMatrixType,SchurComplementMatrixType, VectorType>;
@@ -1352,7 +1352,7 @@ namespace aspect
           {
             ++sim.linear_solver_failures;
 
-            this->get_signals().post_stokes_solver(sim,
+            this->get_signals().post_stokes_solver(*this,
                                                    schur_approximation_cheap.n_iterations() + schur_approximation_expensive.n_iterations(),
                                                    inverse_velocity_block_cheap.n_iterations() + inverse_velocity_block_expensive.n_iterations(),
                                                    solver_control_cheap,
@@ -1388,8 +1388,8 @@ namespace aspect
           }
       }
 
-    //signal successful solver
-    this->get_signals().post_stokes_solver(sim,
+    // signal successful solver
+    this->get_signals().post_stokes_solver(*this,
                                            schur_approximation_cheap.n_iterations() + schur_approximation_expensive.n_iterations(),
                                            inverse_velocity_block_cheap.n_iterations() + inverse_velocity_block_expensive.n_iterations(),
                                            solver_control_cheap,
@@ -1529,10 +1529,10 @@ namespace aspect
                                                           true);
         }
 
-      sim.prescribed_solution_manager.constrain_solution(constraints_v);
+      this->get_prescribed_solution().constrain_solution(constraints_v);
 
       // Let plugins add more constraints if they so choose:
-      sim.signals.post_constraints_creation(*this, constraints_v);
+      this->get_signals().post_constraints_creation(*this, constraints_v);
 
       constraints_v.close ();
     }


### PR DESCRIPTION
A bundle of small changes that reduce the reliance on the internal pointer to simulator stored by many Stokes solver classes. The remaining uses require a bit more effort and I will try to address them in separate PRs.