### PR TITLE
Reduce unnecessarily including simulator.h

### DIFF
--- a/include/aspect/particle/property/cpo_bingham_average.h
+++ b/include/aspect/particle/property/cpo_bingham_average.h
@@ -175,7 +175,7 @@ namespace aspect
            * A pointer to the crystal preferred orientation particle property.
            * Avoids repeated searches for that property.
            */
-          std::unique_ptr<const Particle::Property::CrystalPreferredOrientation<dim>> cpo_particle_property;
+          const Particle::Property::CrystalPreferredOrientation<dim> *cpo_particle_property;
 
           /**
            * Random number generator. For reproducibility of tests it is

--- a/source/global.cc
+++ b/source/global.cc
@@ -31,6 +31,7 @@
 #endif
 
 #include <cstring>
+#include <fstream>
 
 #include <mpi.h>
 

--- a/source/heating_model/adiabatic_heating_of_melt.cc
+++ b/source/heating_model/adiabatic_heating_of_melt.cc
@@ -21,8 +21,7 @@
 
 #include <aspect/heating_model/adiabatic_heating_of_melt.h>
 #include <aspect/melt.h>
-#include <aspect/simulator.h>
-#include <deal.II/numerics/fe_field_function.h>
+#include <aspect/gravity_model/interface.h>
 
 namespace aspect
 {

--- a/source/heating_model/shear_heating_with_melt.cc
+++ b/source/heating_model/shear_heating_with_melt.cc
@@ -21,8 +21,6 @@
 
 #include <aspect/heating_model/shear_heating_with_melt.h>
 #include <aspect/melt.h>
-#include <aspect/simulator.h>
-#include <deal.II/numerics/fe_field_function.h>
 
 
 namespace aspect

--- a/source/heating_model/tidal_heating.cc
+++ b/source/heating_model/tidal_heating.cc
@@ -21,7 +21,6 @@
 
 #include <aspect/heating_model/tidal_heating.h>
 
-#include <aspect/simulator.h>
 #include <aspect/geometry_model/interface.h>
 #include <aspect/geometry_model/chunk.h>
 #include <aspect/geometry_model/two_merged_chunks.h>

--- a/source/material_model/melt_boukare.cc
+++ b/source/material_model/melt_boukare.cc
@@ -18,13 +18,14 @@
   <http://www.gnu.org/licenses/>.
 */
 
-#include <algorithm>
-#include <aspect/adiabatic_conditions/interface.h>
 #include <aspect/material_model/melt_boukare.h>
+
+#include <aspect/adiabatic_conditions/interface.h>
 #include <aspect/gravity_model/interface.h>
-#include <aspect/simulator.h>
 
 #include <deal.II/base/parameter_handler.h>
+
+#include <algorithm>
 
 
 namespace aspect

--- a/source/material_model/rheology/strain_dependent.cc
+++ b/source/material_model/rheology/strain_dependent.cc
@@ -18,20 +18,22 @@
   <http://www.gnu.org/licenses/>.
 */
 
-#include <algorithm>
 #include <aspect/material_model/rheology/strain_dependent.h>
+
+#include <aspect/utilities.h>
+#include <aspect/postprocess/particles.h>
+#include <aspect/particle/manager.h>
+#include <aspect/particle/property/interface.h>
+#include <aspect/simulator_signals.h>
 
 #include <deal.II/base/signaling_nan.h>
 #include <deal.II/base/parameter_handler.h>
-#include <aspect/utilities.h>
-#include <aspect/postprocess/particles.h>
-#include <aspect/particle/property/interface.h>
-#include <aspect/simulator.h>
-#include <aspect/simulator_signals.h>
-
 #include <deal.II/fe/fe_values.h>
 #include <deal.II/numerics/fe_field_function.h>
 #include <deal.II/base/quadrature_lib.h>
+
+#include <algorithm>
+
 
 namespace aspect
 {

--- a/source/mesh_deformation/diffusion.cc
+++ b/source/mesh_deformation/diffusion.cc
@@ -20,11 +20,12 @@
 
 
 #include <aspect/mesh_deformation/diffusion.h>
+
+#include <aspect/boundary_velocity/interface.h>
 #include <aspect/gravity_model/interface.h>
 #include <aspect/geometry_model/interface.h>
 #include <aspect/geometry_model/box.h>
 #include <aspect/geometry_model/two_merged_boxes.h>
-#include <aspect/simulator.h>
 #include <aspect/geometry_model/initial_topography_model/zero_topography.h>
 #include <aspect/linear_algebra_types.h>
 

--- a/source/mesh_deformation/fastscape.cc
+++ b/source/mesh_deformation/fastscape.cc
@@ -25,7 +25,6 @@
 #include <deal.II/numerics/vector_tools.h>
 #include <aspect/postprocess/visualization.h>
 #include <ctime>
-#include <aspect/simulator.h>
 
 namespace aspect
 {

--- a/source/mesh_deformation/free_surface.cc
+++ b/source/mesh_deformation/free_surface.cc
@@ -21,11 +21,10 @@
 
 #include <aspect/mesh_deformation/free_surface.h>
 #include <aspect/simulator_signals.h>
+#include <aspect/boundary_velocity/interface.h>
 #include <aspect/gravity_model/interface.h>
 #include <aspect/geometry_model/interface.h>
 #include <aspect/simulator/assemblers/interface.h>
-#include <aspect/melt.h>
-#include <aspect/simulator.h>
 #include <aspect/linear_algebra_types.h>
 
 #include <deal.II/dofs/dof_tools.h>

--- a/source/mesh_deformation/interface.cc
+++ b/source/mesh_deformation/interface.cc
@@ -23,7 +23,6 @@
 #include <aspect/mesh_deformation/interface.h>
 #include <aspect/geometry_model/initial_topography_model/zero_topography.h>
 #include <aspect/geometry_model/box.h>
-#include <aspect/simulator.h>
 #include <aspect/simulator/solver/matrix_free_operators.h>
 #include <aspect/simulator/solver/stokes_matrix_free.h>
 #include <aspect/linear_algebra_types.h>

--- a/source/particle/manager.cc
+++ b/source/particle/manager.cc
@@ -19,21 +19,20 @@
 */
 
 #include <aspect/particle/manager.h>
+
 #include <aspect/global.h>
 #include <aspect/utilities.h>
-#include <aspect/simulator.h>
 #include <aspect/melt.h>
+#include <aspect/particle/distribution.h>
 
 #include <deal.II/base/quadrature_lib.h>
 #include <deal.II/fe/fe_values.h>
 #include <deal.II/grid/grid_tools.h>
-
 #include <deal.II/fe/mapping_cartesian.h>
 
 #include <boost/serialization/map.hpp>
 #include <boost/archive/text_oarchive.hpp>
 #include <boost/archive/text_iarchive.hpp>
-#include <aspect/particle/distribution.h>
 
 namespace aspect
 {

--- a/source/particle/property/cpo_bingham_average.cc
+++ b/source/particle/property/cpo_bingham_average.cc
@@ -19,12 +19,12 @@
  */
 
 #include <aspect/particle/property/cpo_bingham_average.h>
+
 #include <aspect/particle/manager.h>
+#include <aspect/particle/property/interface.h>
+#include <aspect/particle/property/crystal_preferred_orientation.h>
 
 #include <aspect/utilities.h>
-#include <aspect/simulator.h>
-
-#include <boost/serialization/map.hpp>
 
 namespace aspect
 {
@@ -394,8 +394,8 @@ namespace aspect
         prm.enter_subsection("CPO Bingham Average");
         {
           // Get a pointer to the CPO particle property.
-          cpo_particle_property = std::make_unique<const Particle::Property::CrystalPreferredOrientation<dim>> (
-                                    this->get_particle_manager(this->get_particle_manager_index()).get_property_manager().template get_matching_active_plugin<Particle::Property::CrystalPreferredOrientation<dim>>());
+          cpo_particle_property = &this->get_particle_manager(this->get_particle_manager_index()).
+                                  get_property_manager().template get_matching_active_plugin<Particle::Property::CrystalPreferredOrientation<dim>>();
 
           random_number_seed = prm.get_integer ("Random number seed");
           n_grains = cpo_particle_property->get_number_of_grains();

--- a/source/particle/property/melt_particle.cc
+++ b/source/particle/property/melt_particle.cc
@@ -20,7 +20,6 @@
 
 
 #include <aspect/particle/property/melt_particle.h>
-#include <aspect/simulator.h>
 #include <aspect/melt.h>
 
 namespace aspect

--- a/source/postprocess/ODE_statistics.cc
+++ b/source/postprocess/ODE_statistics.cc
@@ -21,11 +21,7 @@
 
 #include <aspect/postprocess/ODE_statistics.h>
 
-#include <deal.II/base/quadrature_lib.h>
-#include <deal.II/fe/fe_values.h>
-#include <aspect/simulator.h>
-
-
+#include <aspect/simulator_signals.h>
 
 namespace aspect
 {

--- a/source/postprocess/dynamic_topography.cc
+++ b/source/postprocess/dynamic_topography.cc
@@ -18,10 +18,12 @@
   <http://www.gnu.org/licenses/>.
 */
 
-#include <aspect/simulator.h>
 #include <aspect/postprocess/dynamic_topography.h>
 
+#include <aspect/geometry_model/interface.h>
+#include <aspect/gravity_model/interface.h>
 #include <aspect/postprocess/boundary_pressures.h>
+#include <aspect/utilities.h>
 
 #include <deal.II/base/quadrature_lib.h>
 #include <deal.II/fe/fe_values.h>

--- a/source/postprocess/geoid.cc
+++ b/source/postprocess/geoid.cc
@@ -19,12 +19,13 @@
  */
 
 
-#include <aspect/simulator.h>
-#include <aspect/mesh_deformation/free_surface.h>
-#include <aspect/utilities.h>
 #include <aspect/postprocess/geoid.h>
 #include <aspect/postprocess/dynamic_topography.h>
 #include <aspect/postprocess/boundary_densities.h>
+
+#include <aspect/gravity_model/interface.h>
+#include <aspect/mesh_deformation/free_surface.h>
+#include <aspect/utilities.h>
 #include <aspect/geometry_model/spherical_shell.h>
 
 #include <deal.II/base/quadrature_lib.h>

--- a/source/postprocess/global_statistics.cc
+++ b/source/postprocess/global_statistics.cc
@@ -20,7 +20,8 @@
 
 
 #include <aspect/postprocess/global_statistics.h>
-#include <aspect/simulator.h>
+
+#include <aspect/simulator_signals.h>
 
 namespace aspect
 {

--- a/source/postprocess/matrix_statistics.cc
+++ b/source/postprocess/matrix_statistics.cc
@@ -21,12 +21,7 @@
 
 #include <aspect/postprocess/matrix_statistics.h>
 
-#include <aspect/simulator.h>
 #include <aspect/utilities.h>
-
-#include <string>
-
-#include <mpi.h>
 
 
 namespace aspect

--- a/source/postprocess/memory_statistics.cc
+++ b/source/postprocess/memory_statistics.cc
@@ -20,7 +20,6 @@
 
 
 #include <aspect/postprocess/memory_statistics.h>
-#include <aspect/simulator.h>
 #include <aspect/simulator/solver/stokes_matrix_free.h>
 
 

--- a/source/postprocess/mobility_statistics.cc
+++ b/source/postprocess/mobility_statistics.cc
@@ -18,13 +18,10 @@
   <http://www.gnu.org/licenses/>.
 */
 
-#include <aspect/simulator.h>
 #include <aspect/postprocess/mobility_statistics.h>
-#include <aspect/material_model/simple.h>
-#include <aspect/global.h>
+
 #include <aspect/utilities.h>
 #include <aspect/geometry_model/interface.h>
-#include <aspect/geometry_model/spherical_shell.h>
 
 #include <deal.II/base/quadrature_lib.h>
 #include <deal.II/fe/fe_values.h>

--- a/source/postprocess/rotation_statistics.cc
+++ b/source/postprocess/rotation_statistics.cc
@@ -20,13 +20,7 @@
 
 
 #include <aspect/postprocess/rotation_statistics.h>
-#include <aspect/material_model/simple.h>
-#include <aspect/global.h>
 #include <aspect/simulator.h>
-
-#include <deal.II/base/quadrature_lib.h>
-#include <deal.II/fe/fe_values.h>
-
 
 namespace aspect
 {

--- a/source/postprocess/sea_level.cc
+++ b/source/postprocess/sea_level.cc
@@ -19,17 +19,15 @@
 */
 
 
-#include <aspect/simulator.h>
-#include <aspect/global.h>
-#include <aspect/mesh_deformation/free_surface.h>
-#include <aspect/utilities.h>
-#include <aspect/structured_data.h>
-#include <aspect/geometry_model/spherical_shell.h>
 #include <aspect/postprocess/sea_level.h>
+
+#include <aspect/geometry_model/spherical_shell.h>
+#include <aspect/gravity_model/interface.h>
+#include <aspect/mesh_deformation/free_surface.h>
 #include <aspect/postprocess/geoid.h>
 
-#include <deal.II/base/quadrature_lib.h>
-#include <deal.II/fe/fe_values.h>
+#include <aspect/utilities.h>
+#include <aspect/structured_data.h>
 
 #include <cmath>
 #include <limits>

--- a/source/postprocess/stokes_residual.cc
+++ b/source/postprocess/stokes_residual.cc
@@ -20,18 +20,8 @@
 
 
 #include <aspect/postprocess/stokes_residual.h>
-#include <aspect/simulator.h>
-#include <aspect/global.h>
 
-#include <deal.II/grid/grid_generator.h>
-#include <deal.II/grid/tria.h>
-#include <deal.II/fe/fe_dgq.h>
-#include <deal.II/dofs/dof_handler.h>
-#include <deal.II/numerics/data_out_stack.h>
-
-
-#include <cmath>
-#include <vector>
+#include <aspect/simulator_signals.h>
 
 namespace aspect
 {

--- a/source/postprocess/timing_statistics.cc
+++ b/source/postprocess/timing_statistics.cc
@@ -20,7 +20,6 @@
 
 
 #include <aspect/postprocess/timing_statistics.h>
-#include <aspect/simulator.h>
 
 namespace aspect
 {

--- a/source/postprocess/topography.cc
+++ b/source/postprocess/topography.cc
@@ -20,16 +20,7 @@
 
 
 #include <aspect/postprocess/topography.h>
-#include <aspect/geometry_model/box.h>
 #include <aspect/geometry_model/sphere.h>
-#include <aspect/geometry_model/spherical_shell.h>
-#include <aspect/geometry_model/chunk.h>
-#include <aspect/simulator.h>
-#include <aspect/global.h>
-
-#include <deal.II/fe/fe_values.h>
-#include <deal.II/base/quadrature_lib.h>
-#include <deal.II/fe/fe_values.h>
 
 #include <cmath>
 #include <limits>

--- a/source/postprocess/visualization.cc
+++ b/source/postprocess/visualization.cc
@@ -20,14 +20,15 @@
 
 
 #include <aspect/postprocess/visualization.h>
+
 #include <aspect/global.h>
 #include <aspect/utilities.h>
-#include <aspect/simulator_access.h>
-#include <aspect/simulator.h>
+#include <aspect/simulator_signals.h>
+
 #include <aspect/geometry_model/interface.h>
 #include <aspect/mesh_deformation/interface.h>
-#include <deal.II/fe/mapping_q1_eulerian.h>
 
+#include <deal.II/fe/mapping_q1_eulerian.h>
 #include <deal.II/dofs/dof_tools.h>
 #include <deal.II/numerics/data_out.h>
 #include <deal.II/numerics/data_out_faces.h>

--- a/source/postprocess/visualization/boundary_strain_rate_residual.cc
+++ b/source/postprocess/visualization/boundary_strain_rate_residual.cc
@@ -19,8 +19,9 @@
 */
 
 #include <aspect/postprocess/visualization/boundary_strain_rate_residual.h>
+
+#include <aspect/geometry_model/interface.h>
 #include <aspect/postprocess/boundary_strain_rate_residual_statistics.h>
-#include <aspect/simulator.h>
 
 namespace aspect
 {

--- a/source/postprocess/visualization/boundary_velocity_residual.cc
+++ b/source/postprocess/visualization/boundary_velocity_residual.cc
@@ -19,8 +19,8 @@
 */
 
 #include <aspect/postprocess/visualization/boundary_velocity_residual.h>
+
 #include <aspect/postprocess/boundary_velocity_residual_statistics.h>
-#include <aspect/simulator.h>
 
 namespace aspect
 {

--- a/source/postprocess/visualization/darcy_velocity.cc
+++ b/source/postprocess/visualization/darcy_velocity.cc
@@ -20,9 +20,11 @@
 
 
 #include <aspect/postprocess/visualization/darcy_velocity.h>
+
+#include <aspect/gravity_model/interface.h>
+
 #include <aspect/utilities.h>
 #include <aspect/melt.h>
-#include <aspect/simulator.h>
 
 namespace aspect
 {

--- a/source/postprocess/visualization/dynamic_topography.cc
+++ b/source/postprocess/visualization/dynamic_topography.cc
@@ -17,8 +17,10 @@
   along with ASPECT; see the file LICENSE.  If not see
   <http://www.gnu.org/licenses/>.
 */
-#include <aspect/simulator.h>
+
 #include <aspect/postprocess/visualization/dynamic_topography.h>
+
+#include <aspect/geometry_model/interface.h>
 #include <aspect/postprocess/dynamic_topography.h>
 
 namespace aspect

--- a/source/postprocess/visualization/geoid.cc
+++ b/source/postprocess/visualization/geoid.cc
@@ -18,13 +18,10 @@
   <http://www.gnu.org/licenses/>.
 */
 
-#include <aspect/simulator.h>
-#include <aspect/simulator_access.h>
-#include <aspect/utilities.h>
-#include <aspect/geometry_model/spherical_shell.h>
 #include <aspect/postprocess/visualization/geoid.h>
 
-
+#include <aspect/utilities.h>
+#include <aspect/geometry_model/spherical_shell.h>
 
 namespace aspect
 {

--- a/source/postprocess/visualization/melt.cc
+++ b/source/postprocess/visualization/melt.cc
@@ -20,9 +20,9 @@
 
 
 #include <aspect/postprocess/visualization/melt.h>
+
 #include <aspect/melt.h>
 #include <aspect/utilities.h>
-#include <aspect/simulator.h>
 #include <aspect/material_model/interface.h>
 
 #include <deal.II/numerics/data_out.h>

--- a/source/postprocess/visualization/surface_dynamic_topography.cc
+++ b/source/postprocess/visualization/surface_dynamic_topography.cc
@@ -17,8 +17,10 @@
   along with ASPECT; see the file LICENSE.  If not see
   <http://www.gnu.org/licenses/>.
 */
-#include <aspect/simulator.h>
+
 #include <aspect/postprocess/visualization/surface_dynamic_topography.h>
+
+#include <aspect/geometry_model/interface.h>
 #include <aspect/postprocess/dynamic_topography.h>
 
 namespace aspect

--- a/source/postprocess/visualization/surface_elevation.cc
+++ b/source/postprocess/visualization/surface_elevation.cc
@@ -17,8 +17,10 @@
   along with ASPECT; see the file LICENSE.  If not see
   <http://www.gnu.org/licenses/>.
 */
-#include <aspect/simulator.h>
+
 #include <aspect/postprocess/visualization/surface_elevation.h>
+
+#include <aspect/geometry_model/interface.h>
 
 namespace aspect
 {

--- a/source/simulator/assemblers/newton_stokes.cc
+++ b/source/simulator/assemblers/newton_stokes.cc
@@ -18,11 +18,13 @@
   <http://www.gnu.org/licenses/>.
 */
 
-#include <aspect/simulator.h>
 #include <aspect/newton.h>
-#include <aspect/simulator_access.h>
+
 #include <aspect/utilities.h>
 #include <aspect/material_model/rheology/elasticity.h>
+#include <aspect/prescribed_dilation/interface.h>
+#include <aspect/gravity_model/interface.h>
+#include <aspect/boundary_traction/interface.h>
 
 namespace aspect
 {

--- a/source/simulator/assemblers/stokes.cc
+++ b/source/simulator/assemblers/stokes.cc
@@ -19,8 +19,12 @@
 */
 
 #include <aspect/simulator/assemblers/stokes.h>
-#include <aspect/simulator.h>
+
 #include <aspect/utilities.h>
+#include <aspect/prescribed_dilation/interface.h>
+#include <aspect/gravity_model/interface.h>
+#include <aspect/boundary_traction/interface.h>
+
 
 #include <deal.II/base/signaling_nan.h>
 

--- a/source/simulator/newton.cc
+++ b/source/simulator/newton.cc
@@ -20,10 +20,11 @@
 
 
 #include <aspect/newton.h>
+
+#include <aspect/boundary_traction/interface.h>
+#include <aspect/prescribed_dilation/interface.h>
 #include <aspect/simulator/assemblers/advection.h>
 #include <aspect/simulator/assemblers/stokes.h>
-
-#include <aspect/simulator.h>
 
 namespace aspect
 {

--- a/source/solution_evaluator.cc
+++ b/source/solution_evaluator.cc
@@ -18,10 +18,10 @@
   <http://www.gnu.org/licenses/>.
 */
 
+#include <aspect/solution_evaluator.h>
+
 #include <aspect/global.h>
 #include <aspect/utilities.h>
-#include <aspect/solution_evaluator.h>
-#include <aspect/simulator.h>
 #include <aspect/melt.h>
 
 namespace aspect

--- a/source/termination_criteria/interface.cc
+++ b/source/termination_criteria/interface.cc
@@ -20,7 +20,6 @@
 
 
 #include <aspect/termination_criteria/interface.h>
-#include <aspect/simulator.h>
 #include <aspect/utilities.h>
 
 #include <typeinfo>

--- a/source/time_stepping/convection_time_step.cc
+++ b/source/time_stepping/convection_time_step.cc
@@ -19,8 +19,10 @@
 */
 
 
-#include <aspect/simulator.h>
 #include <aspect/time_stepping/convection_time_step.h>
+
+#include <aspect/gravity_model/interface.h>
+
 #include <aspect/melt.h>
 #include <aspect/utilities.h>
 

--- a/source/time_stepping/interface.cc
+++ b/source/time_stepping/interface.cc
@@ -20,7 +20,8 @@
 
 
 #include <aspect/time_stepping/interface.h>
-#include <aspect/simulator.h>
+
+#include <aspect/utilities.h>
 
 namespace aspect
 {


### PR DESCRIPTION
In the same direction as #7321. We should not include simulator.h if it is unnecessary, as it tempts to unnecessarily couple the code, and also may slow down compiling (I havent benchmarked the change).

Also fix a small (non-solution affecting) bug in cpo_bingham_average, which creates a copy of another plugin to store it in an owning pointer (which requires including simulator.h because of a funny requirement when copying an ObserverPointer to Simulator).

Also resort the order of includes to make sure the main header file of a cc file is included first.

There are many more instances in benchmarks, cookbooks, and tests, but I will leave them for a later PR.