### PR TITLE
Remove simulator includes in benchmarks, cookbooks, tests

### DIFF
--- a/benchmarks/advection_in_annulus/advection_in_annulus.cc
+++ b/benchmarks/advection_in_annulus/advection_in_annulus.cc
@@ -17,7 +17,7 @@
   along with ASPECT; see the file LICENSE.  If not see
   <http://www.gnu.org/licenses/>.
 */
-#include <aspect/simulator.h>
+
 #include <aspect/material_model/simple.h>
 #include <aspect/boundary_velocity/interface.h>
 #include <aspect/simulator_access.h>

--- a/benchmarks/annulus/plugin/annulus.cc
+++ b/benchmarks/annulus/plugin/annulus.cc
@@ -17,13 +17,15 @@
   along with ASPECT; see the file LICENSE.  If not see
   <http://www.gnu.org/licenses/>.
 */
-#include <aspect/simulator.h>
+
 #include <aspect/boundary_velocity/interface.h>
 #include <aspect/simulator_access.h>
 #include <aspect/global.h>
 #include <aspect/utilities.h>
 
 #include <aspect/gravity_model/interface.h>
+#include <aspect/initial_composition/interface.h>
+#include <aspect/particle/property/interface.h>
 #include <aspect/postprocess/dynamic_topography.h>
 #include <aspect/postprocess/visualization.h>
 

--- a/benchmarks/diffusion_of_hill/analytical_topography.cc
+++ b/benchmarks/diffusion_of_hill/analytical_topography.cc
@@ -22,7 +22,7 @@
 #include "analytical_topography.h"
 #include <aspect/geometry_model/two_merged_boxes.h>
 #include <aspect/geometry_model/box.h>
-#include <aspect/simulator.h>
+
 #include <aspect/global.h>
 
 #include <deal.II/fe/fe_values.h>

--- a/benchmarks/doneahuerta/doneahuerta.cc
+++ b/benchmarks/doneahuerta/doneahuerta.cc
@@ -17,13 +17,14 @@
   along with ASPECT; see the file LICENSE.  If not see
   <http://www.gnu.org/licenses/>.
 */
-#include <aspect/simulator.h>
+
 #include <aspect/material_model/simple.h>
 #include <aspect/boundary_velocity/interface.h>
 #include <aspect/simulator_access.h>
 #include <aspect/global.h>
 #include <aspect/gravity_model/interface.h>
 #include <aspect/utilities.h>
+#include <aspect/postprocess/interface.h>
 
 #include <deal.II/dofs/dof_tools.h>
 #include <deal.II/numerics/data_out.h>

--- a/benchmarks/hollow_sphere/hollow_sphere.cc
+++ b/benchmarks/hollow_sphere/hollow_sphere.cc
@@ -17,9 +17,10 @@
   along with ASPECT; see the file LICENSE.  If not see
   <http://www.gnu.org/licenses/>.
 */
-#include <aspect/simulator.h>
+
 #include <aspect/material_model/simple.h>
 #include <aspect/boundary_velocity/interface.h>
+#include <aspect/gravity_model/interface.h>
 #include <aspect/simulator_access.h>
 #include <aspect/global.h>
 #include <aspect/postprocess/dynamic_topography.h>

--- a/benchmarks/layeredflow/layeredflow.cc
+++ b/benchmarks/layeredflow/layeredflow.cc
@@ -17,13 +17,14 @@
   along with ASPECT; see the file LICENSE.  If not see
   <http://www.gnu.org/licenses/>.
 */
-#include <aspect/simulator.h>
+
 #include <aspect/material_model/simple.h>
 #include <aspect/boundary_velocity/interface.h>
 #include <aspect/simulator_access.h>
 #include <aspect/global.h>
 #include <aspect/gravity_model/interface.h>
 #include <aspect/utilities.h>
+#include <aspect/postprocess/interface.h>
 
 #include <deal.II/dofs/dof_tools.h>
 #include <deal.II/numerics/data_out.h>

--- a/benchmarks/newton_solver_benchmark_set/nonlinear_channel_flow/simple_nonlinear.cc
+++ b/benchmarks/newton_solver_benchmark_set/nonlinear_channel_flow/simple_nonlinear.cc
@@ -19,7 +19,7 @@
 */
 
 #include <algorithm>
-#include <aspect/simulator.h>
+
 #include <deal.II/grid/tria.h>
 #include <aspect/material_model/interface.h>
 #include <aspect/simulator_access.h>

--- a/benchmarks/rayleigh_taylor_instability/rayleigh_taylor_instability.cc
+++ b/benchmarks/rayleigh_taylor_instability/rayleigh_taylor_instability.cc
@@ -18,7 +18,7 @@
   <http://www.gnu.org/licenses/>.
 */
 
-#include <aspect/simulator.h>
+
 #include <aspect/material_model/simple.h>
 #include <aspect/boundary_velocity/interface.h>
 #include <aspect/simulator_access.h>

--- a/benchmarks/sinking_block/sinking_block.cc
+++ b/benchmarks/sinking_block/sinking_block.cc
@@ -17,7 +17,7 @@
   along with ASPECT; see the file LICENSE.  If not see
   <http://www.gnu.org/licenses/>.
 */
-#include <aspect/simulator.h>
+
 #include <aspect/material_model/simple.h>
 #include <aspect/boundary_velocity/interface.h>
 #include <aspect/simulator_access.h>

--- a/benchmarks/viscosity_grooves/viscosity_grooves.cc
+++ b/benchmarks/viscosity_grooves/viscosity_grooves.cc
@@ -17,7 +17,7 @@
   along with ASPECT; see the file LICENSE.  If not see
   <http://www.gnu.org/licenses/>.
 */
-#include <aspect/simulator.h>
+
 #include <aspect/material_model/simple.h>
 #include <aspect/boundary_velocity/interface.h>
 #include <aspect/simulator_access.h>
@@ -25,6 +25,7 @@
 #include <aspect/gravity_model/interface.h>
 #include <aspect/utilities.h>
 #include <aspect/geometry_model/box.h>
+#include <aspect/postprocess/interface.h>
 
 #include <deal.II/dofs/dof_tools.h>
 #include <deal.II/numerics/data_out.h>

--- a/cookbooks/anisotropic_viscosity/av_material.cc
+++ b/cookbooks/anisotropic_viscosity/av_material.cc
@@ -39,7 +39,7 @@
 #include <vector>
 
 #include <aspect/simulator_access.h>
-#include <aspect/simulator.h>
+
 #include <aspect/global.h>
 
 #include <deal.II/base/quadrature_lib.h>

--- a/cookbooks/inner_core_convection/inner_core_assembly.cc
+++ b/cookbooks/inner_core_convection/inner_core_assembly.cc
@@ -20,7 +20,8 @@
 
 #include <aspect/simulator_access.h>
 #include <aspect/global.h>
-#include <aspect/simulator.h>
+#include <aspect/simulator_signals.h>
+
 #include <aspect/simulator/assemblers/interface.h>
 
 #include <deal.II/base/quadrature_lib.h>

--- a/cookbooks/inner_core_convection/inner_core_convection.cc
+++ b/cookbooks/inner_core_convection/inner_core_convection.cc
@@ -20,6 +20,7 @@
 
 #include <aspect/material_model/simple.h>
 #include <aspect/heating_model/interface.h>
+#include <aspect/geometry_model/interface.h>
 #include <aspect/gravity_model/radial_linear.h>
 #include <deal.II/base/parsed_function.h>
 

--- a/tests/additional_outputs_02.cc
+++ b/tests/additional_outputs_02.cc
@@ -18,7 +18,8 @@
   <http://www.gnu.org/licenses/>.
 */
 
-#include <aspect/simulator.h>
+
+#include <aspect/simulator_signals.h>
 #include <deal.II/grid/tria.h>
 #include <aspect/material_model/simple.h>
 #include <aspect/simulator_access.h>

--- a/tests/additional_outputs_03.cc
+++ b/tests/additional_outputs_03.cc
@@ -18,7 +18,8 @@
   <http://www.gnu.org/licenses/>.
 */
 
-#include <aspect/simulator.h>
+
+#include <aspect/simulator_signals.h>
 #include <deal.II/grid/tria.h>
 #include <aspect/material_model/simple.h>
 #include <aspect/simulator_access.h>

--- a/tests/check_compositional_field_functions.cc
+++ b/tests/check_compositional_field_functions.cc
@@ -18,7 +18,9 @@
   <http://www.gnu.org/licenses/>.
 */
 
-#include <aspect/simulator.h>
+
+#include <aspect/simulator_signals.h>
+#include <aspect/introspection.h>
 #include <aspect/parameters.h>
 #include <aspect/material_model/utilities.h>
 

--- a/tests/check_compositional_field_names.cc
+++ b/tests/check_compositional_field_names.cc
@@ -18,7 +18,9 @@
   <http://www.gnu.org/licenses/>.
 */
 
-#include <aspect/simulator.h>
+
+#include <aspect/simulator_signals.h>
+#include <aspect/introspection.h>
 #include <aspect/parameters.h>
 
 template <int dim>

--- a/tests/checkpoint_01.cc
+++ b/tests/checkpoint_01.cc
@@ -18,8 +18,12 @@
   <http://www.gnu.org/licenses/>.
 */
 
-#include <aspect/simulator.h>
+
+#include <aspect/global.h>
+
+#include <cstdlib>
 #include <iostream>
+#include <string>
 
 /*
  * Launch the following function when this plugin is created. Launch ASPECT

--- a/tests/checkpoint_01_check_parameters.cc
+++ b/tests/checkpoint_01_check_parameters.cc
@@ -18,8 +18,12 @@
   <http://www.gnu.org/licenses/>.
 */
 
-#include <aspect/simulator.h>
+
+#include <aspect/global.h>
+
+#include <cstdlib>
 #include <iostream>
+#include <string>
 
 /*
  * Launch the following function when this plugin is created. Launch ASPECT

--- a/tests/checkpoint_02.cc
+++ b/tests/checkpoint_02.cc
@@ -18,7 +18,11 @@
   <http://www.gnu.org/licenses/>.
 */
 
-#include <aspect/simulator.h>
+
+#include <aspect/global.h>
+
+#include <cstdlib>
+#include <iostream>
 
 /*
  * Launch the following function when this plugin is created. Launch ASPECT

--- a/tests/checkpoint_02_direct.cc
+++ b/tests/checkpoint_02_direct.cc
@@ -18,7 +18,11 @@
   <http://www.gnu.org/licenses/>.
 */
 
-#include <aspect/simulator.h>
+
+#include <aspect/global.h>
+
+#include <cstdlib>
+#include <iostream>
 
 /*
  * Launch the following function when this plugin is created. Launch ASPECT

--- a/tests/checkpoint_03_particles.cc
+++ b/tests/checkpoint_03_particles.cc
@@ -18,8 +18,12 @@
   <http://www.gnu.org/licenses/>.
 */
 
-#include <aspect/simulator.h>
+
+#include <aspect/global.h>
+
+#include <cstdlib>
 #include <iostream>
+#include <string>
 
 /*
  * Launch the following function when this plugin is created. Launch ASPECT

--- a/tests/checkpoint_04_particles_no_output.cc
+++ b/tests/checkpoint_04_particles_no_output.cc
@@ -18,8 +18,12 @@
   <http://www.gnu.org/licenses/>.
 */
 
-#include <aspect/simulator.h>
+
+#include <aspect/global.h>
+
+#include <cstdlib>
 #include <iostream>
+#include <string>
 
 /*
  * Launch the following function when this plugin is created. Launch ASPECT

--- a/tests/checkpoint_05_mpi_resume.cc
+++ b/tests/checkpoint_05_mpi_resume.cc
@@ -18,11 +18,15 @@
   <http://www.gnu.org/licenses/>.
 */
 
-#include <aspect/simulator.h>
+
+
+#include <deal.II/base/mpi.h>
 
 #include <iostream>
 #include <thread>
 #include <chrono>
+#include <cstdlib>
+#include <string>
 
 /*
  * Launch the following function when this plugin is created. Copy checkpoint

--- a/tests/checkpoint_06_spherical_shell.cc
+++ b/tests/checkpoint_06_spherical_shell.cc
@@ -18,8 +18,12 @@
   <http://www.gnu.org/licenses/>.
 */
 
-#include <aspect/simulator.h>
+
+#include <aspect/global.h>
+
+#include <cstdlib>
 #include <iostream>
+#include <string>
 
 /*
  * Launch the following function when this plugin is created. Launch ASPECT

--- a/tests/checkpoint_07_enable_free_surface_resume.cc
+++ b/tests/checkpoint_07_enable_free_surface_resume.cc
@@ -18,10 +18,15 @@
   <http://www.gnu.org/licenses/>.
 */
 
-#include <aspect/simulator.h>
+#include <aspect/global.h>
+
+#include <deal.II/base/mpi.h>
+
 #include <iostream>
 #include <thread>
 #include <chrono>
+#include <cstdlib>
+#include <string>
 
 /*
  * Launch the following function when this plugin is created. Copy checkpoint

--- a/tests/checkpoint_08_particles_multiple_systems.cc
+++ b/tests/checkpoint_08_particles_multiple_systems.cc
@@ -18,8 +18,12 @@
   <http://www.gnu.org/licenses/>.
 */
 
-#include <aspect/simulator.h>
+
+#include <aspect/global.h>
+
+#include <cstdlib>
 #include <iostream>
+#include <string>
 
 /*
  * Launch the following function when this plugin is created. Launch ASPECT

--- a/tests/checkpoint_09_particles_no_postprocessor.cc
+++ b/tests/checkpoint_09_particles_no_postprocessor.cc
@@ -18,10 +18,13 @@
   <http://www.gnu.org/licenses/>.
 */
 
-#include <aspect/simulator.h>
+
+
+#include <aspect/global.h>
 
 #include <cstdlib>
 #include <iostream>
+#include <string>
 
 namespace
 {

--- a/tests/checkpoint_10_steady_temperature.cc
+++ b/tests/checkpoint_10_steady_temperature.cc
@@ -18,10 +18,13 @@
   Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 */
 
-#include <aspect/simulator.h>
+
+
+#include <aspect/global.h>
 
 #include <cstdlib>
 #include <iostream>
+#include <string>
 
 
 namespace

--- a/tests/checkpoint_11_steady_heat_flux.cc
+++ b/tests/checkpoint_11_steady_heat_flux.cc
@@ -18,10 +18,13 @@
   Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 */
 
-#include <aspect/simulator.h>
+
+
+#include <aspect/global.h>
 
 #include <cstdlib>
 #include <iostream>
+#include <string>
 
 
 namespace

--- a/tests/checkpoint_12_steady_rms_velocity.cc
+++ b/tests/checkpoint_12_steady_rms_velocity.cc
@@ -18,10 +18,13 @@
   Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 */
 
-#include <aspect/simulator.h>
+
+
+#include <aspect/global.h>
 
 #include <cstdlib>
 #include <iostream>
+#include <string>
 
 
 namespace

--- a/tests/checkpoint_13_particle_generator_random.cc
+++ b/tests/checkpoint_13_particle_generator_random.cc
@@ -18,8 +18,12 @@
   <http://www.gnu.org/licenses/>.
 */
 
-#include <aspect/simulator.h>
+
+#include <aspect/global.h>
+
+#include <cstdlib>
 #include <iostream>
+#include <string>
 
 /*
  * Launch the following function when this plugin is created. Launch ASPECT

--- a/tests/checkpoint_resume_by_slot.cc
+++ b/tests/checkpoint_resume_by_slot.cc
@@ -9,7 +9,9 @@
   any later version.
 */
 
-#include <aspect/simulator.h>
+
+
+#include <aspect/global.h>
 
 #include <cstdlib>
 #include <iostream>

--- a/tests/checkpoint_resume_by_time.cc
+++ b/tests/checkpoint_resume_by_time.cc
@@ -9,7 +9,9 @@
   any later version.
 */
 
-#include <aspect/simulator.h>
+
+
+#include <aspect/global.h>
 
 #include <cstdlib>
 #include <fstream>

--- a/tests/composite_viscous_outputs.cc
+++ b/tests/composite_viscous_outputs.cc
@@ -18,7 +18,7 @@
   <http://www.gnu.org/licenses/>.
 */
 
-#include <aspect/simulator.h>
+
 #include <aspect/material_model/rheology/composite_visco_plastic.h>
 #include <aspect/simulator_signals.h>
 

--- a/tests/composite_viscous_outputs_isostress.cc
+++ b/tests/composite_viscous_outputs_isostress.cc
@@ -18,7 +18,7 @@
   <http://www.gnu.org/licenses/>.
 */
 
-#include <aspect/simulator.h>
+
 #include <aspect/material_model/rheology/composite_visco_plastic.h>
 #include <aspect/simulator_signals.h>
 #include <iostream>

--- a/tests/composite_viscous_outputs_limited.cc
+++ b/tests/composite_viscous_outputs_limited.cc
@@ -18,7 +18,7 @@
   <http://www.gnu.org/licenses/>.
 */
 
-#include <aspect/simulator.h>
+
 #include <aspect/material_model/rheology/composite_visco_plastic.h>
 #include <aspect/simulator_signals.h>
 

--- a/tests/composite_viscous_outputs_no_peierls.cc
+++ b/tests/composite_viscous_outputs_no_peierls.cc
@@ -18,7 +18,8 @@
   <http://www.gnu.org/licenses/>.
 */
 
-#include <aspect/simulator.h>
+
+#include <aspect/simulator_signals.h>
 #include <aspect/material_model/rheology/composite_visco_plastic.h>
 
 namespace aspect

--- a/tests/composite_viscous_outputs_phases.cc
+++ b/tests/composite_viscous_outputs_phases.cc
@@ -18,7 +18,7 @@
   <http://www.gnu.org/licenses/>.
 */
 
-#include <aspect/simulator.h>
+
 #include <aspect/material_model/utilities.h>
 #include <aspect/material_model/rheology/composite_visco_plastic.h>
 #include <aspect/simulator_signals.h>

--- a/tests/dash_dash.cc
+++ b/tests/dash_dash.cc
@@ -18,7 +18,10 @@
   <http://www.gnu.org/licenses/>.
 */
 
-#include <aspect/simulator.h>
+
+#include <aspect/global.h>
+
+#include <cstdlib>
 
 // create a function that is run upon loading the plugin.  as discussed in the
 // corresponding .prm file, this function simply calls ASPECT again, and then

--- a/tests/diffusion_additional_checkpoint.cc
+++ b/tests/diffusion_additional_checkpoint.cc
@@ -18,8 +18,12 @@
   <http://www.gnu.org/licenses/>.
 */
 
-#include <aspect/simulator.h>
+
+#include <aspect/global.h>
+
+#include <cstdlib>
 #include <iostream>
+#include <string>
 
 /*
  * Launch the following function when this plugin is created. Launch ASPECT

--- a/tests/diffusion_additional_checkpoint_2.cc
+++ b/tests/diffusion_additional_checkpoint_2.cc
@@ -18,8 +18,12 @@
   <http://www.gnu.org/licenses/>.
 */
 
-#include <aspect/simulator.h>
+
+#include <aspect/global.h>
+
+#include <cstdlib>
 #include <iostream>
+#include <string>
 
 /*
  * Launch the following function when this plugin is created. Launch ASPECT

--- a/tests/diffusion_additional_checkpoint_3.cc
+++ b/tests/diffusion_additional_checkpoint_3.cc
@@ -18,8 +18,12 @@
   <http://www.gnu.org/licenses/>.
 */
 
-#include <aspect/simulator.h>
+
+#include <aspect/global.h>
+
+#include <cstdlib>
 #include <iostream>
+#include <string>
 
 /*
  * Launch the following function when this plugin is created. Launch ASPECT

--- a/tests/diffusion_additional_checkpoint_4.cc
+++ b/tests/diffusion_additional_checkpoint_4.cc
@@ -18,8 +18,12 @@
   <http://www.gnu.org/licenses/>.
 */
 
-#include <aspect/simulator.h>
+
+#include <aspect/global.h>
+
+#include <cstdlib>
 #include <iostream>
+#include <string>
 
 /*
  * Launch the following function when this plugin is created. Launch ASPECT

--- a/tests/drucker_prager_derivatives_2d.cc
+++ b/tests/drucker_prager_derivatives_2d.cc
@@ -18,6 +18,8 @@
   <http://www.gnu.org/licenses/>.
 */
 
+
+#include <aspect/simulator_signals.h>
 #include <aspect/simulator.h>
 #include <aspect/material_model/interface.h>
 #include <aspect/material_model/drucker_prager.h>

--- a/tests/drucker_prager_derivatives_3d.cc
+++ b/tests/drucker_prager_derivatives_3d.cc
@@ -18,6 +18,8 @@
   <http://www.gnu.org/licenses/>.
 */
 
+
+#include <aspect/simulator_signals.h>
 #include <aspect/simulator.h>
 #include <aspect/material_model/interface.h>
 #include <aspect/material_model/drucker_prager.h>

--- a/tests/fastscape_restart_basement_silt.cc
+++ b/tests/fastscape_restart_basement_silt.cc
@@ -18,8 +18,11 @@
   <http://www.gnu.org/licenses/>.
 */
 
-#include <aspect/simulator.h>
+#include <aspect/global.h>
+
+#include <cstdlib>
 #include <iostream>
+#include <string>
 
 /*
  * Launch the following function when this plugin is created. Run ASPECT twice

--- a/tests/find_boundary_composition_model.cc
+++ b/tests/find_boundary_composition_model.cc
@@ -23,7 +23,7 @@
 #include <aspect/geometry_model/box.h>
 #include <aspect/boundary_composition/initial_composition.h>
 #include <aspect/boundary_composition/box.h>
-#include <aspect/simulator.h>
+
 
 #include <utility>
 #include <limits>

--- a/tests/find_boundary_composition_model_fail_1.cc
+++ b/tests/find_boundary_composition_model_fail_1.cc
@@ -23,7 +23,7 @@
 #include <aspect/geometry_model/box.h>
 #include <aspect/boundary_composition/initial_composition.h>
 #include <aspect/boundary_composition/box.h>
-#include <aspect/simulator.h>
+
 
 #include <utility>
 #include <limits>

--- a/tests/find_mesh_refinement.cc
+++ b/tests/find_mesh_refinement.cc
@@ -23,7 +23,7 @@
 #include <aspect/geometry_model/box.h>
 #include <aspect/mesh_refinement/density.h>
 #include <aspect/mesh_refinement/boundary.h>
-#include <aspect/simulator.h>
+
 
 #include <utility>
 #include <limits>

--- a/tests/find_mesh_refinement_fail_1.cc
+++ b/tests/find_mesh_refinement_fail_1.cc
@@ -22,7 +22,7 @@
 #include <aspect/boundary_temperature/box.h>
 #include <aspect/geometry_model/box.h>
 #include <aspect/mesh_refinement/boundary.h>
-#include <aspect/simulator.h>
+
 
 #include <utility>
 #include <limits>

--- a/tests/find_postprocess.cc
+++ b/tests/find_postprocess.cc
@@ -23,7 +23,7 @@
 #include <aspect/geometry_model/box.h>
 #include <aspect/postprocess/heat_flux_statistics.h>
 #include <aspect/postprocess/pressure_statistics.h>
-#include <aspect/simulator.h>
+
 
 #include <utility>
 #include <limits>

--- a/tests/find_postprocess_fail_1.cc
+++ b/tests/find_postprocess_fail_1.cc
@@ -23,7 +23,7 @@
 #include <aspect/geometry_model/box.h>
 #include <aspect/postprocess/heat_flux_statistics.h>
 #include <aspect/postprocess/pressure_statistics.h>
-#include <aspect/simulator.h>
+
 
 #include <utility>
 #include <limits>

--- a/tests/hydrostatic_compression.cc
+++ b/tests/hydrostatic_compression.cc
@@ -18,11 +18,13 @@
   <http://www.gnu.org/licenses/>.
 */
 
+#include <aspect/simulator_signals.h>
+#include <aspect/postprocess/interface.h>
 #include <aspect/material_model/interface.h>
 #include <aspect/boundary_velocity/interface.h>
 #include <aspect/simulator_access.h>
 #include <aspect/global.h>
-#include <aspect/simulator.h>
+
 #include <aspect/simulator/assemblers/interface.h>
 #include <aspect/gravity_model/interface.h>
 

--- a/tests/include_prm_file_recursive_command_line.cc
+++ b/tests/include_prm_file_recursive_command_line.cc
@@ -18,8 +18,12 @@
   <http://www.gnu.org/licenses/>.
 */
 
-#include <aspect/simulator.h>
+
+#include <aspect/global.h>
+
+#include <cstdlib>
 #include <iostream>
+#include <string>
 
 /*
  * Launch the following function when this plugin is created. Launch ASPECT

--- a/tests/landlab_01.cc
+++ b/tests/landlab_01.cc
@@ -18,11 +18,14 @@
   <http://www.gnu.org/licenses/>.
 */
 
-#include <aspect/simulator.h>
+
 #include <aspect/utilities.h>
+#include <aspect/simulator_signals.h>
 
 #include <iostream>
+#include <cstdlib>
 #include <cfenv>
+#include <string>
 
 #define ASPECT_NUMPY_DEFINE_API
 #include <aspect/python_helper.h>

--- a/tests/melt_introspection.cc
+++ b/tests/melt_introspection.cc
@@ -18,7 +18,8 @@
   <http://www.gnu.org/licenses/>.
 */
 
-#include <aspect/simulator.h>
+
+#include <aspect/simulator_signals.h>
 #include <deal.II/grid/tria.h>
 #include <aspect/material_model/simple.h>
 #include <aspect/simulator_access.h>

--- a/tests/melt_restart.cc
+++ b/tests/melt_restart.cc
@@ -18,8 +18,12 @@
   <http://www.gnu.org/licenses/>.
 */
 
-#include <aspect/simulator.h>
+
+#include <aspect/global.h>
+
+#include <cstdlib>
 #include <iostream>
+#include <string>
 
 /*
  * Launch the following function when this plugin is created. Launch ASPECT

--- a/tests/melt_transport_adaptive.cc
+++ b/tests/melt_transport_adaptive.cc
@@ -27,7 +27,7 @@
 #include <aspect/global.h>
 #include <aspect/mesh_refinement/interface.h>
 #include <aspect/melt.h>
-#include <aspect/simulator.h>
+
 
 #include <deal.II/dofs/dof_tools.h>
 #include <deal.II/numerics/data_out.h>

--- a/tests/melt_transport_compressible.cc
+++ b/tests/melt_transport_compressible.cc
@@ -26,7 +26,7 @@
 #include <aspect/simulator_access.h>
 #include <aspect/global.h>
 #include <aspect/melt.h>
-#include <aspect/simulator.h>
+
 
 #include <deal.II/dofs/dof_tools.h>
 #include <deal.II/numerics/data_out.h>

--- a/tests/melt_transport_convergence_simple.cc
+++ b/tests/melt_transport_convergence_simple.cc
@@ -25,7 +25,7 @@
 #include <aspect/simulator_access.h>
 #include <aspect/global.h>
 #include <aspect/melt.h>
-#include <aspect/simulator.h>
+
 
 #include <deal.II/dofs/dof_tools.h>
 #include <deal.II/numerics/data_out.h>

--- a/tests/melt_transport_convergence_test.cc
+++ b/tests/melt_transport_convergence_test.cc
@@ -25,7 +25,7 @@
 #include <aspect/simulator_access.h>
 #include <aspect/global.h>
 #include <aspect/melt.h>
-#include <aspect/simulator.h>
+
 
 #include <deal.II/dofs/dof_tools.h>
 #include <deal.II/numerics/data_out.h>

--- a/tests/melt_visco_plastic.cc
+++ b/tests/melt_visco_plastic.cc
@@ -22,8 +22,9 @@
 #define _aspect_material_model_melt_visco_plastic_h
 
 #include <algorithm>
+#include <aspect/adiabatic_conditions/interface.h>
 #include <aspect/material_model/interface.h>
-#include <aspect/simulator.h>
+
 #include <aspect/simulator_access.h>
 #include <aspect/postprocess/melt_statistics.h>
 #include <aspect/melt.h>

--- a/tests/particles/particle_property_post_initialize_function.cc
+++ b/tests/particles/particle_property_post_initialize_function.cc
@@ -18,7 +18,8 @@
   <http://www.gnu.org/licenses/>.
 */
 
-#include <aspect/simulator.h>
+
+#include <aspect/particle/manager.h>
 #include <aspect/simulator_access.h>
 #include <aspect/particle/property/interface.h>
 

--- a/tests/prm_distance_polygon.cc
+++ b/tests/prm_distance_polygon.cc
@@ -18,7 +18,7 @@
   <http://www.gnu.org/licenses/>.
 */
 
-#include <aspect/simulator.h>
+
 #include <aspect/simulator_access.h>
 #include <aspect/utilities.h>
 

--- a/tests/prm_polygon_in_out.cc
+++ b/tests/prm_polygon_in_out.cc
@@ -18,7 +18,7 @@
   <http://www.gnu.org/licenses/>.
 */
 
-#include <aspect/simulator.h>
+
 #include <aspect/geometry_model/initial_topography_model/interface.h>
 #include <aspect/geometry_model/initial_topography_model/prm_polygon.h>
 #include <aspect/simulator_access.h>

--- a/tests/python_01.cc
+++ b/tests/python_01.cc
@@ -18,10 +18,13 @@
   <http://www.gnu.org/licenses/>.
 */
 
-#include <aspect/simulator.h>
-#include <aspect/utilities.h>
 
+#include <aspect/utilities.h>
+#include <aspect/simulator_signals.h>
+
+#include <cstdlib>
 #include <iostream>
+#include <string>
 
 #define ASPECT_NUMPY_DEFINE_API
 #include <aspect/python_helper.h>

--- a/tests/q1_q1.cc
+++ b/tests/q1_q1.cc
@@ -20,12 +20,13 @@
 
 // Check the Donea-Huerta benchmark using the Q1 x Q1 element
 
-#include <aspect/simulator.h>
+
 #include <aspect/material_model/simple.h>
 #include <aspect/boundary_velocity/interface.h>
 #include <aspect/simulator_access.h>
 #include <aspect/global.h>
 #include <aspect/gravity_model/interface.h>
+#include <aspect/postprocess/interface.h>
 #include <aspect/utilities.h>
 
 #include <deal.II/dofs/dof_tools.h>

--- a/tests/resume_free_surface.cc
+++ b/tests/resume_free_surface.cc
@@ -18,7 +18,11 @@
   <http://www.gnu.org/licenses/>.
 */
 
-#include <aspect/simulator.h>
+
+#include <aspect/global.h>
+
+#include <cstdlib>
+#include <iostream>
 
 /*
  * Launch the following function when this plugin is created. Launch ASPECT

--- a/tests/signal_fem.cc
+++ b/tests/signal_fem.cc
@@ -18,10 +18,11 @@
   <http://www.gnu.org/licenses/>.
 */
 
-#include <aspect/simulator.h>
+
 #include <deal.II/grid/tria.h>
 #include <aspect/material_model/simple.h>
 #include <aspect/simulator_access.h>
+#include <aspect/simulator_signals.h>
 #include <aspect/simulator/assemblers/interface.h>
 
 #include <deal.II/fe/fe_dgq.h>

--- a/tests/simple_nonlinear.cc
+++ b/tests/simple_nonlinear.cc
@@ -18,7 +18,7 @@
   <http://www.gnu.org/licenses/>.
 */
 
-#include <aspect/simulator.h>
+
 #include <deal.II/grid/tria.h>
 #include <aspect/material_model/interface.h>
 #include <aspect/simulator_access.h>

--- a/tests/spiegelman_fail_test.cc
+++ b/tests/spiegelman_fail_test.cc
@@ -19,7 +19,7 @@
 */
 
 #include <algorithm>
-#include <aspect/simulator.h>
+
 #include <deal.II/grid/tria.h>
 #include <aspect/simulator_access.h>
 #include <aspect/newton.h>

--- a/tests/update_script.cc
+++ b/tests/update_script.cc
@@ -18,7 +18,7 @@
   <http://www.gnu.org/licenses/>.
 */
 
-#include <aspect/simulator.h>
+#include <aspect/global.h>
 #include <iostream>
 
 /*

--- a/tests/update_script_2.cc
+++ b/tests/update_script_2.cc
@@ -18,7 +18,7 @@
   <http://www.gnu.org/licenses/>.
 */
 
-#include <aspect/simulator.h>
+#include <aspect/global.h>
 #include <iostream>
 
 /*

--- a/tests/visco_plastic_derivatives_2d.cc
+++ b/tests/visco_plastic_derivatives_2d.cc
@@ -18,7 +18,7 @@
   <http://www.gnu.org/licenses/>.
 */
 
-#include <aspect/simulator.h>
+#include <aspect/simulator_signals.h>
 #include <aspect/simulator_access.h>
 
 #include <aspect/material_model/interface.h>

--- a/tests/visco_plastic_derivatives_3d.cc
+++ b/tests/visco_plastic_derivatives_3d.cc
@@ -18,7 +18,7 @@
   <http://www.gnu.org/licenses/>.
 */
 
-#include <aspect/simulator.h>
+#include <aspect/simulator_signals.h>
 #include <aspect/simulator_access.h>
 
 #include <aspect/material_model/interface.h>

--- a/tests/weighted_p_norm_average.cc
+++ b/tests/weighted_p_norm_average.cc
@@ -18,7 +18,7 @@
   <http://www.gnu.org/licenses/>.
 */
 
-//#include <aspect/simulator.h>
+//
 //#include <aspect/geometry_model/initial_topography_model/interface.h>
 //#include <aspect/geometry_model/initial_topography_model/prm_polygon.h>
 //#include <aspect/simulator_access.h>


### PR DESCRIPTION
Like #7322, but for the benchmarks, cookbooks, and tests.

I still need to go through all of the test plugins and fix the includes that are now missing (including simulator.h often obscured missing other includes).