### PR TITLE
copyright script: ignore files not tracked

### DIFF
--- a/contrib/release/update_copyright.sh
+++ b/contrib/release/update_copyright.sh
@@ -11,13 +11,17 @@ if test ! -d source -o ! -d include -o ! -d cookbooks ; then
 fi
 
 
-files="
-  $(find . -name CMakeLists.txt)
-  $(find . | egrep '\.(cmake|cc|h|in)$')
-"
+# Use only tracked files so generated files in build* directories are ignored.
+# Keep the list NUL-delimited to handle filenames containing whitespace.
+mapfile -d '' files < <(git ls-files -z -- \
+  ':(glob)**/CMakeLists.txt' \
+  ':(glob)**/*.cmake' \
+  ':(glob)**/*.cc' \
+  ':(glob)**/*.h' \
+  ':(glob)**/*.in')
 
 
-for i in $files ; do
+for i in "${files[@]}" ; do
   # get the last year this file was modified from the git log.
   # we don't want to see patches that just updated the copyright
   # year, so output the dates and log messages of the last 3
@@ -29,7 +33,7 @@ for i in $files ; do
   # ideally no two successive commits should have updated the
   # copyright year. let's err on the safe side and take the last
   # 3 commits.)
-  last_year=`git log -n 3 --date=short --format="format:%cd %s" $i | \
+  last_year=`git log -n 3 --date=short --format="format:%cd %s" -- "$i" | \
              egrep -i -v "update.*copyright|copyright.*update" | \
              head -n 1 | \
              perl -p -e 's/^(\d\d\d\d)-.*/\1/g;'`
@@ -37,7 +41,7 @@ for i in $files ; do
   # get the first year this file was modified from the actual
   # file. this may predate the git log if the file was copied
   # from elsewhere
-  first_year=`cat $i | egrep 'Copyright \(C\) [0-9]{4}' | \
+  first_year=`cat -- "$i" | egrep 'Copyright \(C\) [0-9]{4}' | \
               perl -p -e "s/.*Copyright \(C\) (\d{4}).*/\1/g;"`
 
   # print a status message. we really only have to update
@@ -45,7 +49,6 @@ for i in $files ; do
   # different
   echo "Processing $i: ${first_year} - ${last_year}"
   if test ! "${first_year}" = "${last_year}" ; then
-    perl -pi -e "s/(Copyright \(C\) \d{4})( - \d{4})?(, \d{4}( - \d{4})?)*/\1 - ${last_year}/g;" $i
+    perl -pi -e "s/(Copyright \(C\) \d{4})( - \d{4})?(, \d{4}( - \d{4})?)*/\1 - ${last_year}/g;" -- "$i"
   fi
 done
-


### PR DESCRIPTION
and also safely handle files with spaces.

written by codex.

part of #7338 