### PR TITLE
Add deal.II 9.8 tester

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -50,6 +50,14 @@ jobs:
             result-file: "changes-test-results-9.7.diff"
             container-options: '--user 0 --name container'
             use-tpetra: "OFF"
+          - image: "geodynamics/aspect-tester:jammy-dealii-9.8-v1"
+            run-tests: "ON"
+            compare-tests: "OFF"
+            build-with-python: "OFF"
+            build-with-fastscape: "OFF"
+            result-file: "changes-test-results-9.8.diff"
+            container-options: '--user 0 --name container'
+            use-tpetra: "OFF"
           - image: "geodynamics/aspect-tester:jammy-dealii-master"
             run-tests: "ON"
             compare-tests: "OFF"


### PR DESCRIPTION
Adding the deal.II 9.8 image to the list of testers. We can merge this any time and it will slow down testing a bit, but since we plan to remove the 9.6 support after the ASPECT 3.1 release, that will reduce the number of testers by one again.

Related to #7342 and #7314.